### PR TITLE
feat(pipeline): add sorting, build number, and timestamp to list

### DIFF
--- a/pkg/bbcloud/client.go
+++ b/pkg/bbcloud/client.go
@@ -97,8 +97,9 @@ type Repository struct {
 
 // Pipeline represents a pipeline execution.
 type Pipeline struct {
-	UUID  string `json:"uuid"`
-	State struct {
+	UUID        string `json:"uuid"`
+	BuildNumber int    `json:"build_number"`
+	State       struct {
 		Result struct {
 			Name string `json:"name"`
 		} `json:"result"`
@@ -134,7 +135,7 @@ func (c *Client) ListPipelines(ctx context.Context, workspace, repoSlug string, 
 		pageLen = 20
 	}
 
-	path := fmt.Sprintf("/repositories/%s/%s/pipelines/?pagelen=%d",
+	path := fmt.Sprintf("/repositories/%s/%s/pipelines/?pagelen=%d&sort=-created_on",
 		url.PathEscape(workspace),
 		url.PathEscape(repoSlug),
 		pageLen,

--- a/pkg/bbcloud/client_test.go
+++ b/pkg/bbcloud/client_test.go
@@ -23,6 +23,9 @@ func TestListPipelinesPaginates(t *testing.T) {
 			if r.URL.Query().Get("pagelen") == "" {
 				t.Fatalf("expected pagelen query in first request")
 			}
+			if r.URL.Query().Get("sort") != "-created_on" {
+				t.Fatalf("expected sort=-created_on query in first request")
+			}
 			payload := PipelinePage{
 				Values: []Pipeline{{UUID: "1"}, {UUID: "2"}},
 				Next:   serverURL + "/repositories/work/repo/pipelines/?pagelen=20&page=2",
@@ -68,6 +71,9 @@ func TestListPipelinesRespectsLimit(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 
 		if count == 1 {
+			if r.URL.Query().Get("sort") != "-created_on" {
+				t.Fatalf("expected sort=-created_on query in first request")
+			}
 			payload := PipelinePage{
 				Values: []Pipeline{{UUID: "1"}, {UUID: "2"}},
 				Next:   serverURL + "/repositories/work/repo/pipelines/?pagelen=20&page=2",

--- a/pkg/cmd/pipeline/pipeline.go
+++ b/pkg/cmd/pipeline/pipeline.go
@@ -207,7 +207,14 @@ func runPipelineList(cmd *cobra.Command, f *cmdutil.Factory, opts *listOptions) 
 			return err
 		}
 		for _, p := range pipelines {
-			if _, err := fmt.Fprintf(ios.Out, "%s\t%-12s\t%s\t%s\n", p.UUID, p.State.Name, p.Target.Ref.Name, p.State.Result.Name); err != nil {
+			created := ""
+			if p.CreatedOn != "" {
+				if t, err := time.Parse(time.RFC3339Nano, p.CreatedOn); err == nil {
+					created = t.Local().Format("2006-01-02 15:04")
+				}
+			}
+			if _, err := fmt.Fprintf(ios.Out, "#%-4d %s\t%-12s\t%-10s\t%s\t%s\n",
+				p.BuildNumber, p.UUID, p.State.Name, p.State.Result.Name, p.Target.Ref.Name, created); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
## Summary

- Sort pipelines by `created_on` descending (newest first)
- Add `build_number` field to Pipeline struct  
- Display build number (`#N`) and timestamp in list output

Closes #36

## Before
```
{f9da75d6-daf2-44d8-8ba9-1f3cec21553a}    COMPLETED           SUCCESSFUL
```

## After
```
#10  {f9da75d6-daf2-44d8-8ba9-1f3cec21553a}  COMPLETED  SUCCESSFUL  main  2024-01-15 14:32
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Added test assertions for `sort=-created_on` parameter

Thanks to @chatch for the feedback in the Atlassian Community!

🤖 Generated with [Claude Code](https://claude.ai/code)