### PR TITLE
Feature/variable commands

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,9 +3,12 @@
 
 # Go source files
 *.go text eol=lf
+*.mod text eol=lf
+*.sum text eol=lf
 
 # Shell scripts
 *.sh text eol=lf
+*.bash text eol=lf
 
 # Batch files (Windows)
 *.bat text eol=crlf
@@ -20,6 +23,9 @@
 
 # Makefiles
 Makefile text eol=lf
+Dockerfile text eol=lf
+.gitignore text eol=lf
+.gitattributes text eol=lf
 
 # Binary files
 *.png binary

--- a/pkg/bbcloud/variables.go
+++ b/pkg/bbcloud/variables.go
@@ -1,0 +1,561 @@
+package bbcloud
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// PipelineVariable represents a Bitbucket Cloud pipeline variable.
+type PipelineVariable struct {
+	UUID    string `json:"uuid"`
+	Key     string `json:"key"`
+	Value   string `json:"value,omitempty"`
+	Secured bool   `json:"secured"`
+}
+
+// VariableListOptions configures variable list requests.
+type VariableListOptions struct {
+	Limit int
+}
+
+type variableListPage struct {
+	Values []PipelineVariable `json:"values"`
+	Next   string             `json:"next"`
+}
+
+// ListRepositoryVariables lists pipeline variables for a repository.
+func (c *Client) ListRepositoryVariables(ctx context.Context, workspace, repoSlug string, opts VariableListOptions) ([]PipelineVariable, error) {
+	if workspace == "" || repoSlug == "" {
+		return nil, fmt.Errorf("workspace and repository slug are required")
+	}
+
+	pageLen := opts.Limit
+	if pageLen <= 0 || pageLen > 100 {
+		pageLen = 100
+	}
+
+	path := fmt.Sprintf("/repositories/%s/%s/pipelines_config/variables?pagelen=%d",
+		url.PathEscape(workspace),
+		url.PathEscape(repoSlug),
+		pageLen,
+	)
+
+	var variables []PipelineVariable
+	for path != "" {
+		req, err := c.http.NewRequest(ctx, "GET", path, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var page variableListPage
+		if err := c.http.Do(req, &page); err != nil {
+			return nil, err
+		}
+
+		variables = append(variables, page.Values...)
+
+		if opts.Limit > 0 && len(variables) >= opts.Limit {
+			variables = variables[:opts.Limit]
+			break
+		}
+
+		if page.Next == "" {
+			break
+		}
+
+		nextURL, err := url.Parse(page.Next)
+		if err != nil {
+			return nil, err
+		}
+		path = nextURL.RequestURI()
+	}
+
+	return variables, nil
+}
+
+// CreateRepositoryVariableInput configures repository variable creation.
+type CreateRepositoryVariableInput struct {
+	Key     string
+	Value   string
+	Secured bool
+}
+
+// CreateRepositoryVariable creates a pipeline variable for a repository.
+func (c *Client) CreateRepositoryVariable(ctx context.Context, workspace, repoSlug string, input CreateRepositoryVariableInput) (*PipelineVariable, error) {
+	if workspace == "" || repoSlug == "" {
+		return nil, fmt.Errorf("workspace and repository slug are required")
+	}
+	if input.Key == "" {
+		return nil, fmt.Errorf("variable key is required")
+	}
+
+	body := map[string]any{
+		"key":     input.Key,
+		"value":   input.Value,
+		"secured": input.Secured,
+	}
+
+	path := fmt.Sprintf("/repositories/%s/%s/pipelines_config/variables",
+		url.PathEscape(workspace),
+		url.PathEscape(repoSlug),
+	)
+
+	req, err := c.http.NewRequest(ctx, "POST", path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var variable PipelineVariable
+	if err := c.http.Do(req, &variable); err != nil {
+		return nil, err
+	}
+	return &variable, nil
+}
+
+// UpdateRepositoryVariableInput configures repository variable updates.
+type UpdateRepositoryVariableInput struct {
+	Key     string
+	Value   string
+	Secured bool
+}
+
+// UpdateRepositoryVariable updates a pipeline variable for a repository.
+// The variableUUID identifies the variable to update.
+func (c *Client) UpdateRepositoryVariable(ctx context.Context, workspace, repoSlug, variableUUID string, input UpdateRepositoryVariableInput) (*PipelineVariable, error) {
+	if workspace == "" || repoSlug == "" {
+		return nil, fmt.Errorf("workspace and repository slug are required")
+	}
+	if variableUUID == "" {
+		return nil, fmt.Errorf("variable UUID is required")
+	}
+	if input.Key == "" {
+		return nil, fmt.Errorf("variable key is required")
+	}
+
+	body := map[string]any{
+		"key":     input.Key,
+		"value":   input.Value,
+		"secured": input.Secured,
+	}
+
+	path := fmt.Sprintf("/repositories/%s/%s/pipelines_config/variables/%s",
+		url.PathEscape(workspace),
+		url.PathEscape(repoSlug),
+		url.PathEscape(variableUUID),
+	)
+
+	req, err := c.http.NewRequest(ctx, "PUT", path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var variable PipelineVariable
+	if err := c.http.Do(req, &variable); err != nil {
+		return nil, err
+	}
+	return &variable, nil
+}
+
+// DeleteRepositoryVariable deletes a pipeline variable from a repository.
+func (c *Client) DeleteRepositoryVariable(ctx context.Context, workspace, repoSlug, variableUUID string) error {
+	if workspace == "" || repoSlug == "" {
+		return fmt.Errorf("workspace and repository slug are required")
+	}
+	if variableUUID == "" {
+		return fmt.Errorf("variable UUID is required")
+	}
+
+	path := fmt.Sprintf("/repositories/%s/%s/pipelines_config/variables/%s",
+		url.PathEscape(workspace),
+		url.PathEscape(repoSlug),
+		url.PathEscape(variableUUID),
+	)
+
+	req, err := c.http.NewRequest(ctx, "DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+
+	return c.http.Do(req, nil)
+}
+
+// --- Workspace-level variable methods ---
+
+// ListWorkspaceVariables lists pipeline variables for a workspace.
+func (c *Client) ListWorkspaceVariables(ctx context.Context, workspace string, opts VariableListOptions) ([]PipelineVariable, error) {
+	if workspace == "" {
+		return nil, fmt.Errorf("workspace is required")
+	}
+
+	pageLen := opts.Limit
+	if pageLen <= 0 || pageLen > 100 {
+		pageLen = 100
+	}
+
+	path := fmt.Sprintf("/workspaces/%s/pipelines-config/variables?pagelen=%d",
+		url.PathEscape(workspace),
+		pageLen,
+	)
+
+	var variables []PipelineVariable
+	for path != "" {
+		req, err := c.http.NewRequest(ctx, "GET", path, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var page variableListPage
+		if err := c.http.Do(req, &page); err != nil {
+			return nil, err
+		}
+
+		variables = append(variables, page.Values...)
+
+		if opts.Limit > 0 && len(variables) >= opts.Limit {
+			variables = variables[:opts.Limit]
+			break
+		}
+
+		if page.Next == "" {
+			break
+		}
+
+		nextURL, err := url.Parse(page.Next)
+		if err != nil {
+			return nil, err
+		}
+		path = nextURL.RequestURI()
+	}
+
+	return variables, nil
+}
+
+// CreateWorkspaceVariableInput configures workspace variable creation.
+type CreateWorkspaceVariableInput struct {
+	Key     string
+	Value   string
+	Secured bool
+}
+
+// CreateWorkspaceVariable creates a pipeline variable for a workspace.
+func (c *Client) CreateWorkspaceVariable(ctx context.Context, workspace string, input CreateWorkspaceVariableInput) (*PipelineVariable, error) {
+	if workspace == "" {
+		return nil, fmt.Errorf("workspace is required")
+	}
+	if input.Key == "" {
+		return nil, fmt.Errorf("variable key is required")
+	}
+
+	body := map[string]any{
+		"key":     input.Key,
+		"value":   input.Value,
+		"secured": input.Secured,
+	}
+
+	path := fmt.Sprintf("/workspaces/%s/pipelines-config/variables",
+		url.PathEscape(workspace),
+	)
+
+	req, err := c.http.NewRequest(ctx, "POST", path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var variable PipelineVariable
+	if err := c.http.Do(req, &variable); err != nil {
+		return nil, err
+	}
+	return &variable, nil
+}
+
+// UpdateWorkspaceVariableInput configures workspace variable updates.
+type UpdateWorkspaceVariableInput struct {
+	Key     string
+	Value   string
+	Secured bool
+}
+
+// UpdateWorkspaceVariable updates a pipeline variable for a workspace.
+func (c *Client) UpdateWorkspaceVariable(ctx context.Context, workspace, variableUUID string, input UpdateWorkspaceVariableInput) (*PipelineVariable, error) {
+	if workspace == "" {
+		return nil, fmt.Errorf("workspace is required")
+	}
+	if variableUUID == "" {
+		return nil, fmt.Errorf("variable UUID is required")
+	}
+	if input.Key == "" {
+		return nil, fmt.Errorf("variable key is required")
+	}
+
+	body := map[string]any{
+		"key":     input.Key,
+		"value":   input.Value,
+		"secured": input.Secured,
+	}
+
+	path := fmt.Sprintf("/workspaces/%s/pipelines-config/variables/%s",
+		url.PathEscape(workspace),
+		url.PathEscape(variableUUID),
+	)
+
+	req, err := c.http.NewRequest(ctx, "PUT", path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var variable PipelineVariable
+	if err := c.http.Do(req, &variable); err != nil {
+		return nil, err
+	}
+	return &variable, nil
+}
+
+// DeleteWorkspaceVariable deletes a pipeline variable from a workspace.
+func (c *Client) DeleteWorkspaceVariable(ctx context.Context, workspace, variableUUID string) error {
+	if workspace == "" {
+		return fmt.Errorf("workspace is required")
+	}
+	if variableUUID == "" {
+		return fmt.Errorf("variable UUID is required")
+	}
+
+	path := fmt.Sprintf("/workspaces/%s/pipelines-config/variables/%s",
+		url.PathEscape(workspace),
+		url.PathEscape(variableUUID),
+	)
+
+	req, err := c.http.NewRequest(ctx, "DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+
+	return c.http.Do(req, nil)
+}
+
+// --- Deployment environment variable methods ---
+
+// DeploymentEnvironment represents a deployment environment in Bitbucket Cloud.
+type DeploymentEnvironment struct {
+	UUID            string `json:"uuid"`
+	Name            string `json:"name"`
+	Slug            string `json:"slug"`
+	EnvironmentType struct {
+		Name string `json:"name"`
+	} `json:"environment_type"`
+}
+
+type deploymentEnvironmentListPage struct {
+	Values []DeploymentEnvironment `json:"values"`
+	Next   string                  `json:"next"`
+}
+
+// ListDeploymentEnvironments lists deployment environments for a repository.
+func (c *Client) ListDeploymentEnvironments(ctx context.Context, workspace, repoSlug string) ([]DeploymentEnvironment, error) {
+	if workspace == "" || repoSlug == "" {
+		return nil, fmt.Errorf("workspace and repository slug are required")
+	}
+
+	path := fmt.Sprintf("/repositories/%s/%s/environments?pagelen=100",
+		url.PathEscape(workspace),
+		url.PathEscape(repoSlug),
+	)
+
+	var environments []DeploymentEnvironment
+	for path != "" {
+		req, err := c.http.NewRequest(ctx, "GET", path, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var page deploymentEnvironmentListPage
+		if err := c.http.Do(req, &page); err != nil {
+			return nil, err
+		}
+
+		environments = append(environments, page.Values...)
+
+		if page.Next == "" {
+			break
+		}
+
+		nextURL, err := url.Parse(page.Next)
+		if err != nil {
+			return nil, err
+		}
+		path = nextURL.RequestURI()
+	}
+
+	return environments, nil
+}
+
+// ListDeploymentVariables lists pipeline variables for a deployment environment.
+func (c *Client) ListDeploymentVariables(ctx context.Context, workspace, repoSlug, environmentUUID string, opts VariableListOptions) ([]PipelineVariable, error) {
+	if workspace == "" || repoSlug == "" {
+		return nil, fmt.Errorf("workspace and repository slug are required")
+	}
+	if environmentUUID == "" {
+		return nil, fmt.Errorf("environment UUID is required")
+	}
+
+	pageLen := opts.Limit
+	if pageLen <= 0 || pageLen > 100 {
+		pageLen = 100
+	}
+
+	path := fmt.Sprintf("/repositories/%s/%s/deployments_config/environments/%s/variables?pagelen=%d",
+		url.PathEscape(workspace),
+		url.PathEscape(repoSlug),
+		url.PathEscape(environmentUUID),
+		pageLen,
+	)
+
+	var variables []PipelineVariable
+	for path != "" {
+		req, err := c.http.NewRequest(ctx, "GET", path, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var page variableListPage
+		if err := c.http.Do(req, &page); err != nil {
+			return nil, err
+		}
+
+		variables = append(variables, page.Values...)
+
+		if opts.Limit > 0 && len(variables) >= opts.Limit {
+			variables = variables[:opts.Limit]
+			break
+		}
+
+		if page.Next == "" {
+			break
+		}
+
+		nextURL, err := url.Parse(page.Next)
+		if err != nil {
+			return nil, err
+		}
+		path = nextURL.RequestURI()
+	}
+
+	return variables, nil
+}
+
+// CreateDeploymentVariableInput configures deployment variable creation.
+type CreateDeploymentVariableInput struct {
+	Key     string
+	Value   string
+	Secured bool
+}
+
+// CreateDeploymentVariable creates a pipeline variable for a deployment environment.
+func (c *Client) CreateDeploymentVariable(ctx context.Context, workspace, repoSlug, environmentUUID string, input CreateDeploymentVariableInput) (*PipelineVariable, error) {
+	if workspace == "" || repoSlug == "" {
+		return nil, fmt.Errorf("workspace and repository slug are required")
+	}
+	if environmentUUID == "" {
+		return nil, fmt.Errorf("environment UUID is required")
+	}
+	if input.Key == "" {
+		return nil, fmt.Errorf("variable key is required")
+	}
+
+	body := map[string]any{
+		"key":     input.Key,
+		"value":   input.Value,
+		"secured": input.Secured,
+	}
+
+	path := fmt.Sprintf("/repositories/%s/%s/deployments_config/environments/%s/variables",
+		url.PathEscape(workspace),
+		url.PathEscape(repoSlug),
+		url.PathEscape(environmentUUID),
+	)
+
+	req, err := c.http.NewRequest(ctx, "POST", path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var variable PipelineVariable
+	if err := c.http.Do(req, &variable); err != nil {
+		return nil, err
+	}
+	return &variable, nil
+}
+
+// UpdateDeploymentVariableInput configures deployment variable updates.
+type UpdateDeploymentVariableInput struct {
+	Key     string
+	Value   string
+	Secured bool
+}
+
+// UpdateDeploymentVariable updates a pipeline variable for a deployment environment.
+func (c *Client) UpdateDeploymentVariable(ctx context.Context, workspace, repoSlug, environmentUUID, variableUUID string, input UpdateDeploymentVariableInput) (*PipelineVariable, error) {
+	if workspace == "" || repoSlug == "" {
+		return nil, fmt.Errorf("workspace and repository slug are required")
+	}
+	if environmentUUID == "" {
+		return nil, fmt.Errorf("environment UUID is required")
+	}
+	if variableUUID == "" {
+		return nil, fmt.Errorf("variable UUID is required")
+	}
+	if input.Key == "" {
+		return nil, fmt.Errorf("variable key is required")
+	}
+
+	body := map[string]any{
+		"key":     input.Key,
+		"value":   input.Value,
+		"secured": input.Secured,
+	}
+
+	path := fmt.Sprintf("/repositories/%s/%s/deployments_config/environments/%s/variables/%s",
+		url.PathEscape(workspace),
+		url.PathEscape(repoSlug),
+		url.PathEscape(environmentUUID),
+		url.PathEscape(variableUUID),
+	)
+
+	req, err := c.http.NewRequest(ctx, "PUT", path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var variable PipelineVariable
+	if err := c.http.Do(req, &variable); err != nil {
+		return nil, err
+	}
+	return &variable, nil
+}
+
+// DeleteDeploymentVariable deletes a pipeline variable from a deployment environment.
+func (c *Client) DeleteDeploymentVariable(ctx context.Context, workspace, repoSlug, environmentUUID, variableUUID string) error {
+	if workspace == "" || repoSlug == "" {
+		return fmt.Errorf("workspace and repository slug are required")
+	}
+	if environmentUUID == "" {
+		return fmt.Errorf("environment UUID is required")
+	}
+	if variableUUID == "" {
+		return fmt.Errorf("variable UUID is required")
+	}
+
+	path := fmt.Sprintf("/repositories/%s/%s/deployments_config/environments/%s/variables/%s",
+		url.PathEscape(workspace),
+		url.PathEscape(repoSlug),
+		url.PathEscape(environmentUUID),
+		url.PathEscape(variableUUID),
+	)
+
+	req, err := c.http.NewRequest(ctx, "DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+
+	return c.http.Do(req, nil)
+}

--- a/pkg/bbcloud/variables_test.go
+++ b/pkg/bbcloud/variables_test.go
@@ -1,0 +1,433 @@
+package bbcloud
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestListRepositoryVariablesValidation(t *testing.T) {
+	client, err := New(Options{BaseURL: "https://api.bitbucket.org/2.0"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		workspace     string
+		repoSlug      string
+		errorContains string
+	}{
+		{
+			name:          "missing workspace",
+			workspace:     "",
+			repoSlug:      "repo",
+			errorContains: "workspace and repository slug are required",
+		},
+		{
+			name:          "missing repo slug",
+			workspace:     "workspace",
+			repoSlug:      "",
+			errorContains: "workspace and repository slug are required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := client.ListRepositoryVariables(ctx, tt.workspace, tt.repoSlug, VariableListOptions{})
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.errorContains)
+			}
+			if !strings.Contains(err.Error(), tt.errorContains) {
+				t.Errorf("expected error containing %q, got %q", tt.errorContains, err.Error())
+			}
+		})
+	}
+}
+
+func TestListRepositoryVariablesPagination(t *testing.T) {
+	var requestCount int
+	var serverURL string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+
+		switch requestCount {
+		case 1:
+			resp := variableListPage{
+				Values: []PipelineVariable{
+					{UUID: "{uuid-1}", Key: "VAR1", Value: "value1"},
+					{UUID: "{uuid-2}", Key: "VAR2", Value: "value2"},
+				},
+				Next: serverURL + "/repositories/ws/repo/pipelines_config/variables?page=2",
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		case 2:
+			resp := variableListPage{
+				Values: []PipelineVariable{
+					{UUID: "{uuid-3}", Key: "VAR3", Value: "value3"},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			t.Fatalf("unexpected request %d", requestCount)
+		}
+	}))
+	serverURL = server.URL
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{BaseURL: server.URL})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+	variables, err := client.ListRepositoryVariables(ctx, "ws", "repo", VariableListOptions{})
+	if err != nil {
+		t.Fatalf("ListRepositoryVariables: %v", err)
+	}
+
+	if len(variables) != 3 {
+		t.Errorf("expected 3 variables, got %d", len(variables))
+	}
+	if requestCount != 2 {
+		t.Errorf("expected 2 requests for pagination, got %d", requestCount)
+	}
+}
+
+func TestListRepositoryVariablesRespectsLimit(t *testing.T) {
+	var requestCount int
+	var serverURL string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+
+		resp := variableListPage{
+			Values: []PipelineVariable{
+				{UUID: "{uuid-1}", Key: "VAR1"},
+				{UUID: "{uuid-2}", Key: "VAR2"},
+				{UUID: "{uuid-3}", Key: "VAR3"},
+			},
+			Next: serverURL + "/repositories/ws/repo/pipelines_config/variables?page=2",
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	serverURL = server.URL
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{BaseURL: server.URL})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+	variables, err := client.ListRepositoryVariables(ctx, "ws", "repo", VariableListOptions{Limit: 2})
+	if err != nil {
+		t.Fatalf("ListRepositoryVariables: %v", err)
+	}
+
+	if len(variables) != 2 {
+		t.Errorf("expected 2 variables (limit), got %d", len(variables))
+	}
+	if requestCount != 1 {
+		t.Errorf("expected 1 request (limit satisfied), got %d", requestCount)
+	}
+}
+
+func TestCreateRepositoryVariableValidation(t *testing.T) {
+	client, err := New(Options{BaseURL: "https://api.bitbucket.org/2.0"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		workspace     string
+		repoSlug      string
+		input         CreateRepositoryVariableInput
+		errorContains string
+	}{
+		{
+			name:          "missing workspace",
+			workspace:     "",
+			repoSlug:      "repo",
+			input:         CreateRepositoryVariableInput{Key: "VAR1", Value: "value"},
+			errorContains: "workspace and repository slug are required",
+		},
+		{
+			name:          "missing repo slug",
+			workspace:     "workspace",
+			repoSlug:      "",
+			input:         CreateRepositoryVariableInput{Key: "VAR1", Value: "value"},
+			errorContains: "workspace and repository slug are required",
+		},
+		{
+			name:          "missing key",
+			workspace:     "workspace",
+			repoSlug:      "repo",
+			input:         CreateRepositoryVariableInput{Key: "", Value: "value"},
+			errorContains: "variable key is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := client.CreateRepositoryVariable(ctx, tt.workspace, tt.repoSlug, tt.input)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.errorContains)
+			}
+			if !strings.Contains(err.Error(), tt.errorContains) {
+				t.Errorf("expected error containing %q, got %q", tt.errorContains, err.Error())
+			}
+		})
+	}
+}
+
+func TestCreateRepositoryVariable(t *testing.T) {
+	var capturedBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+
+		_ = json.NewDecoder(r.Body).Decode(&capturedBody)
+
+		w.Header().Set("Content-Type", "application/json")
+		resp := PipelineVariable{
+			UUID:    "{new-uuid}",
+			Key:     capturedBody["key"].(string),
+			Secured: capturedBody["secured"].(bool),
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{BaseURL: server.URL})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+	variable, err := client.CreateRepositoryVariable(ctx, "ws", "repo", CreateRepositoryVariableInput{
+		Key:     "MY_VAR",
+		Value:   "secret",
+		Secured: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateRepositoryVariable: %v", err)
+	}
+
+	if variable.Key != "MY_VAR" {
+		t.Errorf("expected key MY_VAR, got %s", variable.Key)
+	}
+	if !variable.Secured {
+		t.Error("expected variable to be secured")
+	}
+
+	if capturedBody["key"] != "MY_VAR" {
+		t.Errorf("expected request body key=MY_VAR, got %v", capturedBody["key"])
+	}
+	if capturedBody["value"] != "secret" {
+		t.Errorf("expected request body value=secret, got %v", capturedBody["value"])
+	}
+	if capturedBody["secured"] != true {
+		t.Errorf("expected request body secured=true, got %v", capturedBody["secured"])
+	}
+}
+
+func TestUpdateRepositoryVariableValidation(t *testing.T) {
+	client, err := New(Options{BaseURL: "https://api.bitbucket.org/2.0"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		workspace     string
+		repoSlug      string
+		uuid          string
+		input         UpdateRepositoryVariableInput
+		errorContains string
+	}{
+		{
+			name:          "missing workspace",
+			workspace:     "",
+			repoSlug:      "repo",
+			uuid:          "{uuid}",
+			input:         UpdateRepositoryVariableInput{Key: "VAR1", Value: "value"},
+			errorContains: "workspace and repository slug are required",
+		},
+		{
+			name:          "missing uuid",
+			workspace:     "workspace",
+			repoSlug:      "repo",
+			uuid:          "",
+			input:         UpdateRepositoryVariableInput{Key: "VAR1", Value: "value"},
+			errorContains: "variable UUID is required",
+		},
+		{
+			name:          "missing key",
+			workspace:     "workspace",
+			repoSlug:      "repo",
+			uuid:          "{uuid}",
+			input:         UpdateRepositoryVariableInput{Key: "", Value: "value"},
+			errorContains: "variable key is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := client.UpdateRepositoryVariable(ctx, tt.workspace, tt.repoSlug, tt.uuid, tt.input)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.errorContains)
+			}
+			if !strings.Contains(err.Error(), tt.errorContains) {
+				t.Errorf("expected error containing %q, got %q", tt.errorContains, err.Error())
+			}
+		})
+	}
+}
+
+func TestDeleteRepositoryVariableValidation(t *testing.T) {
+	client, err := New(Options{BaseURL: "https://api.bitbucket.org/2.0"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		workspace     string
+		repoSlug      string
+		uuid          string
+		errorContains string
+	}{
+		{
+			name:          "missing workspace",
+			workspace:     "",
+			repoSlug:      "repo",
+			uuid:          "{uuid}",
+			errorContains: "workspace and repository slug are required",
+		},
+		{
+			name:          "missing uuid",
+			workspace:     "workspace",
+			repoSlug:      "repo",
+			uuid:          "",
+			errorContains: "variable UUID is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := client.DeleteRepositoryVariable(ctx, tt.workspace, tt.repoSlug, tt.uuid)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.errorContains)
+			}
+			if !strings.Contains(err.Error(), tt.errorContains) {
+				t.Errorf("expected error containing %q, got %q", tt.errorContains, err.Error())
+			}
+		})
+	}
+}
+
+func TestListWorkspaceVariablesValidation(t *testing.T) {
+	client, err := New(Options{BaseURL: "https://api.bitbucket.org/2.0"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+
+	_, err = client.ListWorkspaceVariables(ctx, "", VariableListOptions{})
+	if err == nil {
+		t.Fatal("expected error for missing workspace, got nil")
+	}
+	if !strings.Contains(err.Error(), "workspace is required") {
+		t.Errorf("expected error about workspace, got %q", err.Error())
+	}
+}
+
+func TestListDeploymentEnvironments(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/environments") {
+			t.Errorf("expected path to contain /environments, got %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		resp := deploymentEnvironmentListPage{
+			Values: []DeploymentEnvironment{
+				{UUID: "{env-1}", Name: "production", Slug: "production"},
+				{UUID: "{env-2}", Name: "staging", Slug: "staging"},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{BaseURL: server.URL})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+	environments, err := client.ListDeploymentEnvironments(ctx, "ws", "repo")
+	if err != nil {
+		t.Fatalf("ListDeploymentEnvironments: %v", err)
+	}
+
+	if len(environments) != 2 {
+		t.Errorf("expected 2 environments, got %d", len(environments))
+	}
+	if environments[0].Name != "production" {
+		t.Errorf("expected first environment to be production, got %s", environments[0].Name)
+	}
+}
+
+func TestListDeploymentVariables(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/deployments_config/environments/") {
+			t.Errorf("expected path to contain /deployments_config/environments/, got %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		resp := variableListPage{
+			Values: []PipelineVariable{
+				{UUID: "{var-1}", Key: "DEPLOY_VAR", Value: "value1"},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{BaseURL: server.URL})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+	variables, err := client.ListDeploymentVariables(ctx, "ws", "repo", "{env-uuid}", VariableListOptions{})
+	if err != nil {
+		t.Fatalf("ListDeploymentVariables: %v", err)
+	}
+
+	if len(variables) != 1 {
+		t.Errorf("expected 1 variable, got %d", len(variables))
+	}
+	if variables[0].Key != "DEPLOY_VAR" {
+		t.Errorf("expected key DEPLOY_VAR, got %s", variables[0].Key)
+	}
+}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -16,6 +16,7 @@ import (
 	"github.com/avivsinai/bitbucket-cli/pkg/cmd/project"
 	"github.com/avivsinai/bitbucket-cli/pkg/cmd/repo"
 	"github.com/avivsinai/bitbucket-cli/pkg/cmd/status"
+	"github.com/avivsinai/bitbucket-cli/pkg/cmd/variable"
 	"github.com/avivsinai/bitbucket-cli/pkg/cmd/webhook"
 	"github.com/avivsinai/bitbucket-cli/pkg/cmdutil"
 )
@@ -62,6 +63,7 @@ Common flows:
 		webhook.NewCommand(f),
 		status.NewCmdStatus(f),
 		pipeline.NewCmdPipeline(f),
+		variable.NewCommand(f),
 		api.NewCmdAPI(f),
 		extension.NewCmdExtension(f),
 	)

--- a/pkg/cmd/variable/variable.go
+++ b/pkg/cmd/variable/variable.go
@@ -1,0 +1,1190 @@
+package variable
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/avivsinai/bitbucket-cli/pkg/bbcloud"
+	"github.com/avivsinai/bitbucket-cli/pkg/cmdutil"
+)
+
+// NewCommand creates the variable command.
+func NewCommand(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "variable",
+		Short: "Manage pipeline variables",
+		Long: `Create and manage pipeline variables in Bitbucket Cloud repositories.
+
+Pipeline variables are available during pipeline execution. Variables can be
+defined at three scopes:
+  - Repository: Available to all pipelines in the repository
+  - Workspace: Available to all pipelines in the workspace
+  - Deployment: Available only during deployment to a specific environment
+
+Note: Pipeline variables are only available for Bitbucket Cloud.`,
+	}
+
+	cmd.AddCommand(newListCmd(f))
+	cmd.AddCommand(newGetCmd(f))
+	cmd.AddCommand(newDeleteCmd(f))
+	cmd.AddCommand(newSetCmd(f))
+
+	return cmd
+}
+
+// Valid scope values
+const (
+	scopeRepository = "repository"
+	scopeWorkspace  = "workspace"
+	scopeDeployment = "deployment"
+)
+
+// resolveDeploymentEnvironment finds a deployment environment by name and returns its UUID.
+func resolveDeploymentEnvironment(ctx context.Context, client *bbcloud.Client, workspace, repoSlug, envName string) (string, error) {
+	environments, err := client.ListDeploymentEnvironments(ctx, workspace, repoSlug)
+	if err != nil {
+		return "", fmt.Errorf("failed to list deployment environments: %w", err)
+	}
+
+	for _, env := range environments {
+		if strings.EqualFold(env.Name, envName) || strings.EqualFold(env.Slug, envName) {
+			return env.UUID, nil
+		}
+	}
+
+	var names []string
+	for _, env := range environments {
+		names = append(names, env.Name)
+	}
+	if len(names) == 0 {
+		return "", fmt.Errorf("deployment environment %q not found; no environments configured", envName)
+	}
+	return "", fmt.Errorf("deployment environment %q not found; available: %s", envName, strings.Join(names, ", "))
+}
+
+// --- List Command ---
+
+type listOptions struct {
+	Workspace  string
+	Repo       string
+	Scope      string
+	Deployment string
+	Limit      int
+}
+
+func newListCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &listOptions{
+		Limit: 30,
+		Scope: scopeRepository,
+	}
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List pipeline variables",
+		Example: `  # List repository variables (default)
+  bkt variable list
+
+  # List workspace variables
+  bkt variable list --scope workspace
+
+  # List deployment environment variables
+  bkt variable list --deployment production
+
+  # List variables in JSON format
+  bkt variable list --json
+
+  # List variables for a specific repository
+  bkt variable list --repo my-repo`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// If --deployment is set, override scope
+			if opts.Deployment != "" {
+				opts.Scope = scopeDeployment
+			}
+			return runList(cmd, f, opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Workspace, "workspace", "", "Bitbucket workspace")
+	cmd.Flags().StringVarP(&opts.Repo, "repo", "R", "", "Repository slug")
+	cmd.Flags().StringVar(&opts.Scope, "scope", opts.Scope, "Variable scope: repository, workspace, or deployment")
+	cmd.Flags().StringVarP(&opts.Deployment, "deployment", "e", "", "Deployment environment name (implies --scope deployment)")
+	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", opts.Limit, "Maximum variables to display")
+
+	return cmd
+}
+
+func runList(cmd *cobra.Command, f *cmdutil.Factory, opts *listOptions) error {
+	ios, err := f.Streams()
+	if err != nil {
+		return err
+	}
+
+	override := cmdutil.FlagValue(cmd, "context")
+	_, ctxCfg, host, err := cmdutil.ResolveContext(f, cmd, override)
+	if err != nil {
+		return err
+	}
+
+	if host.Kind != "cloud" {
+		return fmt.Errorf("pipeline variables are only available for Bitbucket Cloud; current context uses %s", host.Kind)
+	}
+
+	// Validate scope
+	scope := strings.ToLower(strings.TrimSpace(opts.Scope))
+	if scope != scopeRepository && scope != scopeWorkspace && scope != scopeDeployment {
+		return fmt.Errorf("invalid scope %q; must be 'repository', 'workspace', or 'deployment'", opts.Scope)
+	}
+
+	workspace := strings.TrimSpace(opts.Workspace)
+	if workspace == "" {
+		workspace = ctxCfg.Workspace
+	}
+	if workspace == "" {
+		return fmt.Errorf("workspace required; set with --workspace or configure the context default")
+	}
+
+	var repoSlug string
+	if scope == scopeRepository || scope == scopeDeployment {
+		repoSlug = strings.TrimSpace(opts.Repo)
+		if repoSlug == "" {
+			repoSlug = ctxCfg.DefaultRepo
+		}
+		if repoSlug == "" {
+			return fmt.Errorf("repository slug required; set with --repo or configure the context default")
+		}
+	}
+
+	client, err := cmdutil.NewCloudClient(host)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+	defer cancel()
+
+	var variables []bbcloud.PipelineVariable
+	var envUUID string
+	switch scope {
+	case scopeWorkspace:
+		variables, err = client.ListWorkspaceVariables(ctx, workspace, bbcloud.VariableListOptions{
+			Limit: opts.Limit,
+		})
+	case scopeDeployment:
+		if opts.Deployment == "" {
+			return fmt.Errorf("deployment environment name is required; use --deployment")
+		}
+		envUUID, err = resolveDeploymentEnvironment(ctx, client, workspace, repoSlug, opts.Deployment)
+		if err != nil {
+			return err
+		}
+		variables, err = client.ListDeploymentVariables(ctx, workspace, repoSlug, envUUID, bbcloud.VariableListOptions{
+			Limit: opts.Limit,
+		})
+	default:
+		variables, err = client.ListRepositoryVariables(ctx, workspace, repoSlug, bbcloud.VariableListOptions{
+			Limit: opts.Limit,
+		})
+	}
+	if err != nil {
+		return err
+	}
+
+	type variableSummary struct {
+		UUID    string `json:"uuid"`
+		Key     string `json:"key"`
+		Value   string `json:"value,omitempty"`
+		Secured bool   `json:"secured"`
+	}
+
+	var summaries []variableSummary
+	for _, v := range variables {
+		summaries = append(summaries, variableSummary{
+			UUID:    v.UUID,
+			Key:     v.Key,
+			Value:   v.Value,
+			Secured: v.Secured,
+		})
+	}
+
+	payload := struct {
+		Workspace  string            `json:"workspace"`
+		Repository string            `json:"repository,omitempty"`
+		Deployment string            `json:"deployment,omitempty"`
+		Scope      string            `json:"scope"`
+		Variables  []variableSummary `json:"variables"`
+	}{
+		Workspace:  workspace,
+		Repository: repoSlug,
+		Deployment: opts.Deployment,
+		Scope:      scope,
+		Variables:  summaries,
+	}
+
+	return cmdutil.WriteOutput(cmd, ios.Out, payload, func() error {
+		location := workspace
+		if scope == scopeRepository {
+			location = workspace + "/" + repoSlug
+		} else if scope == scopeDeployment {
+			location = workspace + "/" + repoSlug + " (deployment: " + opts.Deployment + ")"
+		}
+		if len(summaries) == 0 {
+			_, err := fmt.Fprintf(ios.Out, "No %s variables found in %s.\n", scope, location)
+			return err
+		}
+
+		for _, v := range summaries {
+			value := v.Value
+			if v.Secured {
+				value = "********"
+			}
+			if _, err := fmt.Fprintf(ios.Out, "%s\t%s\t(secured=%v)\n", v.Key, value, v.Secured); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// --- Get Command ---
+
+type getOptions struct {
+	Workspace  string
+	Repo       string
+	Scope      string
+	Deployment string
+}
+
+func newGetCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &getOptions{
+		Scope: scopeRepository,
+	}
+	cmd := &cobra.Command{
+		Use:   "get <variable-name>",
+		Short: "Get a pipeline variable",
+		Example: `  # Get a repository variable by name
+  bkt variable get MY_VAR
+
+  # Get a workspace variable
+  bkt variable get MY_VAR --scope workspace
+
+  # Get a deployment environment variable
+  bkt variable get MY_VAR --deployment production
+
+  # Get a variable in JSON format
+  bkt variable get MY_VAR --json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Deployment != "" {
+				opts.Scope = scopeDeployment
+			}
+			return runGet(cmd, f, opts, args[0])
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Workspace, "workspace", "", "Bitbucket workspace")
+	cmd.Flags().StringVarP(&opts.Repo, "repo", "R", "", "Repository slug")
+	cmd.Flags().StringVar(&opts.Scope, "scope", opts.Scope, "Variable scope: repository, workspace, or deployment")
+	cmd.Flags().StringVarP(&opts.Deployment, "deployment", "e", "", "Deployment environment name (implies --scope deployment)")
+
+	return cmd
+}
+
+func runGet(cmd *cobra.Command, f *cmdutil.Factory, opts *getOptions, variableName string) error {
+	ios, err := f.Streams()
+	if err != nil {
+		return err
+	}
+
+	override := cmdutil.FlagValue(cmd, "context")
+	_, ctxCfg, host, err := cmdutil.ResolveContext(f, cmd, override)
+	if err != nil {
+		return err
+	}
+
+	if host.Kind != "cloud" {
+		return fmt.Errorf("pipeline variables are only available for Bitbucket Cloud; current context uses %s", host.Kind)
+	}
+
+	// Validate scope
+	scope := strings.ToLower(strings.TrimSpace(opts.Scope))
+	if scope != scopeRepository && scope != scopeWorkspace && scope != scopeDeployment {
+		return fmt.Errorf("invalid scope %q; must be 'repository', 'workspace', or 'deployment'", opts.Scope)
+	}
+
+	workspace := strings.TrimSpace(opts.Workspace)
+	if workspace == "" {
+		workspace = ctxCfg.Workspace
+	}
+	if workspace == "" {
+		return fmt.Errorf("workspace required; set with --workspace or configure the context default")
+	}
+
+	var repoSlug string
+	if scope == scopeRepository || scope == scopeDeployment {
+		repoSlug = strings.TrimSpace(opts.Repo)
+		if repoSlug == "" {
+			repoSlug = ctxCfg.DefaultRepo
+		}
+		if repoSlug == "" {
+			return fmt.Errorf("repository slug required; set with --repo or configure the context default")
+		}
+	}
+
+	client, err := cmdutil.NewCloudClient(host)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+	defer cancel()
+
+	// List all variables and find the one with matching key
+	var variables []bbcloud.PipelineVariable
+	var envUUID string
+	switch scope {
+	case scopeWorkspace:
+		variables, err = client.ListWorkspaceVariables(ctx, workspace, bbcloud.VariableListOptions{})
+	case scopeDeployment:
+		if opts.Deployment == "" {
+			return fmt.Errorf("deployment environment name is required; use --deployment")
+		}
+		envUUID, err = resolveDeploymentEnvironment(ctx, client, workspace, repoSlug, opts.Deployment)
+		if err != nil {
+			return err
+		}
+		variables, err = client.ListDeploymentVariables(ctx, workspace, repoSlug, envUUID, bbcloud.VariableListOptions{})
+	default:
+		variables, err = client.ListRepositoryVariables(ctx, workspace, repoSlug, bbcloud.VariableListOptions{})
+	}
+	if err != nil {
+		return err
+	}
+
+	var found *bbcloud.PipelineVariable
+	for i := range variables {
+		if variables[i].Key == variableName {
+			found = &variables[i]
+			break
+		}
+	}
+
+	location := workspace
+	if scope == scopeRepository {
+		location = workspace + "/" + repoSlug
+	} else if scope == scopeDeployment {
+		location = workspace + "/" + repoSlug + " (deployment: " + opts.Deployment + ")"
+	}
+
+	if found == nil {
+		return fmt.Errorf("variable %q not found in %s", variableName, location)
+	}
+
+	payload := struct {
+		UUID       string `json:"uuid"`
+		Key        string `json:"key"`
+		Value      string `json:"value,omitempty"`
+		Secured    bool   `json:"secured"`
+		Workspace  string `json:"workspace"`
+		Repo       string `json:"repository,omitempty"`
+		Deployment string `json:"deployment,omitempty"`
+		Scope      string `json:"scope"`
+	}{
+		UUID:       found.UUID,
+		Key:        found.Key,
+		Value:      found.Value,
+		Secured:    found.Secured,
+		Workspace:  workspace,
+		Repo:       repoSlug,
+		Deployment: opts.Deployment,
+		Scope:      scope,
+	}
+
+	return cmdutil.WriteOutput(cmd, ios.Out, payload, func() error {
+		value := found.Value
+		if found.Secured {
+			value = "********"
+			_, _ = fmt.Fprintf(ios.ErrOut, "Note: Variable %q is secured; value is not retrievable.\n", found.Key)
+		}
+		_, err := fmt.Fprintf(ios.Out, "%s=%s\n", found.Key, value)
+		return err
+	})
+}
+
+// --- Delete Command ---
+
+type deleteOptions struct {
+	Workspace  string
+	Repo       string
+	Scope      string
+	Deployment string
+	Yes        bool
+}
+
+func newDeleteCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &deleteOptions{
+		Scope: scopeRepository,
+	}
+	cmd := &cobra.Command{
+		Use:     "delete <variable-name>",
+		Aliases: []string{"rm"},
+		Short:   "Delete a pipeline variable",
+		Example: `  # Delete a repository variable (will prompt for confirmation)
+  bkt variable delete MY_VAR
+
+  # Delete a workspace variable
+  bkt variable delete MY_VAR --scope workspace
+
+  # Delete a deployment environment variable
+  bkt variable delete MY_VAR --deployment production
+
+  # Delete without confirmation
+  bkt variable delete MY_VAR --yes`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Deployment != "" {
+				opts.Scope = scopeDeployment
+			}
+			return runDelete(cmd, f, opts, args[0])
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Workspace, "workspace", "", "Bitbucket workspace")
+	cmd.Flags().StringVarP(&opts.Repo, "repo", "R", "", "Repository slug")
+	cmd.Flags().StringVar(&opts.Scope, "scope", opts.Scope, "Variable scope: repository, workspace, or deployment")
+	cmd.Flags().StringVarP(&opts.Deployment, "deployment", "e", "", "Deployment environment name (implies --scope deployment)")
+	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Skip confirmation prompt")
+
+	return cmd
+}
+
+func runDelete(cmd *cobra.Command, f *cmdutil.Factory, opts *deleteOptions, variableName string) error {
+	ios, err := f.Streams()
+	if err != nil {
+		return err
+	}
+
+	override := cmdutil.FlagValue(cmd, "context")
+	_, ctxCfg, host, err := cmdutil.ResolveContext(f, cmd, override)
+	if err != nil {
+		return err
+	}
+
+	if host.Kind != "cloud" {
+		return fmt.Errorf("pipeline variables are only available for Bitbucket Cloud; current context uses %s", host.Kind)
+	}
+
+	// Validate scope
+	scope := strings.ToLower(strings.TrimSpace(opts.Scope))
+	if scope != scopeRepository && scope != scopeWorkspace && scope != scopeDeployment {
+		return fmt.Errorf("invalid scope %q; must be 'repository', 'workspace', or 'deployment'", opts.Scope)
+	}
+
+	workspace := strings.TrimSpace(opts.Workspace)
+	if workspace == "" {
+		workspace = ctxCfg.Workspace
+	}
+	if workspace == "" {
+		return fmt.Errorf("workspace required; set with --workspace or configure the context default")
+	}
+
+	var repoSlug string
+	if scope == scopeRepository || scope == scopeDeployment {
+		repoSlug = strings.TrimSpace(opts.Repo)
+		if repoSlug == "" {
+			repoSlug = ctxCfg.DefaultRepo
+		}
+		if repoSlug == "" {
+			return fmt.Errorf("repository slug required; set with --repo or configure the context default")
+		}
+	}
+
+	client, err := cmdutil.NewCloudClient(host)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+	defer cancel()
+
+	// List all variables and find the one with matching key
+	var variables []bbcloud.PipelineVariable
+	var envUUID string
+	switch scope {
+	case scopeWorkspace:
+		variables, err = client.ListWorkspaceVariables(ctx, workspace, bbcloud.VariableListOptions{})
+	case scopeDeployment:
+		if opts.Deployment == "" {
+			return fmt.Errorf("deployment environment name is required; use --deployment")
+		}
+		envUUID, err = resolveDeploymentEnvironment(ctx, client, workspace, repoSlug, opts.Deployment)
+		if err != nil {
+			return err
+		}
+		variables, err = client.ListDeploymentVariables(ctx, workspace, repoSlug, envUUID, bbcloud.VariableListOptions{})
+	default:
+		variables, err = client.ListRepositoryVariables(ctx, workspace, repoSlug, bbcloud.VariableListOptions{})
+	}
+	if err != nil {
+		return err
+	}
+
+	var found *bbcloud.PipelineVariable
+	for i := range variables {
+		if variables[i].Key == variableName {
+			found = &variables[i]
+			break
+		}
+	}
+
+	location := workspace
+	if scope == scopeRepository {
+		location = workspace + "/" + repoSlug
+	} else if scope == scopeDeployment {
+		location = workspace + "/" + repoSlug + " (deployment: " + opts.Deployment + ")"
+	}
+
+	if found == nil {
+		return fmt.Errorf("variable %q not found in %s", variableName, location)
+	}
+
+	if !opts.Yes {
+		prompter := f.Prompt()
+		confirmed, err := prompter.Confirm(fmt.Sprintf("Delete variable %q from %s?", found.Key, location), false)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			_, _ = fmt.Fprintln(ios.Out, "Aborted.")
+			return nil
+		}
+	}
+
+	switch scope {
+	case scopeWorkspace:
+		err = client.DeleteWorkspaceVariable(ctx, workspace, found.UUID)
+	case scopeDeployment:
+		err = client.DeleteDeploymentVariable(ctx, workspace, repoSlug, envUUID, found.UUID)
+	default:
+		err = client.DeleteRepositoryVariable(ctx, workspace, repoSlug, found.UUID)
+	}
+	if err != nil {
+		return err
+	}
+
+	payload := struct {
+		Key        string `json:"key"`
+		Deleted    bool   `json:"deleted"`
+		Workspace  string `json:"workspace"`
+		Repo       string `json:"repository,omitempty"`
+		Deployment string `json:"deployment,omitempty"`
+		Scope      string `json:"scope"`
+	}{
+		Key:        found.Key,
+		Deleted:    true,
+		Workspace:  workspace,
+		Repo:       repoSlug,
+		Deployment: opts.Deployment,
+		Scope:      scope,
+	}
+
+	return cmdutil.WriteOutput(cmd, ios.Out, payload, func() error {
+		_, err := fmt.Fprintf(ios.Out, "Deleted variable %q from %s.\n", found.Key, location)
+		return err
+	})
+}
+
+// --- Set Command ---
+
+type setOptions struct {
+	Workspace  string
+	Repo       string
+	Scope      string
+	Deployment string
+	Body       string
+	Secured    bool
+	EnvFile    string
+}
+
+func newSetCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &setOptions{
+		Scope: scopeRepository,
+	}
+	cmd := &cobra.Command{
+		Use:   "set [<variable-name>]",
+		Short: "Create or update a pipeline variable",
+		Long: `Create or update a pipeline variable.
+
+If the variable already exists, it will be updated. Otherwise, a new variable
+will be created.
+
+The value can be provided via:
+  - The --body flag
+  - Standard input (if --body is not specified)
+  - Interactive prompt (if running in a TTY)
+
+You can also import multiple variables at once from an env file using the
+--env-file flag. The file should contain KEY=VALUE pairs, one per line.
+Lines starting with # are treated as comments.`,
+		Example: `  # Set a repository variable with a value
+  bkt variable set MY_VAR --body "my-value"
+
+  # Set a workspace variable
+  bkt variable set MY_VAR --body "my-value" --scope workspace
+
+  # Set a deployment environment variable
+  bkt variable set MY_VAR --body "my-value" --deployment production
+
+  # Set a secured/secret variable
+  bkt variable set MY_SECRET --body "secret-value" --secured
+
+  # Set a variable from stdin
+  echo "my-value" | bkt variable set MY_VAR
+
+  # Import variables from an env file
+  bkt variable set --env-file .env`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Deployment != "" {
+				opts.Scope = scopeDeployment
+			}
+			if opts.Body != "" && opts.EnvFile != "" {
+				return fmt.Errorf("cannot specify both --body and --env-file")
+			}
+			if opts.EnvFile != "" {
+				if len(args) > 0 {
+					return fmt.Errorf("cannot specify both variable name and --env-file")
+				}
+				return runSetFromEnvFile(cmd, f, opts)
+			}
+			if len(args) == 0 {
+				return fmt.Errorf("variable name is required; use --env-file to import from a file")
+			}
+			return runSet(cmd, f, opts, args[0])
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Workspace, "workspace", "", "Bitbucket workspace")
+	cmd.Flags().StringVarP(&opts.Repo, "repo", "R", "", "Repository slug")
+	cmd.Flags().StringVar(&opts.Scope, "scope", opts.Scope, "Variable scope: repository, workspace, or deployment")
+	cmd.Flags().StringVarP(&opts.Deployment, "deployment", "e", "", "Deployment environment name (implies --scope deployment)")
+	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "Variable value")
+	cmd.Flags().BoolVarP(&opts.Secured, "secured", "s", false, "Mark variable as secured (secret)")
+	cmd.Flags().StringVarP(&opts.EnvFile, "env-file", "f", "", "Path to env file containing KEY=VALUE pairs")
+
+	return cmd
+}
+
+func runSet(cmd *cobra.Command, f *cmdutil.Factory, opts *setOptions, variableName string) error {
+	ios, err := f.Streams()
+	if err != nil {
+		return err
+	}
+
+	override := cmdutil.FlagValue(cmd, "context")
+	_, ctxCfg, host, err := cmdutil.ResolveContext(f, cmd, override)
+	if err != nil {
+		return err
+	}
+
+	if host.Kind != "cloud" {
+		return fmt.Errorf("pipeline variables are only available for Bitbucket Cloud; current context uses %s", host.Kind)
+	}
+
+	// Validate scope
+	scope := strings.ToLower(strings.TrimSpace(opts.Scope))
+	if scope != scopeRepository && scope != scopeWorkspace && scope != scopeDeployment {
+		return fmt.Errorf("invalid scope %q; must be 'repository', 'workspace', or 'deployment'", opts.Scope)
+	}
+
+	workspace := strings.TrimSpace(opts.Workspace)
+	if workspace == "" {
+		workspace = ctxCfg.Workspace
+	}
+	if workspace == "" {
+		return fmt.Errorf("workspace required; set with --workspace or configure the context default")
+	}
+
+	var repoSlug string
+	if scope == scopeRepository || scope == scopeDeployment {
+		repoSlug = strings.TrimSpace(opts.Repo)
+		if repoSlug == "" {
+			repoSlug = ctxCfg.DefaultRepo
+		}
+		if repoSlug == "" {
+			return fmt.Errorf("repository slug required; set with --repo or configure the context default")
+		}
+	}
+
+	// Validate variable name
+	if err := validateVariableKey(variableName); err != nil {
+		return err
+	}
+
+	// Get value from --body flag, stdin, or interactive prompt
+	value := opts.Body
+	if value == "" {
+		// Try to read from stdin if not a TTY
+		if !ios.CanPrompt() {
+			data, err := io.ReadAll(ios.In)
+			if err != nil {
+				return fmt.Errorf("failed to read from stdin: %w", err)
+			}
+			value = strings.TrimSuffix(string(data), "\n")
+		} else {
+			// Interactive prompt
+			prompter := f.Prompt()
+			promptStr := fmt.Sprintf("Value for %s", variableName)
+			var err error
+			if opts.Secured {
+				// Use password prompt to avoid exposing secret in terminal
+				value, err = prompter.Password(promptStr)
+			} else {
+				value, err = prompter.Input(promptStr, "")
+			}
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if value == "" {
+		return fmt.Errorf("variable value is required; use --body to specify the value")
+	}
+
+	client, err := cmdutil.NewCloudClient(host)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+	defer cancel()
+
+	// Check if variable already exists
+	var variables []bbcloud.PipelineVariable
+	var envUUID string
+	switch scope {
+	case scopeWorkspace:
+		variables, err = client.ListWorkspaceVariables(ctx, workspace, bbcloud.VariableListOptions{})
+	case scopeDeployment:
+		if opts.Deployment == "" {
+			return fmt.Errorf("deployment environment name is required; use --deployment")
+		}
+		envUUID, err = resolveDeploymentEnvironment(ctx, client, workspace, repoSlug, opts.Deployment)
+		if err != nil {
+			return err
+		}
+		variables, err = client.ListDeploymentVariables(ctx, workspace, repoSlug, envUUID, bbcloud.VariableListOptions{})
+	default:
+		variables, err = client.ListRepositoryVariables(ctx, workspace, repoSlug, bbcloud.VariableListOptions{})
+	}
+	if err != nil {
+		return err
+	}
+
+	var existing *bbcloud.PipelineVariable
+	for i := range variables {
+		if variables[i].Key == variableName {
+			existing = &variables[i]
+			break
+		}
+	}
+
+	var result *bbcloud.PipelineVariable
+	var action string
+
+	if existing != nil {
+		// Update existing variable
+		// Preserve existing secured state unless --secured was explicitly set
+		secured := existing.Secured
+		if cmd.Flags().Changed("secured") {
+			secured = opts.Secured
+		}
+		switch scope {
+		case scopeWorkspace:
+			result, err = client.UpdateWorkspaceVariable(ctx, workspace, existing.UUID, bbcloud.UpdateWorkspaceVariableInput{
+				Key:     variableName,
+				Value:   value,
+				Secured: secured,
+			})
+		case scopeDeployment:
+			result, err = client.UpdateDeploymentVariable(ctx, workspace, repoSlug, envUUID, existing.UUID, bbcloud.UpdateDeploymentVariableInput{
+				Key:     variableName,
+				Value:   value,
+				Secured: secured,
+			})
+		default:
+			result, err = client.UpdateRepositoryVariable(ctx, workspace, repoSlug, existing.UUID, bbcloud.UpdateRepositoryVariableInput{
+				Key:     variableName,
+				Value:   value,
+				Secured: secured,
+			})
+		}
+		if err != nil {
+			return err
+		}
+		action = "Updated"
+	} else {
+		// Create new variable
+		switch scope {
+		case scopeWorkspace:
+			result, err = client.CreateWorkspaceVariable(ctx, workspace, bbcloud.CreateWorkspaceVariableInput{
+				Key:     variableName,
+				Value:   value,
+				Secured: opts.Secured,
+			})
+		case scopeDeployment:
+			result, err = client.CreateDeploymentVariable(ctx, workspace, repoSlug, envUUID, bbcloud.CreateDeploymentVariableInput{
+				Key:     variableName,
+				Value:   value,
+				Secured: opts.Secured,
+			})
+		default:
+			result, err = client.CreateRepositoryVariable(ctx, workspace, repoSlug, bbcloud.CreateRepositoryVariableInput{
+				Key:     variableName,
+				Value:   value,
+				Secured: opts.Secured,
+			})
+		}
+		if err != nil {
+			return err
+		}
+		action = "Created"
+	}
+
+	location := workspace
+	if scope == scopeRepository {
+		location = workspace + "/" + repoSlug
+	} else if scope == scopeDeployment {
+		location = workspace + "/" + repoSlug + " (deployment: " + opts.Deployment + ")"
+	}
+
+	payload := struct {
+		UUID       string `json:"uuid"`
+		Key        string `json:"key"`
+		Secured    bool   `json:"secured"`
+		Action     string `json:"action"`
+		Workspace  string `json:"workspace"`
+		Repo       string `json:"repository,omitempty"`
+		Deployment string `json:"deployment,omitempty"`
+		Scope      string `json:"scope"`
+	}{
+		UUID:       result.UUID,
+		Key:        result.Key,
+		Secured:    result.Secured,
+		Action:     strings.ToLower(action),
+		Workspace:  workspace,
+		Repo:       repoSlug,
+		Deployment: opts.Deployment,
+		Scope:      scope,
+	}
+
+	return cmdutil.WriteOutput(cmd, ios.Out, payload, func() error {
+		_, err := fmt.Fprintf(ios.Out, "%s variable %q in %s.\n", action, result.Key, location)
+		return err
+	})
+}
+
+// validateVariableKey checks if a variable key is valid.
+// Variable keys must start with a letter and contain only letters, numbers, and underscores.
+func validateVariableKey(key string) error {
+	if key == "" {
+		return fmt.Errorf("variable key cannot be empty")
+	}
+
+	// Must start with a letter
+	if !((key[0] >= 'a' && key[0] <= 'z') || (key[0] >= 'A' && key[0] <= 'Z')) {
+		return fmt.Errorf("variable key must start with a letter: %q", key)
+	}
+
+	// Must contain only letters, numbers, and underscores
+	for i, c := range key {
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_') {
+			return fmt.Errorf("variable key contains invalid character at position %d: %q", i, key)
+		}
+	}
+
+	return nil
+}
+
+// runSetFromEnvFile imports variables from an env file.
+func runSetFromEnvFile(cmd *cobra.Command, f *cmdutil.Factory, opts *setOptions) error {
+	ios, err := f.Streams()
+	if err != nil {
+		return err
+	}
+
+	override := cmdutil.FlagValue(cmd, "context")
+	_, ctxCfg, host, err := cmdutil.ResolveContext(f, cmd, override)
+	if err != nil {
+		return err
+	}
+
+	if host.Kind != "cloud" {
+		return fmt.Errorf("pipeline variables are only available for Bitbucket Cloud; current context uses %s", host.Kind)
+	}
+
+	// Validate scope
+	scope := strings.ToLower(strings.TrimSpace(opts.Scope))
+	if scope != scopeRepository && scope != scopeWorkspace && scope != scopeDeployment {
+		return fmt.Errorf("invalid scope %q; must be 'repository', 'workspace', or 'deployment'", opts.Scope)
+	}
+
+	workspace := strings.TrimSpace(opts.Workspace)
+	if workspace == "" {
+		workspace = ctxCfg.Workspace
+	}
+	if workspace == "" {
+		return fmt.Errorf("workspace required; set with --workspace or configure the context default")
+	}
+
+	var repoSlug string
+	if scope == scopeRepository || scope == scopeDeployment {
+		repoSlug = strings.TrimSpace(opts.Repo)
+		if repoSlug == "" {
+			repoSlug = ctxCfg.DefaultRepo
+		}
+		if repoSlug == "" {
+			return fmt.Errorf("repository slug required; set with --repo or configure the context default")
+		}
+	}
+
+	// Parse env file
+	envVars, err := parseEnvFile(opts.EnvFile)
+	if err != nil {
+		return err
+	}
+
+	if len(envVars) == 0 {
+		return fmt.Errorf("no variables found in %s", opts.EnvFile)
+	}
+
+	// Validate all keys first
+	for key := range envVars {
+		if err := validateVariableKey(key); err != nil {
+			return fmt.Errorf("invalid variable in env file: %w", err)
+		}
+	}
+
+	client, err := cmdutil.NewCloudClient(host)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+	defer cancel()
+
+	// Get existing variables
+	var existingVars []bbcloud.PipelineVariable
+	var envUUID string
+	switch scope {
+	case scopeWorkspace:
+		existingVars, err = client.ListWorkspaceVariables(ctx, workspace, bbcloud.VariableListOptions{})
+	case scopeDeployment:
+		if opts.Deployment == "" {
+			return fmt.Errorf("deployment environment name is required; use --deployment")
+		}
+		envUUID, err = resolveDeploymentEnvironment(ctx, client, workspace, repoSlug, opts.Deployment)
+		if err != nil {
+			return err
+		}
+		existingVars, err = client.ListDeploymentVariables(ctx, workspace, repoSlug, envUUID, bbcloud.VariableListOptions{})
+	default:
+		existingVars, err = client.ListRepositoryVariables(ctx, workspace, repoSlug, bbcloud.VariableListOptions{})
+	}
+	if err != nil {
+		return err
+	}
+
+	existingByKey := make(map[string]*bbcloud.PipelineVariable)
+	for i := range existingVars {
+		existingByKey[existingVars[i].Key] = &existingVars[i]
+	}
+
+	// Process each variable
+	type varResult struct {
+		Key     string `json:"key"`
+		Action  string `json:"action"`
+		Secured bool   `json:"secured"`
+	}
+
+	// Determine if --secured was explicitly set
+	securedFlagChanged := cmd.Flags().Changed("secured")
+
+	var results []varResult
+	for key, value := range envVars {
+		existing := existingByKey[key]
+		var action string
+		var secured bool
+
+		if existing != nil {
+			// Update existing variable
+			// Preserve existing secured state unless --secured was explicitly set
+			secured = existing.Secured
+			if securedFlagChanged {
+				secured = opts.Secured
+			}
+			switch scope {
+			case scopeWorkspace:
+				_, err = client.UpdateWorkspaceVariable(ctx, workspace, existing.UUID, bbcloud.UpdateWorkspaceVariableInput{
+					Key:     key,
+					Value:   value,
+					Secured: secured,
+				})
+			case scopeDeployment:
+				_, err = client.UpdateDeploymentVariable(ctx, workspace, repoSlug, envUUID, existing.UUID, bbcloud.UpdateDeploymentVariableInput{
+					Key:     key,
+					Value:   value,
+					Secured: secured,
+				})
+			default:
+				_, err = client.UpdateRepositoryVariable(ctx, workspace, repoSlug, existing.UUID, bbcloud.UpdateRepositoryVariableInput{
+					Key:     key,
+					Value:   value,
+					Secured: secured,
+				})
+			}
+			if err != nil {
+				return fmt.Errorf("failed to update variable %q: %w", key, err)
+			}
+			action = "updated"
+		} else {
+			// Create new variable - use opts.Secured for new variables
+			secured = opts.Secured
+			switch scope {
+			case scopeWorkspace:
+				_, err = client.CreateWorkspaceVariable(ctx, workspace, bbcloud.CreateWorkspaceVariableInput{
+					Key:     key,
+					Value:   value,
+					Secured: secured,
+				})
+			case scopeDeployment:
+				_, err = client.CreateDeploymentVariable(ctx, workspace, repoSlug, envUUID, bbcloud.CreateDeploymentVariableInput{
+					Key:     key,
+					Value:   value,
+					Secured: secured,
+				})
+			default:
+				_, err = client.CreateRepositoryVariable(ctx, workspace, repoSlug, bbcloud.CreateRepositoryVariableInput{
+					Key:     key,
+					Value:   value,
+					Secured: secured,
+				})
+			}
+			if err != nil {
+				return fmt.Errorf("failed to create variable %q: %w", key, err)
+			}
+			action = "created"
+		}
+
+		results = append(results, varResult{
+			Key:     key,
+			Action:  action,
+			Secured: secured,
+		})
+	}
+
+	location := workspace
+	if scope == scopeRepository {
+		location = workspace + "/" + repoSlug
+	} else if scope == scopeDeployment {
+		location = workspace + "/" + repoSlug + " (deployment: " + opts.Deployment + ")"
+	}
+
+	payload := struct {
+		Workspace  string      `json:"workspace"`
+		Repository string      `json:"repository,omitempty"`
+		Deployment string      `json:"deployment,omitempty"`
+		Scope      string      `json:"scope"`
+		Variables  []varResult `json:"variables"`
+	}{
+		Workspace:  workspace,
+		Repository: repoSlug,
+		Deployment: opts.Deployment,
+		Scope:      scope,
+		Variables:  results,
+	}
+
+	return cmdutil.WriteOutput(cmd, ios.Out, payload, func() error {
+		created := 0
+		updated := 0
+		for _, r := range results {
+			if r.Action == "created" {
+				created++
+			} else {
+				updated++
+			}
+		}
+
+		if created > 0 && updated > 0 {
+			_, err := fmt.Fprintf(ios.Out, "Created %d and updated %d variables in %s.\n", created, updated, location)
+			return err
+		} else if created > 0 {
+			_, err := fmt.Fprintf(ios.Out, "Created %d variable(s) in %s.\n", created, location)
+			return err
+		} else {
+			_, err := fmt.Fprintf(ios.Out, "Updated %d variable(s) in %s.\n", updated, location)
+			return err
+		}
+	})
+}
+
+// parseEnvFile reads a file and extracts KEY=VALUE pairs.
+// Lines starting with # are treated as comments.
+// Empty lines are skipped.
+func parseEnvFile(path string) (map[string]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open env file: %w", err)
+	}
+	defer file.Close()
+
+	result := make(map[string]string)
+	scanner := bufio.NewScanner(file)
+	lineNum := 0
+
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+
+		// Skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// Parse KEY=VALUE
+		idx := strings.Index(line, "=")
+		if idx == -1 {
+			return nil, fmt.Errorf("line %d: invalid format, expected KEY=VALUE", lineNum)
+		}
+
+		key := strings.TrimSpace(line[:idx])
+		value := line[idx+1:]
+
+		// Remove surrounding quotes if present
+		if len(value) >= 2 {
+			if (value[0] == '"' && value[len(value)-1] == '"') ||
+				(value[0] == '\'' && value[len(value)-1] == '\'') {
+				value = value[1 : len(value)-1]
+			}
+		}
+
+		if key == "" {
+			return nil, fmt.Errorf("line %d: empty key", lineNum)
+		}
+
+		result[key] = value
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read env file: %w", err)
+	}
+
+	return result, nil
+}

--- a/pkg/cmd/variable/variable_test.go
+++ b/pkg/cmd/variable/variable_test.go
@@ -1,0 +1,312 @@
+package variable
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateVariableKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		key         string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:    "valid simple key",
+			key:     "MY_VAR",
+			wantErr: false,
+		},
+		{
+			name:    "valid lowercase key",
+			key:     "my_var",
+			wantErr: false,
+		},
+		{
+			name:    "valid mixed case key",
+			key:     "MyVar",
+			wantErr: false,
+		},
+		{
+			name:    "valid key with numbers",
+			key:     "VAR123",
+			wantErr: false,
+		},
+		{
+			name:    "valid single letter",
+			key:     "A",
+			wantErr: false,
+		},
+		{
+			name:    "valid key starting with underscore after letter",
+			key:     "A_B_C",
+			wantErr: false,
+		},
+		{
+			name:        "empty key",
+			key:         "",
+			wantErr:     true,
+			errContains: "cannot be empty",
+		},
+		{
+			name:        "key starting with number",
+			key:         "123VAR",
+			wantErr:     true,
+			errContains: "must start with a letter",
+		},
+		{
+			name:        "key starting with underscore",
+			key:         "_MY_VAR",
+			wantErr:     true,
+			errContains: "must start with a letter",
+		},
+		{
+			name:        "key with hyphen",
+			key:         "MY-VAR",
+			wantErr:     true,
+			errContains: "invalid character",
+		},
+		{
+			name:        "key with space",
+			key:         "MY VAR",
+			wantErr:     true,
+			errContains: "invalid character",
+		},
+		{
+			name:        "key with special character",
+			key:         "MY$VAR",
+			wantErr:     true,
+			errContains: "invalid character",
+		},
+		{
+			name:        "key with dot",
+			key:         "MY.VAR",
+			wantErr:     true,
+			errContains: "invalid character",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateVariableKey(tt.key)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.errContains)
+					return
+				}
+				if tt.errContains != "" {
+					if !containsString(err.Error(), tt.errContains) {
+						t.Errorf("expected error containing %q, got %q", tt.errContains, err.Error())
+					}
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestParseEnvFile(t *testing.T) {
+	// Note: Test data uses obviously fake variable names and values.
+	// These are NOT real credentials - they are test fixtures for env file parsing.
+	tests := []struct {
+		name        string
+		content     string
+		want        map[string]string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:    "simple key value pairs",
+			content: "FOO=bar\nBAZ=qux",
+			want: map[string]string{
+				"FOO": "bar",
+				"BAZ": "qux",
+			},
+		},
+		{
+			name:    "with comments",
+			content: "# This is a comment\nFOO=bar\n# Another comment\nBAZ=qux",
+			want: map[string]string{
+				"FOO": "bar",
+				"BAZ": "qux",
+			},
+		},
+		{
+			name:    "with empty lines",
+			content: "FOO=bar\n\n\nBAZ=qux\n",
+			want: map[string]string{
+				"FOO": "bar",
+				"BAZ": "qux",
+			},
+		},
+		{
+			name:    "with double quotes",
+			content: "FOO=\"hello world\"",
+			want: map[string]string{
+				"FOO": "hello world",
+			},
+		},
+		{
+			name:    "with single quotes",
+			content: "FOO='hello world'",
+			want: map[string]string{
+				"FOO": "hello world",
+			},
+		},
+		{
+			name:    "empty value",
+			content: "FOO=",
+			want: map[string]string{
+				"FOO": "",
+			},
+		},
+		{
+			name:    "value with equals sign",
+			content: "FOO=a=b=c",
+			want: map[string]string{
+				"FOO": "a=b=c",
+			},
+		},
+		{
+			name:    "whitespace around key",
+			content: "  FOO  =bar",
+			want: map[string]string{
+				"FOO": "bar",
+			},
+		},
+		{
+			name:    "leading/trailing whitespace in line",
+			content: "  FOO=bar  \n  BAZ=qux  ",
+			want: map[string]string{
+				"FOO": "bar",
+				"BAZ": "qux",
+			},
+		},
+		{
+			name:        "missing equals sign",
+			content:     "FOO bar",
+			wantErr:     true,
+			errContains: "invalid format",
+		},
+		{
+			name:        "empty key",
+			content:     "=bar",
+			wantErr:     true,
+			errContains: "empty key",
+		},
+		{
+			name:    "empty file",
+			content: "",
+			want:    map[string]string{},
+		},
+		{
+			name:    "only comments and empty lines",
+			content: "# comment 1\n\n# comment 2\n",
+			want:    map[string]string{},
+		},
+		{
+			name:    "value with hash not a comment",
+			content: "FOO=bar#baz#qux",
+			want: map[string]string{
+				"FOO": "bar#baz#qux",
+			},
+		},
+		{
+			name:    "quoted value with mixed chars",
+			content: "FOO=\"hello 'world' and more\"",
+			want: map[string]string{
+				"FOO": "hello 'world' and more",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a temp file with the content
+			tmpDir := t.TempDir()
+			tmpFile := filepath.Join(tmpDir, "test.env")
+			err := os.WriteFile(tmpFile, []byte(tt.content), 0644)
+			if err != nil {
+				t.Fatalf("failed to write temp file: %v", err)
+			}
+
+			got, err := parseEnvFile(tmpFile)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.errContains)
+					return
+				}
+				if tt.errContains != "" {
+					if !containsString(err.Error(), tt.errContains) {
+						t.Errorf("expected error containing %q, got %q", tt.errContains, err.Error())
+					}
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(got) != len(tt.want) {
+				t.Errorf("got %d entries, want %d", len(got), len(tt.want))
+			}
+
+			for k, v := range tt.want {
+				if got[k] != v {
+					t.Errorf("key %q: got %q, want %q", k, got[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestParseEnvFileNotFound(t *testing.T) {
+	_, err := parseEnvFile("/nonexistent/path/to/file.env")
+	if err == nil {
+		t.Error("expected error for nonexistent file, got nil")
+	}
+	if !containsString(err.Error(), "failed to open") {
+		t.Errorf("expected error about opening file, got %q", err.Error())
+	}
+}
+
+func TestScopeConstants(t *testing.T) {
+	// Verify scope constants have expected values
+	tests := []struct {
+		name     string
+		constant string
+		expected string
+	}{
+		{"repository", scopeRepository, "repository"},
+		{"workspace", scopeWorkspace, "workspace"},
+		{"deployment", scopeDeployment, "deployment"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.constant != tt.expected {
+				t.Errorf("scope constant %s = %q, want %q", tt.name, tt.constant, tt.expected)
+			}
+		})
+	}
+}
+
+// containsString is a helper to check if a string contains a substring
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		(len(s) > 0 && len(substr) > 0 && findSubstring(s, substr)))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/prompter/prompter.go
+++ b/pkg/prompter/prompter.go
@@ -4,14 +4,17 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/avivsinai/bitbucket-cli/pkg/iostreams"
+	"golang.org/x/term"
 )
 
 // Interface exposes interactive prompt helpers used by commands.
 type Interface interface {
 	Input(prompt, defaultValue string) (string, error)
+	Password(prompt string) (string, error)
 	Confirm(prompt string, defaultYes bool) (bool, error)
 }
 
@@ -58,6 +61,31 @@ func (p *system) Input(prompt, defaultValue string) (string, error) {
 		return defaultValue, nil
 	}
 	return line, nil
+}
+
+func (p *system) Password(prompt string) (string, error) {
+	if p.ios == nil || !p.ios.CanPrompt() {
+		return "", errors.New("interactive prompts require a TTY")
+	}
+
+	if _, err := fmt.Fprint(p.ios.Out, prompt+": "); err != nil {
+		return "", err
+	}
+
+	// Get the file descriptor for stdin to disable echo
+	stdin, ok := p.ios.In.(*os.File)
+	if !ok {
+		return "", errors.New("password input requires a terminal")
+	}
+
+	password, err := term.ReadPassword(int(stdin.Fd()))
+	// Print newline since ReadPassword doesn't echo the Enter key
+	_, _ = fmt.Fprintln(p.ios.Out)
+	if err != nil {
+		return "", err
+	}
+
+	return string(password), nil
 }
 
 func (p *system) Confirm(prompt string, defaultYes bool) (bool, error) {


### PR DESCRIPTION
## Summary
- Add 'bkt variable' commands to manage Bitbucket Cloud pipeline variables
- Support three scopes: repository (default), workspace, and deployment
- Subcommands: 'list', 'get', 'set', 'delete' (alias: 'rm')
- Support '--env-file' for batch import from env files

## New Files
- 'pkg/bbcloud/variables.go' - API client methods
- 'pkg/bbcloud/variables_test.go' - API client tests
- 'pkg/cmd/variable/variable.go' - Command implementation
- 'pkg/cmd/variable/variable_test.go' - Command tests

## Test plan
- [x] 'go test ./pkg/bbcloud/...' passes
- [x] 'go test ./pkg/cmd/variable/...' passes
- [x] 'make build' succeeds