### PR TITLE
chore: add .golangci.yaml, fix dependabot assignee, fix gocritic lint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,10 @@ updates:
     schedule:
       interval: "weekly"
     assignees:
-      - example
+      - avivsinai
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     assignees:
-      - example
+      - avivsinai

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,22 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  enable:
+    - govet
+    - staticcheck
+    - ineffassign
+    - unused
+    - errcheck
+    - gocritic
+  settings:
+    errcheck:
+      exclude-functions:
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln
+        - fmt.Print
+        - fmt.Printf
+        - fmt.Println

--- a/pkg/cmd/factory/factory.go
+++ b/pkg/cmd/factory/factory.go
@@ -25,9 +25,7 @@ func New(appVersion string) (*cmdutil.Factory, error) {
 	f.Prompter = prompter.New(ios)
 	f.Spinner = progress.NewSpinner(ios)
 
-	f.Config = func() (*config.Config, error) {
-		return config.Load()
-	}
+	f.Config = config.Load
 
 	return f, nil
 }

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -554,8 +554,7 @@ func firstPRLinkDC(pr *bbdc.PullRequest, kind string) string {
 	if pr == nil {
 		return ""
 	}
-	switch kind {
-	case "self":
+	if kind == "self" {
 		for _, link := range pr.Links.Self {
 			if strings.TrimSpace(link.Href) != "" {
 				return link.Href

--- a/pkg/cmd/pr/pr_test.go
+++ b/pkg/cmd/pr/pr_test.go
@@ -659,7 +659,7 @@ func TestRunChecksDataCenter(t *testing.T) {
 				t.Error("expected PR endpoint to be called")
 			}
 
-			if tt.prResponse.FromRef.LatestCommit != "" && len(tt.statusResponse) >= 0 && !statusCalled {
+			if tt.prResponse.FromRef.LatestCommit != "" && !statusCalled {
 				t.Error("expected status endpoint to be called")
 			}
 
@@ -819,7 +819,7 @@ func TestRunChecksCloud(t *testing.T) {
 				t.Error("expected PR endpoint to be called")
 			}
 
-			if tt.prResponse.Source.Commit.Hash != "" && len(tt.statusResponse) >= 0 && !statusCalled {
+			if tt.prResponse.Source.Commit.Hash != "" && !statusCalled {
 				t.Error("expected status endpoint to be called")
 			}
 

--- a/pkg/cmd/repo/repo.go
+++ b/pkg/cmd/repo/repo.go
@@ -807,8 +807,7 @@ the context does not define defaults.`,
 }
 
 func firstLinkDC(repo bbdc.Repository, kind string) string {
-	switch kind {
-	case "web":
+	if kind == "web" {
 		if len(repo.Links.Web) > 0 {
 			return repo.Links.Web[0].Href
 		}

--- a/pkg/cmd/variable/variable.go
+++ b/pkg/cmd/variable/variable.go
@@ -1129,13 +1129,14 @@ func runSetFromEnvFile(cmd *cobra.Command, f *cmdutil.Factory, opts *setOptions)
 			}
 		}
 
-		if created > 0 && updated > 0 {
+		switch {
+		case created > 0 && updated > 0:
 			_, err := fmt.Fprintf(ios.Out, "Created %d and updated %d variables in %s.\n", created, updated, location)
 			return err
-		} else if created > 0 {
+		case created > 0:
 			_, err := fmt.Fprintf(ios.Out, "Created %d variable(s) in %s.\n", created, location)
 			return err
-		} else {
+		default:
 			_, err := fmt.Fprintf(ios.Out, "Updated %d variable(s) in %s.\n", updated, location)
 			return err
 		}

--- a/pkg/cmd/variable/variable_test.go
+++ b/pkg/cmd/variable/variable_test.go
@@ -100,10 +100,8 @@ func TestValidateVariableKey(t *testing.T) {
 						t.Errorf("expected error containing %q, got %q", tt.errContains, err.Error())
 					}
 				}
-			} else {
-				if err != nil {
-					t.Errorf("unexpected error: %v", err)
-				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
 			}
 		})
 	}

--- a/pkg/httpx/client.go
+++ b/pkg/httpx/client.go
@@ -419,7 +419,7 @@ func (c *Client) backoff(ctx context.Context, attempts int, resp *http.Response)
 
 	delay := c.retry.InitialBackoff
 	if attempts > 1 {
-		delay = delay * time.Duration(1<<(attempts-1))
+		delay *= time.Duration(1 << (attempts - 1))
 	}
 	if delay > c.retry.MaxBackoff {
 		delay = c.retry.MaxBackoff


### PR DESCRIPTION
## Summary
- Add explicit `.golangci.yaml` (v2 format) enabling govet, staticcheck, ineffassign, unused, errcheck, and gocritic with 5m timeout
- Fix dependabot assignee from `example` to `avivsinai` in `.github/dependabot.yml`
- Fix 8 gocritic findings: `unlambda`, `singleCaseSwitch` (x2), `sloppyLen` (x2), `ifElseChain`, `elseif`, `assignOp`

## Test plan
- [x] `golangci-lint run ./...` passes with zero issues
- [x] `go test ./...` passes (all tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)