### PR TITLE
Remove security reports section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,6 @@ bkt api /2.0/repositories --param workspace=myteam --field pagelen=50
 
 - **Questions / Ideas**: File an [issue](https://github.com/avivsinai/bitbucket-cli/issues/new?template=feature_request.md)
 - **Bug Reports**: File an [issue](https://github.com/avivsinai/bitbucket-cli/issues/new?template=bug_report.md)
-- **Security Reports**: Email [security@avivsinai.dev](mailto:security@avivsinai.dev)
 
 ## Roadmap highlights
 


### PR DESCRIPTION
Removed security report contact information from README.

## Summary

<!-- What does this change do? Why is it needed? -->

## Testing

- [ ] `make fmt`
- [ ] `make test`
- [ ] `make build`
- [ ] Other (please specify):

## Screenshots / recordings

<!-- Attach terminal recordings or screenshots when changing CLI UX. -->

## Checklist

- [ ] Adds or updates documentation
- [ ] Updates `CHANGELOG.md`
- [ ] Signed commits (`git commit -s`)

## Notes for reviewers

<!-- Anything reviewers should pay special attention to. -->
