### PR TITLE
fix: address PR #31 review comments

### DIFF
--- a/.claude/skills/bkt/SKILL.md
+++ b/.claude/skills/bkt/SKILL.md
@@ -191,7 +191,7 @@ For endpoints not yet wrapped:
 
 ```bash
 bkt api /rest/api/1.0/projects --param limit=100 --json
-bkt api /2.0/repositories --param workspace=myteam --field pagelen=50
+bkt api /repositories --param workspace=myteam --field pagelen=50
 ```
 
 ## Output Modes

--- a/.claude/skills/bkt/references/commands.md
+++ b/.claude/skills/bkt/references/commands.md
@@ -420,14 +420,14 @@ bkt api /rest/api/1.0/projects --param limit=100
 bkt api /rest/api/1.0/projects/ABC/repos --json
 
 # Cloud
-bkt api /2.0/repositories --param workspace=myteam
-bkt api /2.0/repositories/myteam/api --field pagelen=50
+bkt api /repositories --param workspace=myteam
+bkt api /repositories/myteam/api --field pagelen=50
 
 # POST/PUT/DELETE with fields
 bkt api /rest/api/1.0/projects/ABC/repos -X POST --field name=demo --field scmId=git
 
 # POST with raw JSON body
-bkt api /2.0/repositories/myteam/api/issues -X POST --input '{"title": "Bug report"}'
+bkt api /repositories/myteam/api/issues -X POST --input '{"title": "Bug report"}'
 ```
 
 Options:

--- a/.codex/skills/bkt/SKILL.md
+++ b/.codex/skills/bkt/SKILL.md
@@ -191,7 +191,7 @@ For endpoints not yet wrapped:
 
 ```bash
 bkt api /rest/api/1.0/projects --param limit=100 --json
-bkt api /2.0/repositories --param workspace=myteam --field pagelen=50
+bkt api /repositories --param workspace=myteam --field pagelen=50
 ```
 
 ## Output Modes

--- a/.codex/skills/bkt/references/commands.md
+++ b/.codex/skills/bkt/references/commands.md
@@ -420,14 +420,14 @@ bkt api /rest/api/1.0/projects --param limit=100
 bkt api /rest/api/1.0/projects/ABC/repos --json
 
 # Cloud
-bkt api /2.0/repositories --param workspace=myteam
-bkt api /2.0/repositories/myteam/api --field pagelen=50
+bkt api /repositories --param workspace=myteam
+bkt api /repositories/myteam/api --field pagelen=50
 
 # POST/PUT/DELETE with fields
 bkt api /rest/api/1.0/projects/ABC/repos -X POST --field name=demo --field scmId=git
 
 # POST with raw JSON body
-bkt api /2.0/repositories/myteam/api/issues -X POST --input '{"title": "Bug report"}'
+bkt api /repositories/myteam/api/issues -X POST --input '{"title": "Bug report"}'
 ```
 
 Options:

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ For endpoints that are not yet wrapped, reach directly for the API escape hatch:
 
 ```bash
 bkt api /rest/api/1.0/projects --param limit=100 --json
-bkt api /2.0/repositories --param workspace=myteam --field pagelen=50
+bkt api /repositories --param workspace=myteam --field pagelen=50
 ```
 
 ## Security

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -29,7 +29,7 @@ func NewCmdAPI(f *cmdutil.Factory) *cobra.Command {
 
 Examples:
   bkt api /rest/api/1.0/projects
-  bkt api /2.0/repositories --workspace my-team --param pagelen=50
+  bkt api /repositories --workspace my-team --param pagelen=50
   bkt api /rest/api/1.0/projects/ABC/repos --method POST --field name=demo --field scmId=git`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -22,6 +22,15 @@ import (
 	"github.com/avivsinai/bitbucket-cli/pkg/iostreams"
 )
 
+// CloudTokenURL is the URL where users create Bitbucket Cloud API tokens.
+const CloudTokenURL = "https://id.atlassian.com/manage-profile/security/api-tokens"
+
+// CloudEmailPrompt is the prompt shown when asking for the Atlassian account email.
+const CloudEmailPrompt = "Atlassian account email"
+
+// CloudTokenPrompt is the prompt shown when asking for the API token.
+const CloudTokenPrompt = "API token"
+
 // NewCmdAuth returns the root auth command.
 func NewCmdAuth(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
@@ -188,7 +197,7 @@ func runLogin(cmd *cobra.Command, f *cmdutil.Factory, opts *loginOptions) error 
 		}
 	case "cloud":
 		if opts.Web && isTerminal(ios.In) {
-			tokenURL := "https://id.atlassian.com/manage-profile/security/api-tokens"
+			tokenURL := CloudTokenURL
 			if _, err := fmt.Fprintln(ios.Out, "Opening Atlassian to create a Bitbucket API token..."); err != nil {
 				return err
 			}
@@ -224,11 +233,7 @@ func runLogin(cmd *cobra.Command, f *cmdutil.Factory, opts *loginOptions) error 
 			if !isTerminal(ios.In) {
 				return fmt.Errorf("username is required when not running in a TTY")
 			}
-			prompt := "Atlassian account email"
-			if opts.Web {
-				prompt = "Atlassian account email"
-			}
-			opts.Username, err = promptString(reader, ios.Out, prompt)
+			opts.Username, err = promptString(reader, ios.Out, CloudEmailPrompt)
 			if err != nil {
 				return err
 			}
@@ -238,11 +243,7 @@ func runLogin(cmd *cobra.Command, f *cmdutil.Factory, opts *loginOptions) error 
 			if !isTerminal(ios.In) {
 				return fmt.Errorf("token is required when not running in a TTY")
 			}
-			prompt := "API token"
-			if opts.Web {
-				prompt = "API token"
-			}
-			opts.Token, err = promptSecret(ios, prompt)
+			opts.Token, err = promptSecret(ios, CloudTokenPrompt)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/auth/auth_test.go
+++ b/pkg/cmd/auth/auth_test.go
@@ -10,13 +10,13 @@ import (
 )
 
 func TestCloudTokenURLIsAtlassian(t *testing.T) {
-	// The token URL for cloud should point to Atlassian's account management
-	expectedURL := "https://id.atlassian.com/manage-profile/security/api-tokens"
-
-	// Verify the URL constant/value used in runLogin for cloud kind
-	// This test ensures we don't regress to the old bitbucket.org URL
-	if !strings.Contains(expectedURL, "id.atlassian.com") {
-		t.Fatal("Cloud token URL should use id.atlassian.com")
+	// Verify the actual CloudTokenURL constant points to Atlassian's account management.
+	// This test ensures we don't regress to the old bitbucket.org URL.
+	if !strings.Contains(CloudTokenURL, "id.atlassian.com") {
+		t.Fatalf("CloudTokenURL should use id.atlassian.com, got: %s", CloudTokenURL)
+	}
+	if !strings.Contains(CloudTokenURL, "api-tokens") {
+		t.Fatalf("CloudTokenURL should point to api-tokens page, got: %s", CloudTokenURL)
 	}
 }
 
@@ -53,11 +53,20 @@ func TestLoginFlagHelpTextNoAppPassword(t *testing.T) {
 }
 
 func TestCloudLoginPromptsNoAppPassword(t *testing.T) {
-	// Test that the email prompt for cloud login doesn't mention app password
-	// This would require capturing output during runLogin with opts.Web = false
-	// and verifying the prompt text
-	//
-	// The implementation removes "app password" from prompt text when
-	// opts.Web is false, so this verifies the change was made correctly.
-	// Full integration testing would require mocking terminal input.
+	// Verify that the cloud login prompt constants don't mention "app password".
+	// This ensures users aren't confused by old terminology since Bitbucket Cloud
+	// uses API tokens, not app passwords.
+	prompts := []struct {
+		name  string
+		value string
+	}{
+		{"CloudEmailPrompt", CloudEmailPrompt},
+		{"CloudTokenPrompt", CloudTokenPrompt},
+	}
+
+	for _, p := range prompts {
+		if strings.Contains(strings.ToLower(p.value), "app password") {
+			t.Errorf("%s should not mention 'app password', got: %s", p.name, p.value)
+		}
+	}
 }

--- a/pkg/httpx/client_test.go
+++ b/pkg/httpx/client_test.go
@@ -203,6 +203,24 @@ func TestClientBackoffRespectsContextCancellation(t *testing.T) {
 	}
 }
 
+func TestClientNewRequestNoDoubledBasePath(t *testing.T) {
+	client, err := New(Options{BaseURL: "https://api.bitbucket.org/2.0"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Pass path that already includes /2.0 - should NOT become /2.0/2.0/repositories
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "/2.0/repositories", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	expected := "https://api.bitbucket.org/2.0/repositories"
+	if got := req.URL.String(); got != expected {
+		t.Fatalf("doubled base path: got %s, want %s", got, expected)
+	}
+}
+
 func TestDecodeErrorPrioritizesCaptchaException(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/skills/bkt/SKILL.md
+++ b/skills/bkt/SKILL.md
@@ -191,7 +191,7 @@ For endpoints not yet wrapped:
 
 ```bash
 bkt api /rest/api/1.0/projects --param limit=100 --json
-bkt api /2.0/repositories --param workspace=myteam --field pagelen=50
+bkt api /repositories --param workspace=myteam --field pagelen=50
 ```
 
 ## Output Modes

--- a/skills/bkt/references/commands.md
+++ b/skills/bkt/references/commands.md
@@ -420,14 +420,14 @@ bkt api /rest/api/1.0/projects --param limit=100
 bkt api /rest/api/1.0/projects/ABC/repos --json
 
 # Cloud
-bkt api /2.0/repositories --param workspace=myteam
-bkt api /2.0/repositories/myteam/api --field pagelen=50
+bkt api /repositories --param workspace=myteam
+bkt api /repositories/myteam/api --field pagelen=50
 
 # POST/PUT/DELETE with fields
 bkt api /rest/api/1.0/projects/ABC/repos -X POST --field name=demo --field scmId=git
 
 # POST with raw JSON body
-bkt api /2.0/repositories/myteam/api/issues -X POST --input '{"title": "Bug report"}'
+bkt api /repositories/myteam/api/issues -X POST --input '{"title": "Bug report"}'
 ```
 
 Options:


### PR DESCRIPTION
**Summary**

This PR addresses the follow-up review comments from PR #31 (Atlassian API tokens fix).

- Add backward compatibility guard to prevent doubled base paths when callers pass paths that already include /2.0
- Fix self-referential test to verify actual constant
- Implement previously stubbed test for prompt text validation
- Update documentation examples to use relative paths

Changes

URL Path Backward Compatibility (pkg/httpx/client.go)

Added guard to detect when the request path already includes the base path component. This prevents doubled paths like
/2.0/2.0/repositories when a caller passes /2.0/repositories with base URL https://api.bitbucket.org/2.0.

Test Coverage (pkg/httpx/client_test.go, pkg/cmd/auth/auth_test.go)

- Added TestClientNewRequestNoDoubledBasePath to verify the guard works correctly
- Fixed TestCloudTokenURLIsAtlassian to verify the actual CloudTokenURL constant instead of a self-defined string
- Implemented TestCloudLoginPromptsNoAppPassword to verify prompt constants don't mention "app password"

Documentation (8 files)

Updated Cloud API examples to use relative paths (/repositories) instead of absolute paths (/2.0/repositories), which
is the recommended usage pattern now that the base URL includes the version.

Test plan

- All existing tests pass (go test ./...)
- New test cases pass for doubled path prevention
- Manually verified URL construction with BKT_HTTP_DEBUG=1