### PR TITLE
docs: clarify Bitbucket Cloud context creation with api.bitbucket.org…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented here. The format follows
 
 ## [Unreleased]
 
+### Changed
+- Clarified Bitbucket Cloud context creation in README, showing that `--host api.bitbucket.org` is required and adding a tip to use `bkt auth status` to discover the correct host value.
+
 ## [0.4.1] - 2026-01-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -170,10 +170,21 @@ without a native keychain.
 
 ### 2. Create and activate a context
 
+#### Bitbucket Data Center
+
 ```bash
 bkt context create dc-prod --host bitbucket.mycorp.example --project ABC --set-active
 bkt context list
 ```
+
+#### Bitbucket Cloud
+
+```bash
+bkt context create cloud-prod --host api.bitbucket.org --workspace myteam --set-active
+bkt context list
+```
+
+> **Tip:** Run `bkt auth status` to see configured hosts and the exact host value to use with `--host`.
 
 Contexts capture the host mapping, default project/workspace, and optional default repository for commands.
 


### PR DESCRIPTION
  ## Summary

  When authenticating with Bitbucket Cloud via `bkt auth login https://bitbucket.org --kind cloud`, credentials are stored under `api.bitbucket.org`. However, the existing documentation only showed a Data Center
  example for context creation, which led users to try `--host bitbucket.org` for Cloud contexts and fail to match their credentials.

  This adds a dedicated Cloud example showing the correct `--host api.bitbucket.org` and a tip directing users to `bkt auth status` to discover the exact host value.

  ## Testing

  - [x] `make fmt`
  - [x] `make test`
  - [x] `make build`
  - [x] Other (please specify): Documentation-only change

  ## Screenshots / recordings

  N/A - documentation change only

  ## Checklist

  - [x] Adds or updates documentation
  - [x] Updates `CHANGELOG.md`
  - [x] Signed commits (`git commit -s`)

  ## Notes for reviewers

  This is a documentation clarification based on user feedback. The `api.bitbucket.org` host requirement is a consequence of how `auth.go` normalizes Cloud URLs (lines 251-259), which converts `bitbucket.org` to
  `api.bitbucket.org/2.0` before storing credentials.