### PR TITLE
feat(pr): add decline/reopen commands

### DIFF
--- a/pkg/bbcloud/pullrequests.go
+++ b/pkg/bbcloud/pullrequests.go
@@ -138,6 +138,48 @@ func (c *Client) GetPullRequest(ctx context.Context, workspace, repoSlug string,
 	return &pr, nil
 }
 
+// DeclinePullRequest declines (rejects) a pull request.
+func (c *Client) DeclinePullRequest(ctx context.Context, workspace, repoSlug string, id int) error {
+	if workspace == "" || repoSlug == "" {
+		return fmt.Errorf("workspace and repository slug are required")
+	}
+
+	path := fmt.Sprintf("/repositories/%s/%s/pullrequests/%d/decline",
+		url.PathEscape(workspace),
+		url.PathEscape(repoSlug),
+		id,
+	)
+	req, err := c.http.NewRequest(ctx, "POST", path, nil)
+	if err != nil {
+		return err
+	}
+
+	return c.http.Do(req, nil)
+}
+
+// ReopenPullRequest reopens a previously declined pull request by updating its state to OPEN.
+func (c *Client) ReopenPullRequest(ctx context.Context, workspace, repoSlug string, id int) error {
+	if workspace == "" || repoSlug == "" {
+		return fmt.Errorf("workspace and repository slug are required")
+	}
+
+	body := map[string]any{
+		"state": "OPEN",
+	}
+
+	path := fmt.Sprintf("/repositories/%s/%s/pullrequests/%d",
+		url.PathEscape(workspace),
+		url.PathEscape(repoSlug),
+		id,
+	)
+	req, err := c.http.NewRequest(ctx, "PUT", path, body)
+	if err != nil {
+		return err
+	}
+
+	return c.http.Do(req, nil)
+}
+
 // CreatePullRequestInput configures PR creation.
 type CreatePullRequestInput struct {
 	Title       string

--- a/pkg/bbcloud/pullrequests_test.go
+++ b/pkg/bbcloud/pullrequests_test.go
@@ -1,0 +1,307 @@
+package bbcloud_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/avivsinai/bitbucket-cli/pkg/bbcloud"
+)
+
+func newTestClient(t *testing.T, handler http.Handler) *bbcloud.Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	client, err := bbcloud.New(bbcloud.Options{
+		BaseURL:  server.URL,
+		Username: "user",
+		Token:    "token",
+	})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+	return client
+}
+
+func TestGetPullRequest(t *testing.T) {
+	var gotMethod, gotPath string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":    7,
+			"title": "Test PR",
+			"state": "OPEN",
+		})
+	}))
+
+	pr, err := client.GetPullRequest(context.Background(), "myworkspace", "my-repo", 7)
+	if err != nil {
+		t.Fatalf("GetPullRequest: %v", err)
+	}
+	if gotMethod != "GET" {
+		t.Errorf("method = %s, want GET", gotMethod)
+	}
+	if gotPath != "/repositories/myworkspace/my-repo/pullrequests/7" {
+		t.Errorf("path = %q, want /repositories/myworkspace/my-repo/pullrequests/7", gotPath)
+	}
+	if pr.ID != 7 {
+		t.Errorf("pr.ID = %d, want 7", pr.ID)
+	}
+}
+
+func TestGetPullRequestValidation(t *testing.T) {
+	client, err := bbcloud.New(bbcloud.Options{
+		BaseURL: "http://localhost", Username: "u", Token: "t",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name      string
+		workspace string
+		repo      string
+	}{
+		{"empty workspace", "", "repo"},
+		{"empty repo", "ws", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := client.GetPullRequest(context.Background(), tt.workspace, tt.repo, 1)
+			if err == nil {
+				t.Error("expected error")
+			}
+		})
+	}
+}
+
+func TestListPullRequestsPaginates(t *testing.T) {
+	var hits int32
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		switch count {
+		case 1:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values": []map[string]any{{"id": 1}, {"id": 2}},
+				"next":   serverURL + "/repositories/ws/repo/pullrequests?pagelen=20&page=2",
+			})
+		case 2:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values": []map[string]any{{"id": 3}},
+			})
+		default:
+			t.Fatalf("unexpected request %d", count)
+		}
+	}))
+	serverURL = server.URL
+	t.Cleanup(server.Close)
+
+	client, err := bbcloud.New(bbcloud.Options{BaseURL: server.URL, Username: "u", Token: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prs, err := client.ListPullRequests(context.Background(), "ws", "repo", bbcloud.PullRequestListOptions{
+		State: "OPEN",
+		Limit: 0,
+	})
+	if err != nil {
+		t.Fatalf("ListPullRequests: %v", err)
+	}
+	if len(prs) != 3 {
+		t.Fatalf("expected 3 PRs, got %d", len(prs))
+	}
+	if hits != 2 {
+		t.Fatalf("expected 2 requests, got %d", hits)
+	}
+}
+
+func TestListPullRequestsRespectsLimit(t *testing.T) {
+	var hits int32
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"values": []map[string]any{{"id": 1}, {"id": 2}, {"id": 3}},
+			"next":   serverURL + "/repositories/ws/repo/pullrequests?page=2",
+		})
+	}))
+	serverURL = server.URL
+	t.Cleanup(server.Close)
+
+	client, err := bbcloud.New(bbcloud.Options{BaseURL: server.URL, Username: "u", Token: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prs, err := client.ListPullRequests(context.Background(), "ws", "repo", bbcloud.PullRequestListOptions{
+		Limit: 2,
+	})
+	if err != nil {
+		t.Fatalf("ListPullRequests: %v", err)
+	}
+	if len(prs) != 2 {
+		t.Errorf("expected 2 PRs, got %d", len(prs))
+	}
+}
+
+func TestListRepositoriesPaginates(t *testing.T) {
+	var hits int32
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		switch count {
+		case 1:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values": []map[string]any{{"slug": "repo1"}},
+				"next":   serverURL + "/repositories/ws?pagelen=20&page=2",
+			})
+		case 2:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values": []map[string]any{{"slug": "repo2"}},
+			})
+		default:
+			t.Fatalf("unexpected request %d", count)
+		}
+	}))
+	serverURL = server.URL
+	t.Cleanup(server.Close)
+
+	client, err := bbcloud.New(bbcloud.Options{BaseURL: server.URL, Username: "u", Token: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repos, err := client.ListRepositories(context.Background(), "ws", 0)
+	if err != nil {
+		t.Fatalf("ListRepositories: %v", err)
+	}
+	if len(repos) != 2 {
+		t.Fatalf("expected 2 repos, got %d", len(repos))
+	}
+	if hits != 2 {
+		t.Fatalf("expected 2 requests, got %d", hits)
+	}
+}
+
+func TestListRepositoriesRespectsLimit(t *testing.T) {
+	var hits int32
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"values": []map[string]any{{"slug": "r1"}, {"slug": "r2"}, {"slug": "r3"}},
+			"next":   serverURL + "/repositories/ws?page=2",
+		})
+	}))
+	serverURL = server.URL
+	t.Cleanup(server.Close)
+
+	client, err := bbcloud.New(bbcloud.Options{BaseURL: server.URL, Username: "u", Token: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repos, err := client.ListRepositories(context.Background(), "ws", 2)
+	if err != nil {
+		t.Fatalf("ListRepositories: %v", err)
+	}
+	if len(repos) != 2 {
+		t.Errorf("expected 2 repos, got %d", len(repos))
+	}
+}
+
+func TestDeclinePullRequest(t *testing.T) {
+	var gotMethod, gotPath string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	if err := client.DeclinePullRequest(context.Background(), "myworkspace", "my-repo", 7); err != nil {
+		t.Fatalf("DeclinePullRequest: %v", err)
+	}
+	if gotMethod != "POST" {
+		t.Errorf("method = %s, want POST", gotMethod)
+	}
+	if gotPath != "/repositories/myworkspace/my-repo/pullrequests/7/decline" {
+		t.Errorf("path = %s, want .../7/decline", gotPath)
+	}
+}
+
+func TestDeclinePullRequestValidation(t *testing.T) {
+	client, err := bbcloud.New(bbcloud.Options{
+		BaseURL: "http://localhost", Username: "u", Token: "t",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name      string
+		workspace string
+		repo      string
+	}{
+		{"empty workspace", "", "repo"},
+		{"empty repo", "ws", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := client.DeclinePullRequest(context.Background(), tt.workspace, tt.repo, 1); err == nil {
+				t.Error("expected error")
+			}
+		})
+	}
+}
+
+func TestReopenPullRequest(t *testing.T) {
+	var gotMethod, gotPath string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	if err := client.ReopenPullRequest(context.Background(), "myworkspace", "my-repo", 7); err != nil {
+		t.Fatalf("ReopenPullRequest: %v", err)
+	}
+	if gotMethod != "PUT" {
+		t.Errorf("method = %s, want PUT", gotMethod)
+	}
+	if gotPath != "/repositories/myworkspace/my-repo/pullrequests/7" {
+		t.Errorf("path = %s, want .../pullrequests/7", gotPath)
+	}
+}
+
+func TestReopenPullRequestValidation(t *testing.T) {
+	client, err := bbcloud.New(bbcloud.Options{
+		BaseURL: "http://localhost", Username: "u", Token: "t",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name      string
+		workspace string
+		repo      string
+	}{
+		{"empty workspace", "", "repo"},
+		{"empty repo", "ws", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := client.ReopenPullRequest(context.Background(), tt.workspace, tt.repo, 1); err == nil {
+				t.Error("expected error")
+			}
+		})
+	}
+}

--- a/pkg/bbdc/pullrequests.go
+++ b/pkg/bbdc/pullrequests.go
@@ -236,6 +236,50 @@ func (c *Client) UpdatePullRequest(ctx context.Context, projectKey, repoSlug str
 	return &pr, nil
 }
 
+// DeclinePullRequest declines (rejects) a pull request.
+func (c *Client) DeclinePullRequest(ctx context.Context, projectKey, repoSlug string, prID int, version int) error {
+	if projectKey == "" || repoSlug == "" {
+		return fmt.Errorf("project key and repository slug are required")
+	}
+
+	body := map[string]any{
+		"version": version,
+	}
+
+	req, err := c.http.NewRequest(ctx, "POST", fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/decline",
+		url.PathEscape(projectKey),
+		url.PathEscape(repoSlug),
+		prID,
+	), body)
+	if err != nil {
+		return err
+	}
+
+	return c.http.Do(req, nil)
+}
+
+// ReopenPullRequest reopens a previously declined pull request.
+func (c *Client) ReopenPullRequest(ctx context.Context, projectKey, repoSlug string, prID int, version int) error {
+	if projectKey == "" || repoSlug == "" {
+		return fmt.Errorf("project key and repository slug are required")
+	}
+
+	body := map[string]any{
+		"version": version,
+	}
+
+	req, err := c.http.NewRequest(ctx, "POST", fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/reopen",
+		url.PathEscape(projectKey),
+		url.PathEscape(repoSlug),
+		prID,
+	), body)
+	if err != nil {
+		return err
+	}
+
+	return c.http.Do(req, nil)
+}
+
 // PullRequestDiff streams the diff for the given pull request into w.
 func (c *Client) PullRequestDiff(ctx context.Context, projectKey, repoSlug string, id int, w io.Writer) error {
 	if projectKey == "" || repoSlug == "" {

--- a/pkg/bbdc/pullrequests_test.go
+++ b/pkg/bbdc/pullrequests_test.go
@@ -1,0 +1,341 @@
+package bbdc_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/avivsinai/bitbucket-cli/pkg/bbdc"
+)
+
+func newTestClient(t *testing.T, handler http.Handler) *bbdc.Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	client, err := bbdc.New(bbdc.Options{
+		BaseURL:  server.URL,
+		Username: "user",
+		Token:    "token",
+	})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+	return client
+}
+
+func TestGetPullRequestPathEscaping(t *testing.T) {
+	var gotPath string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":    1,
+			"title": "Test PR",
+			"state": "OPEN",
+		})
+	}))
+
+	_, err := client.GetPullRequest(context.Background(), "MY-PROJ", "my-repo", 99)
+	if err != nil {
+		t.Fatalf("GetPullRequest: %v", err)
+	}
+	want := "/rest/api/1.0/projects/MY-PROJ/repos/my-repo/pull-requests/99"
+	if gotPath != want {
+		t.Errorf("path = %q, want %q", gotPath, want)
+	}
+}
+
+func TestGetPullRequestValidation(t *testing.T) {
+	client, err := bbdc.New(bbdc.Options{
+		BaseURL: "http://localhost", Username: "u", Token: "t",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name    string
+		project string
+		repo    string
+	}{
+		{"empty project", "", "repo"},
+		{"empty repo", "PROJ", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := client.GetPullRequest(context.Background(), tt.project, tt.repo, 1)
+			if err == nil {
+				t.Error("expected error")
+			}
+		})
+	}
+}
+
+func TestListPullRequestsPaginates(t *testing.T) {
+	var hits int32
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		switch count {
+		case 1:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values":        []map[string]any{{"id": 1, "title": "PR 1"}, {"id": 2, "title": "PR 2"}},
+				"isLastPage":    false,
+				"nextPageStart": 2,
+			})
+		case 2:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values":     []map[string]any{{"id": 3, "title": "PR 3"}},
+				"isLastPage": true,
+			})
+		default:
+			t.Fatalf("unexpected request %d", count)
+		}
+	}))
+
+	prs, err := client.ListPullRequests(context.Background(), "PROJ", "repo", "OPEN", 0)
+	if err != nil {
+		t.Fatalf("ListPullRequests: %v", err)
+	}
+	if len(prs) != 3 {
+		t.Fatalf("expected 3 PRs, got %d", len(prs))
+	}
+	if hits != 2 {
+		t.Fatalf("expected 2 requests, got %d", hits)
+	}
+}
+
+func TestListPullRequestsRespectsLimit(t *testing.T) {
+	var hits int32
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"values":        []map[string]any{{"id": 1}, {"id": 2}, {"id": 3}},
+			"isLastPage":    false,
+			"nextPageStart": 3,
+		})
+	}))
+
+	prs, err := client.ListPullRequests(context.Background(), "PROJ", "repo", "OPEN", 2)
+	if err != nil {
+		t.Fatalf("ListPullRequests: %v", err)
+	}
+	if len(prs) != 2 {
+		t.Errorf("expected 2 PRs, got %d", len(prs))
+	}
+}
+
+func TestListPullRequestsPassesStateParam(t *testing.T) {
+	var gotQuery string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"values":     []map[string]any{},
+			"isLastPage": true,
+		})
+	}))
+
+	_, err := client.ListPullRequests(context.Background(), "PROJ", "repo", "DECLINED", 10)
+	if err != nil {
+		t.Fatalf("ListPullRequests: %v", err)
+	}
+	if gotQuery == "" || !containsParam(gotQuery, "state=DECLINED") {
+		t.Errorf("expected state=DECLINED in query, got %q", gotQuery)
+	}
+}
+
+func TestListPullRequestsValidation(t *testing.T) {
+	client, err := bbdc.New(bbdc.Options{
+		BaseURL: "http://localhost", Username: "u", Token: "t",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name    string
+		project string
+		repo    string
+	}{
+		{"empty project", "", "repo"},
+		{"empty repo", "PROJ", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := client.ListPullRequests(context.Background(), tt.project, tt.repo, "OPEN", 10)
+			if err == nil {
+				t.Error("expected error")
+			}
+		})
+	}
+}
+
+func TestListRepositoriesPaginates(t *testing.T) {
+	var hits int32
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		switch count {
+		case 1:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values":        []map[string]any{{"slug": "repo1"}},
+				"isLastPage":    false,
+				"nextPageStart": 1,
+			})
+		case 2:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values":     []map[string]any{{"slug": "repo2"}},
+				"isLastPage": true,
+			})
+		default:
+			t.Fatalf("unexpected request %d", count)
+		}
+	}))
+
+	repos, err := client.ListRepositories(context.Background(), "PROJ", 0)
+	if err != nil {
+		t.Fatalf("ListRepositories: %v", err)
+	}
+	if len(repos) != 2 {
+		t.Fatalf("expected 2 repos, got %d", len(repos))
+	}
+	if hits != 2 {
+		t.Fatalf("expected 2 requests, got %d", hits)
+	}
+}
+
+func TestListRepositoriesRespectsLimit(t *testing.T) {
+	var hits int32
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"values":        []map[string]any{{"slug": "repo1"}, {"slug": "repo2"}, {"slug": "repo3"}},
+			"isLastPage":    false,
+			"nextPageStart": 3,
+		})
+	}))
+
+	repos, err := client.ListRepositories(context.Background(), "PROJ", 2)
+	if err != nil {
+		t.Fatalf("ListRepositories: %v", err)
+	}
+	if len(repos) != 2 {
+		t.Errorf("expected 2 repos, got %d", len(repos))
+	}
+}
+
+func TestDeclinePullRequest(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody map[string]any
+
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	if err := client.DeclinePullRequest(context.Background(), "PROJ", "my-repo", 42, 3); err != nil {
+		t.Fatalf("DeclinePullRequest: %v", err)
+	}
+
+	if gotMethod != "POST" {
+		t.Errorf("method = %s, want POST", gotMethod)
+	}
+	if gotPath != "/rest/api/1.0/projects/PROJ/repos/my-repo/pull-requests/42/decline" {
+		t.Errorf("path = %s, want .../42/decline", gotPath)
+	}
+	if v, ok := gotBody["version"].(float64); !ok || int(v) != 3 {
+		t.Errorf("version = %v, want 3", gotBody["version"])
+	}
+}
+
+func TestDeclinePullRequestValidation(t *testing.T) {
+	client, err := bbdc.New(bbdc.Options{
+		BaseURL: "http://localhost", Username: "u", Token: "t",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		project string
+		repo    string
+	}{
+		{"empty project", "", "repo"},
+		{"empty repo", "PROJ", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := client.DeclinePullRequest(context.Background(), tt.project, tt.repo, 1, 0); err == nil {
+				t.Error("expected error")
+			}
+		})
+	}
+}
+
+func TestReopenPullRequest(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody map[string]any
+
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	if err := client.ReopenPullRequest(context.Background(), "PROJ", "my-repo", 42, 5); err != nil {
+		t.Fatalf("ReopenPullRequest: %v", err)
+	}
+
+	if gotMethod != "POST" {
+		t.Errorf("method = %s, want POST", gotMethod)
+	}
+	if gotPath != "/rest/api/1.0/projects/PROJ/repos/my-repo/pull-requests/42/reopen" {
+		t.Errorf("path = %s, want .../42/reopen", gotPath)
+	}
+	if v, ok := gotBody["version"].(float64); !ok || int(v) != 5 {
+		t.Errorf("version = %v, want 5", gotBody["version"])
+	}
+}
+
+func TestReopenPullRequestValidation(t *testing.T) {
+	client, err := bbdc.New(bbdc.Options{
+		BaseURL: "http://localhost", Username: "u", Token: "t",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		project string
+		repo    string
+	}{
+		{"empty project", "", "repo"},
+		{"empty repo", "PROJ", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := client.ReopenPullRequest(context.Background(), tt.project, tt.repo, 1, 0); err == nil {
+				t.Error("expected error")
+			}
+		})
+	}
+}
+
+func containsParam(query, param string) bool {
+	for _, p := range strings.Split(query, "&") {
+		if p == param {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -44,6 +44,8 @@ func NewCmdPR(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(newDiffCmd(f))
 	cmd.AddCommand(newApproveCmd(f))
 	cmd.AddCommand(newMergeCmd(f))
+	cmd.AddCommand(newDeclineCmd(f))
+	cmd.AddCommand(newReopenCmd(f))
 	cmd.AddCommand(newCommentCmd(f))
 	cmd.AddCommand(newReviewerGroupCmd(f))
 	cmd.AddCommand(newAutoMergeCmd(f))
@@ -1153,6 +1155,236 @@ func runMerge(cmd *cobra.Command, f *cmdutil.Factory, id int, opts *mergeOptions
 		return err
 	}
 	return nil
+}
+
+type declineOptions struct {
+	Project      string
+	Workspace    string
+	Repo         string
+	DeleteSource bool
+}
+
+func newDeclineCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &declineOptions{}
+	cmd := &cobra.Command{
+		Use:   "decline <id>",
+		Short: "Decline a pull request",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.Atoi(args[0])
+			if err != nil {
+				return fmt.Errorf("invalid pull request id %q", args[0])
+			}
+			return runDecline(cmd, f, id, opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Project, "project", "", "Bitbucket project key override")
+	cmd.Flags().StringVar(&opts.Workspace, "workspace", "", "Bitbucket workspace override (Cloud)")
+	cmd.Flags().StringVar(&opts.Repo, "repo", "", "Repository slug override")
+	cmd.Flags().BoolVar(&opts.DeleteSource, "delete-source", false, "Delete the source branch after declining")
+
+	return cmd
+}
+
+func runDecline(cmd *cobra.Command, f *cmdutil.Factory, id int, opts *declineOptions) error {
+	ios, err := f.Streams()
+	if err != nil {
+		return err
+	}
+
+	override := cmdutil.FlagValue(cmd, "context")
+	_, ctxCfg, host, err := cmdutil.ResolveContext(f, cmd, override)
+	if err != nil {
+		return err
+	}
+
+	switch host.Kind {
+	case "dc":
+		projectKey := cmdutil.FirstNonEmpty(opts.Project, ctxCfg.ProjectKey)
+		repoSlug := cmdutil.FirstNonEmpty(opts.Repo, ctxCfg.DefaultRepo)
+		if projectKey == "" || repoSlug == "" {
+			return fmt.Errorf("context must supply project and repo; use --project/--repo if needed")
+		}
+
+		client, err := cmdutil.NewDCClient(host)
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
+		defer cancel()
+
+		pr, err := client.GetPullRequest(ctx, projectKey, repoSlug, id)
+		if err != nil {
+			return err
+		}
+
+		if err := client.DeclinePullRequest(ctx, projectKey, repoSlug, id, pr.Version); err != nil {
+			return err
+		}
+
+		if _, err := fmt.Fprintf(ios.Out, "Declined pull request #%d\n", id); err != nil {
+			return err
+		}
+
+		if opts.DeleteSource {
+			sourceBranch := pr.FromRef.DisplayID
+			if sourceBranch == "" {
+				sourceBranch = pr.FromRef.ID
+			}
+			if sourceBranch != "" {
+				// Use the source ref's own repository for deletion — it may
+				// differ from the destination repo when the PR comes from a fork.
+				srcProject := projectKey
+				srcRepo := repoSlug
+				if pr.FromRef.Repository.Project != nil && pr.FromRef.Repository.Project.Key != "" {
+					srcProject = pr.FromRef.Repository.Project.Key
+				}
+				if pr.FromRef.Repository.Slug != "" {
+					srcRepo = pr.FromRef.Repository.Slug
+				}
+				if err := client.DeleteBranch(ctx, srcProject, srcRepo, sourceBranch, false); err != nil {
+					return fmt.Errorf("declined PR but failed to delete source branch %q: %w", sourceBranch, err)
+				}
+				if _, err := fmt.Fprintf(ios.Out, "Deleted source branch %s\n", sourceBranch); err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
+
+	case "cloud":
+		if opts.DeleteSource {
+			return fmt.Errorf("--delete-source is not supported for Bitbucket Cloud")
+		}
+
+		workspace := cmdutil.FirstNonEmpty(opts.Workspace, ctxCfg.Workspace)
+		repoSlug := cmdutil.FirstNonEmpty(opts.Repo, ctxCfg.DefaultRepo)
+		if workspace == "" || repoSlug == "" {
+			return fmt.Errorf("context must supply workspace and repo; use --workspace/--repo if needed")
+		}
+
+		client, err := cmdutil.NewCloudClient(host)
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
+		defer cancel()
+
+		if err := client.DeclinePullRequest(ctx, workspace, repoSlug, id); err != nil {
+			return err
+		}
+
+		if _, err := fmt.Fprintf(ios.Out, "Declined pull request #%d\n", id); err != nil {
+			return err
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("unsupported host kind %q", host.Kind)
+	}
+}
+
+type reopenOptions struct {
+	Project   string
+	Workspace string
+	Repo      string
+}
+
+func newReopenCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &reopenOptions{}
+	cmd := &cobra.Command{
+		Use:   "reopen <id>",
+		Short: "Reopen a declined pull request",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.Atoi(args[0])
+			if err != nil {
+				return fmt.Errorf("invalid pull request id %q", args[0])
+			}
+			return runReopen(cmd, f, id, opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Project, "project", "", "Bitbucket project key override")
+	cmd.Flags().StringVar(&opts.Workspace, "workspace", "", "Bitbucket workspace override (Cloud)")
+	cmd.Flags().StringVar(&opts.Repo, "repo", "", "Repository slug override")
+
+	return cmd
+}
+
+func runReopen(cmd *cobra.Command, f *cmdutil.Factory, id int, opts *reopenOptions) error {
+	ios, err := f.Streams()
+	if err != nil {
+		return err
+	}
+
+	override := cmdutil.FlagValue(cmd, "context")
+	_, ctxCfg, host, err := cmdutil.ResolveContext(f, cmd, override)
+	if err != nil {
+		return err
+	}
+
+	switch host.Kind {
+	case "dc":
+		projectKey := cmdutil.FirstNonEmpty(opts.Project, ctxCfg.ProjectKey)
+		repoSlug := cmdutil.FirstNonEmpty(opts.Repo, ctxCfg.DefaultRepo)
+		if projectKey == "" || repoSlug == "" {
+			return fmt.Errorf("context must supply project and repo; use --project/--repo if needed")
+		}
+
+		client, err := cmdutil.NewDCClient(host)
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
+		defer cancel()
+
+		pr, err := client.GetPullRequest(ctx, projectKey, repoSlug, id)
+		if err != nil {
+			return err
+		}
+
+		if err := client.ReopenPullRequest(ctx, projectKey, repoSlug, id, pr.Version); err != nil {
+			return err
+		}
+
+		if _, err := fmt.Fprintf(ios.Out, "Reopened pull request #%d\n", id); err != nil {
+			return err
+		}
+		return nil
+
+	case "cloud":
+		ws := cmdutil.FirstNonEmpty(opts.Workspace, ctxCfg.Workspace)
+		repoSlug := cmdutil.FirstNonEmpty(opts.Repo, ctxCfg.DefaultRepo)
+		if ws == "" || repoSlug == "" {
+			return fmt.Errorf("context must supply workspace and repo; use --workspace/--repo if needed")
+		}
+
+		client, err := cmdutil.NewCloudClient(host)
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
+		defer cancel()
+
+		if err := client.ReopenPullRequest(ctx, ws, repoSlug, id); err != nil {
+			return err
+		}
+
+		if _, err := fmt.Fprintf(ios.Out, "Reopened pull request #%d\n", id); err != nil {
+			return err
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("unsupported host kind %q", host.Kind)
+	}
 }
 
 type commentOptions struct {

--- a/pkg/cmd/pr/pr_decline_reopen_test.go
+++ b/pkg/cmd/pr/pr_decline_reopen_test.go
@@ -1,0 +1,368 @@
+package pr_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/bitbucket-cli/internal/config"
+	"github.com/avivsinai/bitbucket-cli/pkg/cmd/root"
+	"github.com/avivsinai/bitbucket-cli/pkg/cmdutil"
+	"github.com/avivsinai/bitbucket-cli/pkg/iostreams"
+)
+
+func TestPRDeclineDataCenter(t *testing.T) {
+	var declineCalled bool
+	var declineMethod, declinePath string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:token"))
+		if r.Header.Get("Authorization") != auth {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		switch {
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/pull-requests/42"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      42,
+				"title":   "Test PR",
+				"state":   "OPEN",
+				"version": 7,
+				"fromRef": map[string]any{
+					"id":        "refs/heads/feature",
+					"displayId": "feature",
+				},
+				"toRef": map[string]any{
+					"id":        "refs/heads/main",
+					"displayId": "main",
+				},
+			})
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/pull-requests/42/decline"):
+			declineCalled = true
+			declineMethod = r.Method
+			declinePath = r.URL.Path
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if v, ok := body["version"].(float64); !ok || int(v) != 7 {
+				t.Errorf("expected version=7, got %v", body["version"])
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	stdout, stderr, err := runCLI(t, dcConfig(srv.URL), "pr", "decline", "42")
+	if err != nil {
+		t.Fatalf("pr decline error: %v (stderr=%s)", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("unexpected stderr: %s", stderr)
+	}
+	if !declineCalled {
+		t.Fatal("decline endpoint was not called")
+	}
+	if declineMethod != "POST" {
+		t.Errorf("expected POST, got %s", declineMethod)
+	}
+	if !strings.Contains(declinePath, "/pull-requests/42/decline") {
+		t.Errorf("unexpected path: %s", declinePath)
+	}
+	if !strings.Contains(stdout, "Declined pull request #42") {
+		t.Errorf("unexpected output: %s", stdout)
+	}
+}
+
+func TestPRDeclineWithDeleteSource(t *testing.T) {
+	var deleteBranchCalled bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:token"))
+		if r.Header.Get("Authorization") != auth {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		switch {
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/pull-requests/10"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      10,
+				"title":   "Test PR",
+				"state":   "OPEN",
+				"version": 2,
+				"fromRef": map[string]any{
+					"id":        "refs/heads/feature-branch",
+					"displayId": "feature-branch",
+				},
+				"toRef": map[string]any{
+					"id":        "refs/heads/main",
+					"displayId": "main",
+				},
+			})
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/pull-requests/10/decline"):
+			w.WriteHeader(http.StatusOK)
+		case r.Method == "DELETE" && strings.HasSuffix(r.URL.Path, "/branches"):
+			deleteBranchCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	stdout, stderr, err := runCLI(t, dcConfig(srv.URL), "pr", "decline", "10", "--delete-source")
+	if err != nil {
+		t.Fatalf("pr decline --delete-source error: %v (stderr=%s)", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("unexpected stderr: %s", stderr)
+	}
+	if !deleteBranchCalled {
+		t.Fatal("delete branch endpoint was not called")
+	}
+	if !strings.Contains(stdout, "Declined pull request #10") {
+		t.Errorf("expected decline message in output: %s", stdout)
+	}
+	if !strings.Contains(stdout, "Deleted source branch feature-branch") {
+		t.Errorf("expected branch deletion message in output: %s", stdout)
+	}
+}
+
+func TestPRDeclineDeleteSourceUsesFromRefRepo(t *testing.T) {
+	// When the PR comes from a fork, --delete-source should target
+	// the fork's repository, not the destination repo.
+	var deletePath string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:token"))
+		if r.Header.Get("Authorization") != auth {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		switch {
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/pull-requests/5"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      5,
+				"title":   "Fork PR",
+				"state":   "OPEN",
+				"version": 1,
+				"fromRef": map[string]any{
+					"id":        "refs/heads/fork-branch",
+					"displayId": "fork-branch",
+					"repository": map[string]any{
+						"slug": "forked-repo",
+						"project": map[string]any{
+							"key": "FORK",
+						},
+					},
+				},
+				"toRef": map[string]any{
+					"id":        "refs/heads/main",
+					"displayId": "main",
+				},
+			})
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/pull-requests/5/decline"):
+			w.WriteHeader(http.StatusOK)
+		case r.Method == "DELETE" && strings.HasSuffix(r.URL.Path, "/branches"):
+			deletePath = r.URL.Path
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	_, stderr, err := runCLI(t, dcConfig(srv.URL), "pr", "decline", "5", "--delete-source")
+	if err != nil {
+		t.Fatalf("pr decline --delete-source (fork) error: %v (stderr=%s)", err, stderr)
+	}
+	// The delete branch call should target the fork's project/repo, not PROJ/my-repo.
+	if !strings.Contains(deletePath, "/projects/FORK/repos/forked-repo/") {
+		t.Errorf("expected delete to target fork repo FORK/forked-repo, got path: %s", deletePath)
+	}
+}
+
+func TestPRReopenDataCenter(t *testing.T) {
+	var reopenCalled bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:token"))
+		if r.Header.Get("Authorization") != auth {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		switch {
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/pull-requests/42"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      42,
+				"title":   "Test PR",
+				"state":   "DECLINED",
+				"version": 8,
+			})
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/pull-requests/42/reopen"):
+			reopenCalled = true
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if v, ok := body["version"].(float64); !ok || int(v) != 8 {
+				t.Errorf("expected version=8, got %v", body["version"])
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	stdout, stderr, err := runCLI(t, dcConfig(srv.URL), "pr", "reopen", "42")
+	if err != nil {
+		t.Fatalf("pr reopen error: %v (stderr=%s)", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("unexpected stderr: %s", stderr)
+	}
+	if !reopenCalled {
+		t.Fatal("reopen endpoint was not called")
+	}
+	if !strings.Contains(stdout, "Reopened pull request #42") {
+		t.Errorf("unexpected output: %s", stdout)
+	}
+}
+
+func TestPRDeclineRequiresArg(t *testing.T) {
+	_, _, err := runCLI(t, dcConfig("http://localhost"), "pr", "decline")
+	if err == nil {
+		t.Fatal("expected error when no PR ID provided")
+	}
+}
+
+func TestPRReopenRequiresArg(t *testing.T) {
+	_, _, err := runCLI(t, dcConfig("http://localhost"), "pr", "reopen")
+	if err == nil {
+		t.Fatal("expected error when no PR ID provided")
+	}
+}
+
+func TestPRDeclineInvalidID(t *testing.T) {
+	_, _, err := runCLI(t, dcConfig("http://localhost"), "pr", "decline", "abc")
+	if err == nil {
+		t.Fatal("expected error for invalid PR ID")
+	}
+	if !strings.Contains(err.Error(), "invalid pull request id") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestPRReopenInvalidID(t *testing.T) {
+	_, _, err := runCLI(t, dcConfig("http://localhost"), "pr", "reopen", "abc")
+	if err == nil {
+		t.Fatal("expected error for invalid PR ID")
+	}
+	if !strings.Contains(err.Error(), "invalid pull request id") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestPRDeclineDeleteSourceRejectsCloud(t *testing.T) {
+	cfg := cloudConfig("http://localhost")
+	_, _, err := runCLI(t, cfg, "pr", "decline", "1", "--delete-source")
+	if err == nil {
+		t.Fatal("expected error for --delete-source on Cloud")
+	}
+	if !strings.Contains(err.Error(), "--delete-source is not supported") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func cloudConfig(baseURL string) *config.Config {
+	return &config.Config{
+		ActiveContext: "test",
+		Contexts: map[string]*config.Context{
+			"test": {
+				Host:        "mock",
+				Workspace:   "myworkspace",
+				DefaultRepo: "my-repo",
+			},
+		},
+		Hosts: map[string]*config.Host{
+			"mock": {
+				Kind:     "cloud",
+				BaseURL:  baseURL,
+				Username: "admin",
+				Token:    "token",
+			},
+		},
+	}
+}
+
+func dcConfig(baseURL string) *config.Config {
+	return &config.Config{
+		ActiveContext: "test",
+		Contexts: map[string]*config.Context{
+			"test": {
+				Host:        "mock",
+				ProjectKey:  "PROJ",
+				DefaultRepo: "my-repo",
+			},
+		},
+		Hosts: map[string]*config.Host{
+			"mock": {
+				Kind:     "dc",
+				BaseURL:  baseURL,
+				Username: "admin",
+				Token:    "token",
+			},
+		},
+	}
+}
+
+func runCLI(t *testing.T, cfg *config.Config, args ...string) (string, string, error) {
+	t.Helper()
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	ios := &iostreams.IOStreams{
+		In:     io.NopCloser(bytes.NewReader(nil)),
+		Out:    stdout,
+		ErrOut: stderr,
+	}
+
+	factory := &cmdutil.Factory{
+		AppVersion:     "test",
+		ExecutableName: "bkt",
+		IOStreams:      ios,
+		Config: func() (*config.Config, error) {
+			return cfg, nil
+		},
+	}
+
+	rootCmd, err := root.NewCmdRoot(factory)
+	if err != nil {
+		t.Fatalf("NewCmdRoot: %v", err)
+	}
+	rootCmd.SetArgs(args)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(stderr)
+
+	t.Setenv("BKT_NO_UPDATE_CHECK", "1")
+	t.Setenv("NO_COLOR", "1")
+
+	// Suppress usage output on errors.
+	rootCmd.SilenceUsage = true
+
+	err = rootCmd.ExecuteContext(context.Background())
+	return stdout.String(), stderr.String(), err
+}


### PR DESCRIPTION
## Summary

- Add `bkt pr decline <id>` to decline (reject) a pull request
- Add `bkt pr reopen <id>` to reopen a previously declined PR
- Both commands support Bitbucket Data Center and Cloud
- `--delete-source` flag safely handles forked PRs by targeting the source ref's repository

Closes #51
Supersedes #52 (split from original PR for focused review)

## Bug fixes vs. #52

- **`--delete-source` now targets the correct repo for forked PRs** — the original used the destination repo context, which could delete the wrong branch or fail for cross-repo PRs
- **`--delete-source` on Cloud returns an explicit error** instead of being silently ignored
- `newReopenCmd` uses an options struct consistent with other commands

## Test plan

- [x] `go build ./...` passes
- [x] `golangci-lint run` — 0 issues
- [x] `go test ./...` — all packages pass
- [x] DC decline with version optimistic locking
- [x] DC decline with `--delete-source` (same-repo and forked-repo)
- [x] Cloud decline rejects `--delete-source` with clear error
- [x] DC reopen with version optimistic locking
- [x] Argument validation (missing ID, invalid ID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)