### PR TITLE
feat: add pr edit command to update PR title and description

### DIFF
--- a/pkg/bbcloud/pullrequests.go
+++ b/pkg/bbcloud/pullrequests.go
@@ -191,3 +191,46 @@ func (c *Client) CreatePullRequest(ctx context.Context, workspace, repoSlug stri
 	}
 	return &pr, nil
 }
+
+// UpdatePullRequestInput configures PR updates. Use pointers to distinguish
+// between "not set" and "set to empty string" for clearing fields.
+type UpdatePullRequestInput struct {
+	Title       *string
+	Description *string
+}
+
+// UpdatePullRequest updates an existing pull request's title and/or description.
+func (c *Client) UpdatePullRequest(ctx context.Context, workspace, repoSlug string, id int, input UpdatePullRequestInput) (*PullRequest, error) {
+	if workspace == "" || repoSlug == "" {
+		return nil, fmt.Errorf("workspace and repository slug are required")
+	}
+
+	body := make(map[string]any)
+	if input.Title != nil {
+		body["title"] = *input.Title
+	}
+	if input.Description != nil {
+		body["description"] = *input.Description
+	}
+
+	if len(body) == 0 {
+		return nil, fmt.Errorf("at least one field (title or description) must be provided")
+	}
+
+	path := fmt.Sprintf("/repositories/%s/%s/pullrequests/%d",
+		url.PathEscape(workspace),
+		url.PathEscape(repoSlug),
+		id,
+	)
+
+	req, err := c.http.NewRequest(ctx, "PUT", path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var pr PullRequest
+	if err := c.http.Do(req, &pr); err != nil {
+		return nil, err
+	}
+	return &pr, nil
+}

--- a/pkg/bbdc/pullrequests.go
+++ b/pkg/bbdc/pullrequests.go
@@ -162,6 +162,80 @@ func (c *Client) CommentPullRequest(ctx context.Context, projectKey, repoSlug st
 	return c.http.Do(req, nil)
 }
 
+// UpdatePROptions configures pull request updates.
+type UpdatePROptions struct {
+	Title       string
+	Description string
+	// Reviewers to preserve (from GET response). If nil, reviewers may be cleared.
+	Reviewers []PullRequestReviewer
+	// FromRef to preserve (from GET response). Required by DC API.
+	FromRef *Ref
+	// ToRef to preserve (from GET response). Required by DC API.
+	ToRef *Ref
+}
+
+// UpdatePullRequest updates an existing pull request's title and/or description.
+// Requires the current PR version for optimistic locking.
+// Note: DC's PUT endpoint replaces the entire PR; include Reviewers/FromRef/ToRef
+// from the GET response to prevent them from being cleared.
+func (c *Client) UpdatePullRequest(ctx context.Context, projectKey, repoSlug string, prID int, version int, opts UpdatePROptions) (*PullRequest, error) {
+	if projectKey == "" || repoSlug == "" {
+		return nil, fmt.Errorf("project key and repository slug are required")
+	}
+
+	body := map[string]any{
+		"version":     version,
+		"title":       opts.Title,
+		"description": opts.Description,
+	}
+
+	// Include reviewers to prevent them from being cleared
+	if opts.Reviewers != nil {
+		body["reviewers"] = opts.Reviewers
+	}
+
+	// Include refs to prevent API errors (DC may require these)
+	if opts.FromRef != nil {
+		fromRefBody := map[string]any{
+			"id": opts.FromRef.ID,
+			"repository": map[string]any{
+				"slug": opts.FromRef.Repository.Slug,
+			},
+		}
+		if opts.FromRef.Repository.Project != nil {
+			fromRefBody["repository"].(map[string]any)["project"] = map[string]any{"key": opts.FromRef.Repository.Project.Key}
+		}
+		body["fromRef"] = fromRefBody
+	}
+	if opts.ToRef != nil {
+		toRefBody := map[string]any{
+			"id": opts.ToRef.ID,
+			"repository": map[string]any{
+				"slug": opts.ToRef.Repository.Slug,
+			},
+		}
+		if opts.ToRef.Repository.Project != nil {
+			toRefBody["repository"].(map[string]any)["project"] = map[string]any{"key": opts.ToRef.Repository.Project.Key}
+		}
+		body["toRef"] = toRefBody
+	}
+
+	req, err := c.http.NewRequest(ctx, "PUT", fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d",
+		url.PathEscape(projectKey),
+		url.PathEscape(repoSlug),
+		prID,
+	), body)
+	if err != nil {
+		return nil, err
+	}
+
+	var pr PullRequest
+	if err := c.http.Do(req, &pr); err != nil {
+		return nil, err
+	}
+	return &pr, nil
+}
+
 // PullRequestDiff streams the diff for the given pull request into w.
 func (c *Client) PullRequestDiff(ctx context.Context, projectKey, repoSlug string, id int, w io.Writer) error {
 	if projectKey == "" || repoSlug == "" {


### PR DESCRIPTION
## Summary
- Add `bkt pr edit` command to update pull request title and/or description
- Support both Bitbucket Data Center (with optimistic locking) and Cloud
- Follow gh CLI ergonomics (`--body`/`-b`, `--title`/`-t`)

## Features
- `--title` / `-t` to update PR title
- `--body` / `-b` or `--description` to update PR description  
- DC: preserves reviewers and refs to prevent being cleared on PUT
- Cloud: sends only changed fields (partial update)
- Supports `--json`, `--yaml`, `--template` output

## Usage
```bash
bkt pr edit 123 --title "New title"
bkt pr edit 123 --body "New description"
bkt pr edit 123 -t "Fix bug" -b "Resolves timeout issue"
```

## Test plan
- [x] Unit tests for argument parsing (error cases and valid cases)
- [x] Integration tests for DC (GET then PUT with version)
- [x] Integration tests for Cloud (PUT with partial fields)
- [x] All tests pass (~0.7s, no network calls)

Closes #18

🤖 Generated with [Claude Code](https://claude.ai/code)