### PR TITLE
test: improve coverage across 7 packages

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -4,108 +4,204 @@ This document outlines testing priorities and patterns for expanding test covera
 
 ## Current State
 
-As of the last coverage review:
+As of the February 2026 coverage audit, overall statement coverage is **9.8%** across the codebase. The project has **10 test files** covering 10 of 32 packages.
 
-- **Excellent**: `pkg/httpx`, `pkg/prompter`, `internal/remote`, `pkg/cmdutil` have good test coverage
-- **Good**: Smoke tests cover critical CLI workflows
-- **Needs Work**: `pkg/bbdc` (0 test files), most `pkg/cmd/*` subdirectories (limited coverage)
+### Per-Package Coverage
 
-## Testing Priorities
+| Package | Coverage | Test File | Notes |
+|---|---|---|---|
+| `internal/build` | 77.3% | `info_test.go` | Covers ldflags injection |
+| `internal/remote` | 79.3% | `remote_test.go` | Covers Cloud/DC URL detection |
+| `pkg/httpx` | 59.3% | `client_test.go` | Caching, retries, URL building tested; `decodeError` (0%), `applyAdaptiveThrottle` (45%) missing |
+| `pkg/format` | 54.1% | `format_test.go` | JQ and large integer tests; YAML/template paths untested |
+| `pkg/cmd/api` | 44.2% | `api_test.go` | YAML, JSON, streaming tested; `--jq`, `--template`, HTTP methods untested |
+| `pkg/prompter` | 39.5% | `prompter_test.go` | Confirm retries tested; `Input()` untested |
+| `pkg/cmdutil` | 23.2% | `context_test.go` | `ResolveHost` tested; `ResolveContext`, output helpers, URL utils untested |
+| `pkg/bbcloud` | 34.1% | `client_test.go`, `pullrequests_test.go` | Pagination for pipelines, repos, PRs tested; decline/reopen tested; GetPullRequest tested |
+| `pkg/bbdc` | 14.0% | `pullrequests_test.go` | ListRepositories/ListPullRequests pagination, GetPullRequest path escaping, decline/reopen tested |
+| `pkg/cmd/pr` | 22.8% | `pr_test.go` | Decline, reopen, delete-source smoke tests; argument validation |
+| `pkg/cmd/repo` | 7.7% | `repo_test.go` | Clone URL selection tested; list/create/browse untested |
+| `pkg/cmd/smoke` | n/a | `cli_smoke_test.go` | End-to-end smoke tests for repo list, project list |
+| `internal/config` | **0%** | none | 255 lines, all CRUD operations untested |
+| `internal/secret` | **0%** | none | 270 lines, keyring backend selection untested |
+| `pkg/cmd/auth` | **0%** | none | 537 lines, credential flow untested |
+| `pkg/cmd/branch` | **0%** | none | 700 lines across 3 files |
+| `pkg/cmd/status` | **0%** | none | 462 lines across 3 files |
+| `pkg/cmd/factory` | **0%** | none | Factory wiring |
+| `pkg/iostreams` | **0%** | none | IO stream abstractions |
+| Others | **0%** | none | admin, context, extension, perms, pipeline, project, webhook, browser, pager, progress |
 
-### Priority 1: Core API Clients
+### What Existing Tests Cover Well
 
-Focus on `pkg/bbdc` (Bitbucket Data Center client) and expand `pkg/bbcloud`:
+- **HTTP client infrastructure** (`pkg/httpx`): ETag caching, retry with exponential backoff, context cancellation during backoff, URL query preservation, relative path handling.
+- **Git remote detection** (`internal/remote`): Cloud HTTPS/SSH URLs, DC `/scm/` and `/projects/` paths, missing remote error.
+- **Output formatting** (`pkg/format`): JQ on structs and slices, large integer preservation through json.Number.
+- **API command** (`pkg/cmd/api`): YAML output, invalid JSON rejection, plain text streaming, large integer passthrough.
+- **Host resolution** (`pkg/cmdutil`): By key, by URL, via context, single-host fallback, multi-host error.
+- **Smoke tests** (`pkg/cmd/smoke`): Full CLI execution for `repo list` (text + JSON) and `project list` with a mock Bitbucket server including auth verification.
 
-**Why**: These packages encapsulate all external API interactions. Tests here prevent regressions and document expected API contracts.
+### What Existing Tests Miss
 
-**Approach**: Use `httptest.NewServer` to mock Bitbucket responses (see `pkg/httpx/client_test.go` for examples).
+Even in tested packages, significant gaps remain:
 
-**Example targets**:
-- `pkg/bbdc/client.go` - test client initialization, base URL handling
-- `pkg/bbdc/pullrequests.go` - test PR listing, creation, merging
-- `pkg/bbdc/repos.go` - test repository operations
-- `pkg/bbcloud/client.go` - expand existing coverage
+- **`pkg/httpx`**: `decodeError()` at 0%, `applyAdaptiveThrottle()` at 45%, `Do()` at 50% — error response parsing, rate limit throttling, 429 handling, `Retry-After` header, request body serialization, and `io.Writer` passthrough are all untested.
+- **`pkg/format`**: YAML output path, Go template rendering, format validation, and fallback-to-caller logic are untested.
+- **`pkg/cmdutil`**: `ResolveContext()`, `ResolveOutputSettings()`, `WriteOutput()`, `NormalizeBaseURL()`, `HostKeyFromURL()`, token loading from keyring, and git remote default application are all untested.
+- **`pkg/bbcloud`**: Only `ListPipelines` pagination is tested. `ListRepositories`, `CreateRepository`, `TriggerPipeline`, `GetPipelineLogs`, `CurrentUser`, and the Cloud-specific URL parsing logic lack tests.
 
-**Example pattern**:
+## Recommended Testing Priorities
+
+### Priority 1 — Core API Clients (highest impact)
+
+These packages own all external API interactions. Bugs here silently corrupt data or break every command.
+
+#### `pkg/bbdc` (0% → target 60%+, ~322 lines)
+
+The entire Bitbucket Data Center client has zero tests. Key areas:
+
+| Function | Lines | Why It Matters |
+|---|---|---|
+| `ListRepositories` | ~30 | Pagination loop with limit arithmetic; off-by-one bugs silently truncate results |
+| `ListPullRequests` | ~35 | Pagination + optional state query parameter; same limit risk |
+| `GetPullRequest` | ~15 | URL path escaping for project/repo slugs with special characters |
+| `CommitStatuses` | ~15 | Different API path structure; used by `status commit` command |
+| `New` | ~20 | Client construction with retry policy; validates wiring |
+
+**Approach**: Use `httptest.NewServer` with request assertions (path, query params, auth header). The `pkg/cmd/smoke/cli_smoke_test.go` `bitbucketMock` pattern is a good reference but tests should be at the unit level here.
+
 ```go
-func TestListPullRequests(t *testing.T) {
+func TestListRepositoriesPaginates(t *testing.T) {
+    var hits int32
     server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        if r.URL.Path != "/rest/api/1.0/projects/PROJ/repos/repo/pull-requests" {
-            t.Errorf("unexpected path: %s", r.URL.Path)
-        }
+        count := atomic.AddInt32(&hits, 1)
         w.Header().Set("Content-Type", "application/json")
-        json.NewEncoder(w).Encode(map[string]interface{}{
-            "values": []map[string]interface{}{
-                {"id": 1, "title": "Test PR"},
-            },
-        })
+        switch count {
+        case 1:
+            json.NewEncoder(w).Encode(map[string]any{
+                "values":        []map[string]any{{"slug": "repo1"}},
+                "isLastPage":    false,
+                "nextPageStart": 1,
+            })
+        case 2:
+            json.NewEncoder(w).Encode(map[string]any{
+                "values":     []map[string]any{{"slug": "repo2"}},
+                "isLastPage": true,
+            })
+        }
     }))
-    defer server.Close()
-
-    client := bbdc.NewClient(bbdc.Options{BaseURL: server.URL})
-    prs, err := client.ListPullRequests(context.Background(), "PROJ", "repo")
-    if err != nil {
-        t.Fatalf("ListPullRequests: %v", err)
-    }
-    if len(prs) != 1 || prs[0].ID != 1 {
-        t.Errorf("unexpected PR list: %+v", prs)
-    }
+    t.Cleanup(server.Close)
+    // ... assert 2 repos returned, 2 requests made
 }
 ```
 
-### Priority 2: Command Logic
+#### `pkg/bbcloud` (10.2% → target 60%+, ~445 lines)
 
-Add tests for higher-traffic Cobra commands in `pkg/cmd/*`:
+Only `ListPipelines` pagination is tested. Missing coverage for:
 
-**Why**: These packages contain the user-facing logic. Tests ensure CLI behavior stays consistent.
+- `ListRepositories` — has its own pagination with Cloud's `next` URL pattern
+- `CreateRepository` — POST with JSON body serialization
+- `TriggerPipeline` — variable construction with `secured` flag
+- `GetPipelineLogs` — returns raw bytes, not JSON
+- UUID brace trimming in `GetPipeline`, `ListPipelineSteps`, `GetPipelineLogs`
+- URL parsing fallback logic (`RequestURI()` vs `String()`)
 
-**Approach**: Test helper functions and data transformations. For commands that need IO, consider using `io.Pipe` or `bytes.Buffer` for stdin/stdout.
+#### `pkg/httpx` (59.3% → target 80%+, ~542 lines)
 
-**Example targets**:
-- `pkg/cmd/pr/*.go` - PR formatting, filtering, status checks
-- `pkg/cmd/repo/*.go` - expand existing `repo_test.go`
-- `pkg/cmd/pipeline/*.go` - pipeline state parsing
+The existing tests are good but leave critical paths uncovered:
 
-**Example pattern** (table-driven tests):
+- **`decodeError()`** (0%): API error response parsing is completely untested. A bug here means every error message is wrong or panics.
+- **`applyAdaptiveThrottle()`** (45%): Rate limit sleep logic; untested paths could cause unnecessary delays or missed throttling.
+- **`Do()` response handling** (50%): The `io.Writer` passthrough path (used for streaming raw output), request body serialization with `GetBody`, and 429 `Retry-After` header handling are untested.
+- **`NewRequest()` body encoding** (53%): JSON body marshaling with `GetBody` for retries is not exercised.
+
+### Priority 2 — Configuration and Secrets (data integrity)
+
+#### `internal/config` (0% → target 70%+, ~255 lines)
+
+This package manages all persistent CLI state. It has no tests despite containing:
+
+- `Load()` / `Save()` — YAML round-trip with atomic file writes; a serialization bug loses all user config
+- `MarshalYAML()` — token stripping; if broken, credentials leak to disk
+- `SetContext` / `Context` / `DeleteContext` / `SetActiveContext` — CRUD with thread safety
+- `SetHost` / `Host` / `DeleteHost` — same pattern
+- `resolvePath()` — `BKT_CONFIG_DIR` environment override
+
+**Approach**: Use `t.TempDir()` with `t.Setenv("BKT_CONFIG_DIR", ...)` for filesystem isolation. Test YAML round-trips, nil map initialization, and the token-stripping marshal.
+
 ```go
-func TestFormatPRStatus(t *testing.T) {
-    tests := []struct {
-        name   string
-        pr     bbdc.PullRequest
-        want   string
-    }{
-        {
-            name: "open PR",
-            pr:   bbdc.PullRequest{State: "OPEN"},
-            want: "OPEN",
-        },
-        {
-            name: "merged PR",
-            pr:   bbdc.PullRequest{State: "MERGED"},
-            want: "MERGED",
-        },
+func TestMarshalYAMLStripsToken(t *testing.T) {
+    h := &config.Host{Kind: "dc", BaseURL: "https://example.com", Token: "secret"}
+    data, err := yaml.Marshal(h)
+    if err != nil {
+        t.Fatal(err)
     }
-
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            got := formatStatus(tt.pr)
-            if got != tt.want {
-                t.Errorf("got %q, want %q", got, tt.want)
-            }
-        })
+    if strings.Contains(string(data), "secret") {
+        t.Fatal("token was not stripped during marshaling")
     }
 }
 ```
 
-### Priority 3: Edge Cases and Error Paths
+#### `internal/secret` (0% → target 50%+, ~270 lines)
 
-Expand coverage for error handling:
+The keyring backend selection logic is complex and platform-dependent:
 
-**Example targets**:
-- API retry logic failures
-- Malformed JSON responses
-- Network timeouts
-- Missing configuration scenarios
+- `resolveAllowedBackends()` — reads `BKT_KEYRING_BACKENDS` env var, has platform-specific defaults
+- `parseBackendList()` — string-to-enum mapping for backend names
+- `IsNoKeyringError()` — error classification
+- `Set` / `Get` / `Delete` — nil pointer guards
+
+**Approach**: Unit-test `parseBackendList()` and `IsNoKeyringError()` directly. For `Open()`, use the file backend with `WithFileDir(t.TempDir())` to avoid needing a real keyring.
+
+### Priority 3 — Command Packages (user-facing behavior)
+
+#### `pkg/cmd/pr` (0%, ~1,966 lines — largest untested package)
+
+This is the most complex command package. Recommended test targets:
+
+- **`pr.go` runList/runView**: Test the dual-provider branching (DC vs Cloud), author filtering, and output formatting using the smoke test pattern with `runCLI()`.
+- **`tasks.go` toggleTaskState**: Test the complete/reopen state toggle logic.
+- **`automerge.go`**: Test settings struct construction and status rendering.
+- **`reactions.go`**: Test argument parsing for the triple (PR ID, comment ID, emoji).
+
+#### `pkg/cmd/auth` (0%, ~537 lines)
+
+Auth is security-critical. Key testable areas:
+
+- **`storeHostToken()` / `deleteHostToken()`**: Token lifecycle with mocked secret store.
+- **`runStatus()`**: Output formatting for host/context display.
+- **URL normalization**: The `bitbucket.org` detection logic and Cloud API URL construction.
+- **Non-interactive mode**: Test flag-based auth without TTY.
+
+#### `pkg/cmd/branch` (0%, ~700 lines)
+
+- **`protect.go` `mapProtectType()`**: Pure function mapping protection type strings — table-driven test.
+- **`protect.go` `ensureBranchRef()`**: Ref prefix handling with wildcards.
+- **`branch.go` runList**: Dual-provider branch listing with commit hash truncation.
+
+#### `pkg/cmd/status` (0%, ~462 lines)
+
+- **`renderStatuses()`**: Pure rendering function; test output format.
+- **`resolveCloudStatusContext()`**: Cloud-specific context resolution.
+
+### Priority 4 — Utility Packages
+
+#### `pkg/cmdutil/url.go` (0%, ~42 lines)
+
+Small but used everywhere:
+
+- `NormalizeBaseURL()` — scheme addition, trailing slash removal, query/fragment stripping
+- `HostKeyFromURL()` — hostname extraction
+
+Table-driven tests would cover this in a single test function.
+
+#### `pkg/cmdutil/output.go` (0%, ~81 lines)
+
+- `ResolveOutputSettings()` — flag mutual exclusion validation (json vs yaml, jq vs template, jq requires json)
+- `WriteOutput()` — structured output dispatch
+
+#### `pkg/format` (54.1% → target 80%+)
+
+Missing: YAML rendering, Go template rendering, invalid format rejection, fallback function invocation.
 
 ## Testing Patterns
 
@@ -114,7 +210,7 @@ Expand coverage for error handling:
 Preferred for functions with multiple input/output cases:
 
 ```go
-func TestParseURL(t *testing.T) {
+func TestNormalizeBaseURL(t *testing.T) {
     tests := []struct {
         name    string
         input   string
@@ -122,18 +218,21 @@ func TestParseURL(t *testing.T) {
         wantErr bool
     }{
         {"valid https", "https://example.com", "https://example.com", false},
-        {"missing scheme", "example.com", "", true},
+        {"trailing slash", "https://example.com/", "https://example.com", false},
+        {"missing scheme", "example.com", "https://example.com", false},
+        {"with path", "https://example.com/bitbucket", "https://example.com/bitbucket", false},
+        {"empty string", "", "", true},
     }
 
     for _, tt := range tests {
         t.Run(tt.name, func(t *testing.T) {
-            got, err := parseURL(tt.input)
+            got, err := NormalizeBaseURL(tt.input)
             if (err != nil) != tt.wantErr {
-                t.Errorf("parseURL() error = %v, wantErr %v", err, tt.wantErr)
+                t.Errorf("NormalizeBaseURL() error = %v, wantErr %v", err, tt.wantErr)
                 return
             }
             if got != tt.want {
-                t.Errorf("parseURL() = %v, want %v", got, tt.want)
+                t.Errorf("NormalizeBaseURL() = %v, want %v", got, tt.want)
             }
         })
     }
@@ -157,7 +256,23 @@ server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *htt
 defer server.Close()
 ```
 
-### 3. Golden Files (Future)
+### 3. Smoke Tests with Full CLI Execution
+
+The `pkg/cmd/smoke` pattern is ideal for end-to-end command tests:
+
+```go
+func TestPRListDataCenter(t *testing.T) {
+    mock := newBitbucketMock(t, "user", "token")
+    defer mock.Close()
+    mock.StubPRList("PROJ", "repo", prListResponse{...})
+
+    cfg := configForMock(mock.URL(), "user", "token", "test", "PROJ", "")
+    stdout, stderr, err := runCLI(t, cfg, "pr", "list", "--limit", "10")
+    // ... assertions
+}
+```
+
+### 4. Golden Files (Future)
 
 For complex CLI output, consider golden file testing:
 
@@ -187,6 +302,9 @@ go test ./pkg/bbdc/...
 go test -coverprofile=coverage.out ./...
 go tool cover -html=coverage.out
 
+# Per-function coverage report
+go tool cover -func=coverage.out
+
 # Run specific test
 go test -run TestListPullRequests ./pkg/bbdc/
 ```
@@ -206,15 +324,21 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contribution workflow.
 ## Test Coverage Goals
 
 **Short-term** (next few PRs):
-- Add at least 3-5 test files to `pkg/bbdc/`
-- Expand coverage in `pkg/cmd/pr/`, `pkg/cmd/pipeline/`
+- Add `pkg/bbdc/client_test.go` covering `ListRepositories`, `ListPullRequests`, `GetPullRequest` pagination
+- Add `internal/config/config_test.go` covering Load/Save round-trips and `MarshalYAML` token stripping
+- Add `pkg/cmdutil/url_test.go` covering `NormalizeBaseURL` and `HostKeyFromURL`
+- Expand `pkg/httpx/client_test.go` with `decodeError`, 429 handling, and body serialization tests
+- Target: raise overall coverage from 9.8% to ~20%
 
 **Medium-term** (next release):
 - 60%+ coverage in `pkg/bbdc` and `pkg/bbcloud`
-- 40%+ coverage in `pkg/cmd/*` packages
+- 40%+ coverage in `pkg/cmd/pr`, `pkg/cmd/auth`, `pkg/cmd/branch`
+- Add smoke tests for `pr list`, `pr view`, `auth status`, `branch list`
 - Add golden file tests for complex formatting
+- Target: raise overall coverage to ~40%
 
 **Long-term**:
+- 60%+ overall coverage
 - Integration tests against real Bitbucket test instances (optional)
-- Benchmarks for performance-critical paths
-- Fuzzing for input parsing functions
+- Benchmarks for performance-critical paths (HTTP retry, pagination)
+- Fuzzing for input parsing functions (`parseLocator`, `NormalizeBaseURL`, `parseBackendList`)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,335 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestMarshalYAMLStripsToken(t *testing.T) {
+	h := &Host{Kind: "dc", BaseURL: "https://example.com", Token: "secret-token", Username: "admin"}
+	data, err := yaml.Marshal(h)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(data), "secret-token") {
+		t.Fatalf("token was not stripped during marshaling: %s", data)
+	}
+	if !strings.Contains(string(data), "admin") {
+		t.Fatalf("expected username to be preserved: %s", data)
+	}
+}
+
+func TestMarshalYAMLNilHost(t *testing.T) {
+	var h *Host
+	got, err := h.MarshalYAML()
+	if err != nil {
+		t.Fatalf("MarshalYAML: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}
+
+func TestLoadReturnsDefaultsWhenFileDoesNotExist(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BKT_CONFIG_DIR", dir)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Version != currentVersion {
+		t.Fatalf("expected version %d, got %d", currentVersion, cfg.Version)
+	}
+	if cfg.Contexts == nil {
+		t.Fatalf("expected Contexts map to be initialized")
+	}
+	if cfg.Hosts == nil {
+		t.Fatalf("expected Hosts map to be initialized")
+	}
+}
+
+func TestSaveAndLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BKT_CONFIG_DIR", dir)
+
+	cfg := &Config{
+		ActiveContext: "dev",
+		Contexts: map[string]*Context{
+			"dev": {Host: "main", ProjectKey: "PROJ"},
+		},
+		Hosts: map[string]*Host{
+			"main": {Kind: "dc", BaseURL: "https://bitbucket.example.com", Username: "admin", Token: "secret"},
+		},
+		path: filepath.Join(dir, "config.yml"),
+	}
+
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Verify the file exists and has restrictive permissions.
+	info, err := os.Stat(cfg.path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("expected 0600 permissions, got %o", perm)
+	}
+
+	// Verify token is NOT written to disk.
+	data, err := os.ReadFile(cfg.path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if strings.Contains(string(data), "secret") {
+		t.Fatalf("token was written to disk: %s", data)
+	}
+
+	// Load back and verify structure.
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.ActiveContext != "dev" {
+		t.Fatalf("active context = %q, want %q", loaded.ActiveContext, "dev")
+	}
+	ctx, err := loaded.Context("dev")
+	if err != nil {
+		t.Fatalf("Context: %v", err)
+	}
+	if ctx.ProjectKey != "PROJ" {
+		t.Fatalf("project key = %q, want %q", ctx.ProjectKey, "PROJ")
+	}
+	h, err := loaded.Host("main")
+	if err != nil {
+		t.Fatalf("Host: %v", err)
+	}
+	if h.Kind != "dc" {
+		t.Fatalf("kind = %q, want %q", h.Kind, "dc")
+	}
+	// Token should be empty because MarshalYAML strips it.
+	if h.Token != "" {
+		t.Fatalf("token should be empty after round-trip, got %q", h.Token)
+	}
+}
+
+func TestSaveCreatesDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "dir")
+	cfg := &Config{
+		Hosts: map[string]*Host{},
+		path:  filepath.Join(dir, "config.yml"),
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if _, err := os.Stat(cfg.path); err != nil {
+		t.Fatalf("config file not created: %v", err)
+	}
+}
+
+func TestSaveSetsVersionWhenZero(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &Config{
+		Version: 0,
+		Hosts:   map[string]*Host{},
+		path:    filepath.Join(dir, "config.yml"),
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	data, err := os.ReadFile(cfg.path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(data), "version: 1") {
+		t.Fatalf("expected version to be set, got: %s", data)
+	}
+}
+
+func TestContextCRUD(t *testing.T) {
+	cfg := &Config{Contexts: make(map[string]*Context)}
+
+	// Set
+	cfg.SetContext("dev", &Context{Host: "main", ProjectKey: "PROJ"})
+	ctx, err := cfg.Context("dev")
+	if err != nil {
+		t.Fatalf("Context: %v", err)
+	}
+	if ctx.Host != "main" {
+		t.Fatalf("host = %q, want %q", ctx.Host, "main")
+	}
+
+	// Missing context
+	_, err = cfg.Context("missing")
+	if err != ErrContextNotFound {
+		t.Fatalf("expected ErrContextNotFound, got %v", err)
+	}
+
+	// Delete
+	cfg.ActiveContext = "dev"
+	cfg.DeleteContext("dev")
+	_, err = cfg.Context("dev")
+	if err != ErrContextNotFound {
+		t.Fatalf("expected ErrContextNotFound after delete, got %v", err)
+	}
+	if cfg.ActiveContext != "" {
+		t.Fatalf("active context should be cleared after deleting active, got %q", cfg.ActiveContext)
+	}
+}
+
+func TestSetContextNilMap(t *testing.T) {
+	cfg := &Config{}
+	cfg.SetContext("test", &Context{Host: "h"})
+	ctx, err := cfg.Context("test")
+	if err != nil {
+		t.Fatalf("Context: %v", err)
+	}
+	if ctx.Host != "h" {
+		t.Fatalf("host = %q, want %q", ctx.Host, "h")
+	}
+}
+
+func TestSetActiveContext(t *testing.T) {
+	cfg := &Config{
+		Contexts: map[string]*Context{
+			"dev": {Host: "main"},
+		},
+	}
+
+	if err := cfg.SetActiveContext("dev"); err != nil {
+		t.Fatalf("SetActiveContext: %v", err)
+	}
+	if cfg.ActiveContext != "dev" {
+		t.Fatalf("active = %q, want %q", cfg.ActiveContext, "dev")
+	}
+
+	// Non-existent context
+	if err := cfg.SetActiveContext("missing"); err != ErrContextNotFound {
+		t.Fatalf("expected ErrContextNotFound, got %v", err)
+	}
+
+	// Empty clears
+	if err := cfg.SetActiveContext(""); err != nil {
+		t.Fatalf("SetActiveContext empty: %v", err)
+	}
+	if cfg.ActiveContext != "" {
+		t.Fatalf("expected empty active context, got %q", cfg.ActiveContext)
+	}
+}
+
+func TestHostCRUD(t *testing.T) {
+	cfg := &Config{Hosts: make(map[string]*Host)}
+
+	cfg.SetHost("bb", &Host{Kind: "dc", BaseURL: "https://bb.example.com"})
+	h, err := cfg.Host("bb")
+	if err != nil {
+		t.Fatalf("Host: %v", err)
+	}
+	if h.BaseURL != "https://bb.example.com" {
+		t.Fatalf("base_url = %q", h.BaseURL)
+	}
+
+	// Missing host
+	_, err = cfg.Host("missing")
+	if err != ErrHostNotFound {
+		t.Fatalf("expected ErrHostNotFound, got %v", err)
+	}
+
+	// Delete
+	cfg.DeleteHost("bb")
+	_, err = cfg.Host("bb")
+	if err != ErrHostNotFound {
+		t.Fatalf("expected ErrHostNotFound after delete, got %v", err)
+	}
+}
+
+func TestSetHostNilMap(t *testing.T) {
+	cfg := &Config{}
+	cfg.SetHost("test", &Host{Kind: "cloud"})
+	h, err := cfg.Host("test")
+	if err != nil {
+		t.Fatalf("Host: %v", err)
+	}
+	if h.Kind != "cloud" {
+		t.Fatalf("kind = %q, want %q", h.Kind, "cloud")
+	}
+}
+
+func TestResolvePathUsesEnvVar(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BKT_CONFIG_DIR", dir)
+
+	path, err := resolvePath()
+	if err != nil {
+		t.Fatalf("resolvePath: %v", err)
+	}
+	if path != filepath.Join(dir, "config.yml") {
+		t.Fatalf("path = %q, want %q", path, filepath.Join(dir, "config.yml"))
+	}
+}
+
+func TestLoadInvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BKT_CONFIG_DIR", dir)
+
+	if err := os.WriteFile(filepath.Join(dir, "config.yml"), []byte("{{invalid yaml"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, err := Load()
+	if err == nil {
+		t.Fatalf("expected error for invalid YAML")
+	}
+	if !strings.Contains(err.Error(), "decode config") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadInitializesNilMaps(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BKT_CONFIG_DIR", dir)
+
+	// Write a minimal config with no contexts or hosts keys.
+	if err := os.WriteFile(filepath.Join(dir, "config.yml"), []byte("version: 1\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Contexts == nil {
+		t.Fatal("expected Contexts to be initialized")
+	}
+	if cfg.Hosts == nil {
+		t.Fatal("expected Hosts to be initialized")
+	}
+}
+
+func TestDeleteContextDoesNotClearUnrelatedActiveContext(t *testing.T) {
+	cfg := &Config{
+		ActiveContext: "prod",
+		Contexts: map[string]*Context{
+			"dev":  {Host: "main"},
+			"prod": {Host: "main"},
+		},
+	}
+
+	cfg.DeleteContext("dev")
+	if cfg.ActiveContext != "prod" {
+		t.Fatalf("active context should remain %q, got %q", "prod", cfg.ActiveContext)
+	}
+}
+
+func TestPath(t *testing.T) {
+	cfg := &Config{path: "/tmp/test/config.yml"}
+	if got := cfg.Path(); got != "/tmp/test/config.yml" {
+		t.Fatalf("Path() = %q, want %q", got, "/tmp/test/config.yml")
+	}
+}

--- a/pkg/bbcloud/client_test.go
+++ b/pkg/bbcloud/client_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+
+	"github.com/avivsinai/bitbucket-cli/pkg/httpx"
 )
 
 func TestListPipelinesPaginates(t *testing.T) {
@@ -338,5 +340,354 @@ func TestNormalizeUUID(t *testing.T) {
 				t.Errorf("normalizeUUID(%q) = %q, want %q", tt.input, got, tt.expected)
 			}
 		})
+	}
+}
+
+func newTestClient(t *testing.T, handler http.Handler) *Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{
+		BaseURL: server.URL,
+		Retry:   httpx.RetryPolicy{MaxAttempts: 1},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return client
+}
+
+func TestNewDefaultsBaseURL(t *testing.T) {
+	client, err := New(Options{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected client to be created")
+	}
+}
+
+func TestListRepositoriesPaginates(t *testing.T) {
+	var hits int32
+	var serverURL string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch count {
+		case 1:
+			_ = json.NewEncoder(w).Encode(repositoryListPage{
+				Values: []Repository{{Slug: "repo1"}, {Slug: "repo2"}},
+				Next:   serverURL + "/repositories/ws?pagelen=20&page=2",
+			})
+		case 2:
+			_ = json.NewEncoder(w).Encode(repositoryListPage{
+				Values: []Repository{{Slug: "repo3"}},
+			})
+		default:
+			t.Fatalf("unexpected request %d", count)
+		}
+	}))
+	serverURL = server.URL
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{BaseURL: server.URL})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	repos, err := client.ListRepositories(context.Background(), "ws", 0)
+	if err != nil {
+		t.Fatalf("ListRepositories: %v", err)
+	}
+	if len(repos) != 3 {
+		t.Fatalf("expected 3 repos, got %d", len(repos))
+	}
+	if hits != 2 {
+		t.Fatalf("expected 2 requests, got %d", hits)
+	}
+}
+
+func TestListRepositoriesRespectsLimit(t *testing.T) {
+	var hits int32
+	var serverURL string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(repositoryListPage{
+			Values: []Repository{{Slug: "repo1"}, {Slug: "repo2"}, {Slug: "repo3"}},
+			Next:   serverURL + "/repositories/ws?pagelen=20&page=2",
+		})
+	}))
+	serverURL = server.URL
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{BaseURL: server.URL})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	repos, err := client.ListRepositories(context.Background(), "ws", 2)
+	if err != nil {
+		t.Fatalf("ListRepositories: %v", err)
+	}
+	if len(repos) != 2 {
+		t.Fatalf("expected 2 repos, got %d", len(repos))
+	}
+	if hits != 1 {
+		t.Fatalf("expected 1 request, got %d", hits)
+	}
+}
+
+func TestListRepositoriesRequiresWorkspace(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	_, err := client.ListRepositories(context.Background(), "", 10)
+	if err == nil {
+		t.Fatal("expected error for empty workspace")
+	}
+}
+
+func TestGetRepository(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/repositories/ws/my-repo") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Repository{Slug: "my-repo", Name: "My Repo"})
+	})
+
+	client := newTestClient(t, handler)
+	repo, err := client.GetRepository(context.Background(), "ws", "my-repo")
+	if err != nil {
+		t.Fatalf("GetRepository: %v", err)
+	}
+	if repo.Slug != "my-repo" {
+		t.Fatalf("expected my-repo, got %q", repo.Slug)
+	}
+}
+
+func TestGetRepositoryRequiresParams(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	_, err := client.GetRepository(context.Background(), "", "repo")
+	if err == nil {
+		t.Fatal("expected error for empty workspace")
+	}
+	_, err = client.GetRepository(context.Background(), "ws", "")
+	if err == nil {
+		t.Fatal("expected error for empty repo slug")
+	}
+}
+
+func TestCreateRepository(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/repositories/ws/new-repo") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body["scm"] != "git" {
+			t.Errorf("expected scm=git, got %v", body["scm"])
+		}
+		if body["is_private"] != true {
+			t.Errorf("expected is_private=true, got %v", body["is_private"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Repository{Slug: "new-repo", Name: "New Repo"})
+	})
+
+	client := newTestClient(t, handler)
+	repo, err := client.CreateRepository(context.Background(), "ws", CreateRepositoryInput{
+		Slug:      "new-repo",
+		IsPrivate: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+	if repo.Slug != "new-repo" {
+		t.Fatalf("expected new-repo, got %q", repo.Slug)
+	}
+}
+
+func TestCreateRepositoryValidation(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	_, err := client.CreateRepository(context.Background(), "", CreateRepositoryInput{Slug: "repo"})
+	if err == nil {
+		t.Fatal("expected error for empty workspace")
+	}
+	_, err = client.CreateRepository(context.Background(), "ws", CreateRepositoryInput{})
+	if err == nil {
+		t.Fatal("expected error for empty slug")
+	}
+}
+
+func TestTriggerPipeline(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+
+		target := body["target"].(map[string]any)
+		if target["ref_name"] != "main" {
+			t.Errorf("expected ref_name=main, got %v", target["ref_name"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Pipeline{UUID: "{abc-123}"})
+	})
+
+	client := newTestClient(t, handler)
+	pipeline, err := client.TriggerPipeline(context.Background(), "ws", "repo", TriggerPipelineInput{
+		Ref: "main",
+	})
+	if err != nil {
+		t.Fatalf("TriggerPipeline: %v", err)
+	}
+	if pipeline.UUID != "{abc-123}" {
+		t.Fatalf("expected UUID {abc-123}, got %q", pipeline.UUID)
+	}
+}
+
+func TestTriggerPipelineWithVariables(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+
+		vars, ok := body["variables"].([]any)
+		if !ok || len(vars) == 0 {
+			t.Fatal("expected variables in body")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Pipeline{UUID: "{abc}"})
+	})
+
+	client := newTestClient(t, handler)
+	_, err := client.TriggerPipeline(context.Background(), "ws", "repo", TriggerPipelineInput{
+		Ref:       "main",
+		Variables: map[string]string{"ENV": "prod"},
+	})
+	if err != nil {
+		t.Fatalf("TriggerPipeline: %v", err)
+	}
+}
+
+func TestTriggerPipelineValidation(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	_, err := client.TriggerPipeline(context.Background(), "", "repo", TriggerPipelineInput{Ref: "main"})
+	if err == nil {
+		t.Fatal("expected error for empty workspace")
+	}
+	_, err = client.TriggerPipeline(context.Background(), "ws", "repo", TriggerPipelineInput{})
+	if err == nil {
+		t.Fatal("expected error for empty ref")
+	}
+}
+
+func TestGetPipelineNormalizesUUID(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// normalizeUUID wraps the UUID in braces; verify they appear in the path
+		if !strings.Contains(r.URL.Path, "{abc-123}") {
+			t.Errorf("expected normalized UUID in path, got: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Pipeline{UUID: "{abc-123}"})
+	})
+
+	client := newTestClient(t, handler)
+	pipeline, err := client.GetPipeline(context.Background(), "ws", "repo", "{abc-123}")
+	if err != nil {
+		t.Fatalf("GetPipeline: %v", err)
+	}
+	if pipeline.UUID != "{abc-123}" {
+		t.Fatalf("expected UUID preserved in response, got %q", pipeline.UUID)
+	}
+}
+
+func TestListPipelineStepsNormalizesUUID(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// normalizeUUID wraps the UUID in braces; verify they appear in the path
+		if !strings.Contains(r.URL.Path, "{pipeline-uuid}") {
+			t.Errorf("expected normalized UUID in path, got: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"values": []map[string]any{
+				{"uuid": "{step-1}", "name": "Build"},
+			},
+		})
+	})
+
+	client := newTestClient(t, handler)
+	steps, err := client.ListPipelineSteps(context.Background(), "ws", "repo", "{pipeline-uuid}")
+	if err != nil {
+		t.Fatalf("ListPipelineSteps: %v", err)
+	}
+	if len(steps) != 1 || steps[0].Name != "Build" {
+		t.Fatalf("unexpected steps: %+v", steps)
+	}
+}
+
+func TestGetPipelineLogsNormalizesUUIDs(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// normalizeUUID wraps UUIDs in braces; verify they appear in the path
+		if !strings.Contains(r.URL.Path, "{pipeline-uuid}") {
+			t.Errorf("expected normalized pipeline UUID in path, got: %s", r.URL.Path)
+		}
+		if !strings.Contains(r.URL.Path, "{step-uuid}") {
+			t.Errorf("expected normalized step UUID in path, got: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("build output here"))
+	})
+
+	client := newTestClient(t, handler)
+	logs, err := client.GetPipelineLogs(context.Background(), "ws", "repo", "{pipeline-uuid}", "{step-uuid}")
+	if err != nil {
+		t.Fatalf("GetPipelineLogs: %v", err)
+	}
+	if string(logs) != "build output here" {
+		t.Fatalf("expected log content, got %q", string(logs))
+	}
+}
+
+func TestCurrentUser(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/user" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(User{Username: "admin", Display: "Admin User"})
+	})
+
+	client := newTestClient(t, handler)
+	user, err := client.CurrentUser(context.Background())
+	if err != nil {
+		t.Fatalf("CurrentUser: %v", err)
+	}
+	if user.Username != "admin" {
+		t.Fatalf("expected admin, got %q", user.Username)
+	}
+}
+
+func TestListPipelinesRequiresParams(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	_, err := client.ListPipelines(context.Background(), "", "repo", 0)
+	if err == nil {
+		t.Fatal("expected error for empty workspace")
+	}
+	_, err = client.ListPipelines(context.Background(), "ws", "", 0)
+	if err == nil {
+		t.Fatal("expected error for empty repo slug")
 	}
 }

--- a/pkg/bbdc/client_test.go
+++ b/pkg/bbdc/client_test.go
@@ -1,0 +1,297 @@
+package bbdc
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/avivsinai/bitbucket-cli/pkg/httpx"
+)
+
+func newTestClient(t *testing.T, handler http.Handler) *Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{
+		BaseURL: server.URL,
+		Retry:   httpx.RetryPolicy{MaxAttempts: 1},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return client
+}
+
+func TestNewRequiresBaseURL(t *testing.T) {
+	_, err := New(Options{})
+	if err == nil {
+		t.Fatal("expected error for empty base URL")
+	}
+}
+
+func TestListRepositoriesPaginates(t *testing.T) {
+	var hits int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&hits, 1)
+		if !strings.Contains(r.URL.Path, "/projects/PROJ/repos") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch count {
+		case 1:
+			_ = json.NewEncoder(w).Encode(paged[Repository]{
+				Values:        []Repository{{Slug: "repo1"}},
+				IsLastPage:    false,
+				NextPageStart: 1,
+				Limit:         1,
+			})
+		case 2:
+			_ = json.NewEncoder(w).Encode(paged[Repository]{
+				Values:     []Repository{{Slug: "repo2"}},
+				IsLastPage: true,
+				Limit:      1,
+			})
+		default:
+			t.Errorf("unexpected request %d", count)
+		}
+	})
+
+	client := newTestClient(t, handler)
+	repos, err := client.ListRepositories(context.Background(), "PROJ", 0)
+	if err != nil {
+		t.Fatalf("ListRepositories: %v", err)
+	}
+	if len(repos) != 2 {
+		t.Fatalf("expected 2 repos, got %d", len(repos))
+	}
+	if repos[0].Slug != "repo1" || repos[1].Slug != "repo2" {
+		t.Fatalf("unexpected slugs: %v, %v", repos[0].Slug, repos[1].Slug)
+	}
+	if hits != 2 {
+		t.Fatalf("expected 2 requests, got %d", hits)
+	}
+}
+
+func TestListRepositoriesRespectsLimit(t *testing.T) {
+	var hits int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(paged[Repository]{
+			Values:        []Repository{{Slug: "repo1"}, {Slug: "repo2"}, {Slug: "repo3"}},
+			IsLastPage:    false,
+			NextPageStart: 3,
+		})
+	})
+
+	client := newTestClient(t, handler)
+	repos, err := client.ListRepositories(context.Background(), "PROJ", 2)
+	if err != nil {
+		t.Fatalf("ListRepositories: %v", err)
+	}
+	if len(repos) != 2 {
+		t.Fatalf("expected 2 repos, got %d", len(repos))
+	}
+	if hits != 1 {
+		t.Fatalf("expected 1 request, got %d", hits)
+	}
+}
+
+func TestListRepositoriesRequiresProjectKey(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	_, err := client.ListRepositories(context.Background(), "", 10)
+	if err == nil {
+		t.Fatal("expected error for empty project key")
+	}
+}
+
+func TestGetRepository(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/projects/PROJ/repos/my-repo") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Repository{Slug: "my-repo", Name: "My Repo", ID: 42})
+	})
+
+	client := newTestClient(t, handler)
+	repo, err := client.GetRepository(context.Background(), "PROJ", "my-repo")
+	if err != nil {
+		t.Fatalf("GetRepository: %v", err)
+	}
+	if repo.Slug != "my-repo" || repo.ID != 42 {
+		t.Fatalf("unexpected repo: %+v", repo)
+	}
+}
+
+func TestGetRepositoryRequiresParams(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	_, err := client.GetRepository(context.Background(), "", "repo")
+	if err == nil {
+		t.Fatal("expected error for empty project key")
+	}
+	_, err = client.GetRepository(context.Background(), "PROJ", "")
+	if err == nil {
+		t.Fatal("expected error for empty repo slug")
+	}
+}
+
+func TestGetPullRequest(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/pull-requests/42") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(PullRequest{ID: 42, Title: "Fix bug", State: "OPEN"})
+	})
+
+	client := newTestClient(t, handler)
+	pr, err := client.GetPullRequest(context.Background(), "PROJ", "repo", 42)
+	if err != nil {
+		t.Fatalf("GetPullRequest: %v", err)
+	}
+	if pr.ID != 42 || pr.Title != "Fix bug" || pr.State != "OPEN" {
+		t.Fatalf("unexpected PR: %+v", pr)
+	}
+}
+
+func TestListPullRequestsWithStateFilter(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("state") != "MERGED" {
+			t.Errorf("expected state=MERGED, got %q", r.URL.Query().Get("state"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(paged[PullRequest]{
+			Values:     []PullRequest{{ID: 1, State: "MERGED"}, {ID: 2, State: "MERGED"}},
+			IsLastPage: true,
+		})
+	})
+
+	client := newTestClient(t, handler)
+	prs, err := client.ListPullRequests(context.Background(), "PROJ", "repo", "merged", 0)
+	if err != nil {
+		t.Fatalf("ListPullRequests: %v", err)
+	}
+	if len(prs) != 2 {
+		t.Fatalf("expected 2 PRs, got %d", len(prs))
+	}
+}
+
+func TestListPullRequestsPaginates(t *testing.T) {
+	var hits int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		switch count {
+		case 1:
+			_ = json.NewEncoder(w).Encode(paged[PullRequest]{
+				Values:        []PullRequest{{ID: 1}},
+				IsLastPage:    false,
+				NextPageStart: 1,
+			})
+		case 2:
+			_ = json.NewEncoder(w).Encode(paged[PullRequest]{
+				Values:     []PullRequest{{ID: 2}},
+				IsLastPage: true,
+			})
+		}
+	})
+
+	client := newTestClient(t, handler)
+	prs, err := client.ListPullRequests(context.Background(), "PROJ", "repo", "", 0)
+	if err != nil {
+		t.Fatalf("ListPullRequests: %v", err)
+	}
+	if len(prs) != 2 {
+		t.Fatalf("expected 2 PRs, got %d", len(prs))
+	}
+	if hits != 2 {
+		t.Fatalf("expected 2 requests, got %d", hits)
+	}
+}
+
+func TestCommitStatuses(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/rest/build-status/1.0/commits/abc123") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"values": []map[string]any{
+				{"state": "SUCCESSFUL", "key": "build-1", "name": "CI"},
+			},
+		})
+	})
+
+	client := newTestClient(t, handler)
+	statuses, err := client.CommitStatuses(context.Background(), "abc123")
+	if err != nil {
+		t.Fatalf("CommitStatuses: %v", err)
+	}
+	if len(statuses) != 1 {
+		t.Fatalf("expected 1 status, got %d", len(statuses))
+	}
+	if statuses[0].State != "SUCCESSFUL" {
+		t.Fatalf("expected SUCCESSFUL, got %q", statuses[0].State)
+	}
+}
+
+func TestCommitStatusesRequiresSHA(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	_, err := client.CommitStatuses(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error for empty SHA")
+	}
+}
+
+func TestCurrentUser(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/rest/api/1.0/users/admin") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(User{Name: "admin", Slug: "admin", ID: 1})
+	})
+
+	client := newTestClient(t, handler)
+	user, err := client.CurrentUser(context.Background(), "admin")
+	if err != nil {
+		t.Fatalf("CurrentUser: %v", err)
+	}
+	if user.Name != "admin" || user.ID != 1 {
+		t.Fatalf("unexpected user: %+v", user)
+	}
+}
+
+func TestClientSendsBasicAuth(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "admin" || pass != "token123" {
+			t.Errorf("expected basic auth admin:token123, got %s:%s (ok=%v)", user, pass, ok)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(User{Name: "admin"})
+	})
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{
+		BaseURL:  server.URL,
+		Username: "admin",
+		Token:    "token123",
+		Retry:    httpx.RetryPolicy{MaxAttempts: 1},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = client.CurrentUser(context.Background(), "admin")
+	if err != nil {
+		t.Fatalf("CurrentUser: %v", err)
+	}
+}

--- a/pkg/cmdutil/output_test.go
+++ b/pkg/cmdutil/output_test.go
@@ -1,0 +1,114 @@
+package cmdutil
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newTestCommand(flags map[string]string) *cobra.Command {
+	root := &cobra.Command{Use: "bkt"}
+	root.PersistentFlags().Bool("json", false, "")
+	root.PersistentFlags().Bool("yaml", false, "")
+	root.PersistentFlags().String("jq", "", "")
+	root.PersistentFlags().String("template", "", "")
+
+	child := &cobra.Command{Use: "test"}
+	root.AddCommand(child)
+
+	for k, v := range flags {
+		if err := root.PersistentFlags().Set(k, v); err != nil {
+			panic(err)
+		}
+	}
+	return child
+}
+
+func TestResolveOutputSettingsJSONFormat(t *testing.T) {
+	cmd := newTestCommand(map[string]string{"json": "true"})
+	settings, err := ResolveOutputSettings(cmd)
+	if err != nil {
+		t.Fatalf("ResolveOutputSettings: %v", err)
+	}
+	if settings.Format != "json" {
+		t.Fatalf("format = %q, want json", settings.Format)
+	}
+}
+
+func TestResolveOutputSettingsYAMLFormat(t *testing.T) {
+	cmd := newTestCommand(map[string]string{"yaml": "true"})
+	settings, err := ResolveOutputSettings(cmd)
+	if err != nil {
+		t.Fatalf("ResolveOutputSettings: %v", err)
+	}
+	if settings.Format != "yaml" {
+		t.Fatalf("format = %q, want yaml", settings.Format)
+	}
+}
+
+func TestResolveOutputSettingsNoFlags(t *testing.T) {
+	cmd := newTestCommand(nil)
+	settings, err := ResolveOutputSettings(cmd)
+	if err != nil {
+		t.Fatalf("ResolveOutputSettings: %v", err)
+	}
+	if settings.Format != "" {
+		t.Fatalf("format = %q, want empty", settings.Format)
+	}
+}
+
+func TestResolveOutputSettingsRejectsJSONAndYAML(t *testing.T) {
+	cmd := newTestCommand(map[string]string{"json": "true", "yaml": "true"})
+	_, err := ResolveOutputSettings(cmd)
+	if err == nil {
+		t.Fatal("expected error for simultaneous --json and --yaml")
+	}
+	if !strings.Contains(err.Error(), "cannot use --json and --yaml") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveOutputSettingsRejectsJQAndTemplate(t *testing.T) {
+	cmd := newTestCommand(map[string]string{"json": "true", "jq": ".name", "template": "{{.Name}}"})
+	_, err := ResolveOutputSettings(cmd)
+	if err == nil {
+		t.Fatal("expected error for simultaneous --jq and --template")
+	}
+	if !strings.Contains(err.Error(), "cannot use --jq and --template") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveOutputSettingsJQRequiresJSON(t *testing.T) {
+	cmd := newTestCommand(map[string]string{"jq": ".name"})
+	_, err := ResolveOutputSettings(cmd)
+	if err == nil {
+		t.Fatal("expected error for --jq without --json")
+	}
+	if !strings.Contains(err.Error(), "--jq requires --json") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveOutputSettingsJQWithJSON(t *testing.T) {
+	cmd := newTestCommand(map[string]string{"json": "true", "jq": ".name"})
+	settings, err := ResolveOutputSettings(cmd)
+	if err != nil {
+		t.Fatalf("ResolveOutputSettings: %v", err)
+	}
+	if settings.Format != "json" || settings.JQ != ".name" {
+		t.Fatalf("unexpected settings: %+v", settings)
+	}
+}
+
+func TestOutputFormat(t *testing.T) {
+	cmd := newTestCommand(map[string]string{"yaml": "true"})
+	format, err := OutputFormat(cmd)
+	if err != nil {
+		t.Fatalf("OutputFormat: %v", err)
+	}
+	if format != "yaml" {
+		t.Fatalf("format = %q, want yaml", format)
+	}
+}

--- a/pkg/cmdutil/url_test.go
+++ b/pkg/cmdutil/url_test.go
@@ -1,0 +1,66 @@
+package cmdutil
+
+import "testing"
+
+func TestNormalizeBaseURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"valid https", "https://example.com", "https://example.com", false},
+		{"trailing slash", "https://example.com/", "https://example.com", false},
+		{"missing scheme", "example.com", "https://example.com", false},
+		{"with path", "https://example.com/bitbucket", "https://example.com/bitbucket", false},
+		{"with trailing slash and path", "https://example.com/bitbucket/", "https://example.com/bitbucket", false},
+		{"http scheme", "http://example.com", "http://example.com", false},
+		{"with query", "https://example.com?foo=bar", "https://example.com", false},
+		{"with fragment", "https://example.com#section", "https://example.com", false},
+		{"whitespace", "  https://example.com  ", "https://example.com", false},
+		{"empty", "", "", true},
+		{"only spaces", "   ", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeBaseURL(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NormalizeBaseURL(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("NormalizeBaseURL(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHostKeyFromURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"standard https", "https://bitbucket.example.com", "bitbucket.example.com", false},
+		{"with port", "https://bitbucket.example.com:7990", "bitbucket.example.com:7990", false},
+		{"with path", "https://bitbucket.example.com/context", "bitbucket.example.com", false},
+		{"http", "http://localhost:7990", "localhost:7990", false},
+		{"no scheme", "example.com", "", true},
+		{"empty", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := HostKeyFromURL(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("HostKeyFromURL(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("HostKeyFromURL(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/format/format_test.go
+++ b/pkg/format/format_test.go
@@ -3,6 +3,7 @@ package format
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -92,5 +93,173 @@ func TestWriteJQPreservesLargeIntegersInStructs(t *testing.T) {
 	// Verify the exact integer is preserved through the struct marshal/unmarshal cycle
 	if output != "18446744073709551615\n" {
 		t.Fatalf("expected jq to preserve large integer 18446744073709551615 from struct, got %q", output)
+	}
+}
+
+func TestWriteYAMLFormat(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := sample{Name: "demo", Count: 3}
+
+	err := Write(buf, Options{Format: "yaml"}, data, nil)
+	if err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "name: demo") {
+		t.Fatalf("expected YAML name field, got %q", output)
+	}
+	if !strings.Contains(output, "count: 3") {
+		t.Fatalf("expected YAML count field, got %q", output)
+	}
+}
+
+func TestWriteJSONFormat(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := sample{Name: "demo", Count: 5}
+
+	err := Write(buf, Options{Format: "json"}, data, nil)
+	if err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+
+	output := buf.String()
+	// JSON format should be indented
+	if !strings.Contains(output, "  \"name\": \"demo\"") {
+		t.Fatalf("expected indented JSON, got %q", output)
+	}
+}
+
+func TestWriteTemplateFormat(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := sample{Name: "demo", Count: 7}
+
+	err := Write(buf, Options{Template: "Name={{.Name}} Count={{.Count}}"}, data, nil)
+	if err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+
+	if buf.String() != "Name=demo Count=7" {
+		t.Fatalf("expected template output, got %q", buf.String())
+	}
+}
+
+func TestWriteTemplateInvalidSyntax(t *testing.T) {
+	buf := new(bytes.Buffer)
+	err := Write(buf, Options{Template: "{{.Invalid"}, nil, nil)
+	if err == nil {
+		t.Fatal("expected error for invalid template")
+	}
+	if !strings.Contains(err.Error(), "parse template") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestWriteFallback(t *testing.T) {
+	called := false
+	fallback := func() error {
+		called = true
+		return nil
+	}
+
+	buf := new(bytes.Buffer)
+	err := Write(buf, Options{}, nil, fallback)
+	if err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected fallback to be called")
+	}
+}
+
+func TestWriteFallbackNil(t *testing.T) {
+	buf := new(bytes.Buffer)
+	err := Write(buf, Options{}, nil, nil)
+	if err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+}
+
+func TestWriteUnsupportedFormat(t *testing.T) {
+	buf := new(bytes.Buffer)
+	err := Write(buf, Options{Format: "xml"}, "data", nil)
+	if err == nil {
+		t.Fatal("expected error for unsupported format")
+	}
+	if !strings.Contains(err.Error(), "unsupported format") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestWriteJQInvalidExpression(t *testing.T) {
+	buf := new(bytes.Buffer)
+	err := Write(buf, Options{Format: "json", JQ: ".[invalid"}, "data", nil)
+	if err == nil {
+		t.Fatal("expected error for invalid jq expression")
+	}
+}
+
+func TestWriteJQNoResults(t *testing.T) {
+	buf := new(bytes.Buffer)
+	data := map[string]any{"name": "test"}
+
+	// .missing returns null for objects, which gojq yields as nil
+	err := Write(buf, Options{Format: "json", JQ: ".missing"}, data, nil)
+	if err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+}
+
+func TestNormaliseForJQBytes(t *testing.T) {
+	input := []byte(`{"key":"value"}`)
+	result, err := normaliseForJQ(input)
+	if err != nil {
+		t.Fatalf("normaliseForJQ: %v", err)
+	}
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map, got %T", result)
+	}
+	if m["key"] != "value" {
+		t.Fatalf("expected value, got %v", m["key"])
+	}
+}
+
+func TestNormaliseForJQEmptyBytes(t *testing.T) {
+	result, err := normaliseForJQ([]byte{})
+	if err != nil {
+		t.Fatalf("normaliseForJQ: %v", err)
+	}
+	if result != nil {
+		t.Fatalf("expected nil, got %v", result)
+	}
+}
+
+func TestNormaliseForJQPassthroughTypes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input any
+	}{
+		{"nil", nil},
+		{"string", "hello"},
+		{"bool", true},
+		{"json.Number", json.Number("42")},
+		{"float64", float64(3.14)},
+		{"int", 42},
+		{"int64", int64(100)},
+		{"uint", uint(10)},
+		{"uint64", uint64(999)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := normaliseForJQ(tt.input)
+			if err != nil {
+				t.Fatalf("normaliseForJQ: %v", err)
+			}
+			if result != tt.input {
+				t.Fatalf("expected passthrough, got %v", result)
+			}
+		})
 	}
 }

--- a/pkg/httpx/client_test.go
+++ b/pkg/httpx/client_test.go
@@ -1,11 +1,14 @@
 package httpx
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -408,5 +411,352 @@ func TestDecodeErrorPrioritizesCaptchaException(t *testing.T) {
 				t.Errorf("got %q, want %q", err.Error(), tt.wantMsg)
 			}
 		})
+	}
+}
+
+func TestDecodeErrorStructuredMessage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"errors": []map[string]any{
+				{"message": "Invalid project key"},
+			},
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{BaseURL: server.URL, Retry: RetryPolicy{MaxAttempts: 1}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "/api", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	err = client.Do(req, nil)
+	if err == nil {
+		t.Fatal("expected error for 400 response")
+	}
+	if !strings.Contains(err.Error(), "Invalid project key") {
+		t.Fatalf("expected structured error message, got %v", err)
+	}
+}
+
+func TestDecodeErrorPlainText(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("Access denied"))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{BaseURL: server.URL, Retry: RetryPolicy{MaxAttempts: 1}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "/api", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	err = client.Do(req, nil)
+	if err == nil {
+		t.Fatal("expected error for 403 response")
+	}
+	if !strings.Contains(err.Error(), "Access denied") {
+		t.Fatalf("expected plain text error, got %v", err)
+	}
+}
+
+func TestDecodeErrorEmptyBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{BaseURL: server.URL, Retry: RetryPolicy{MaxAttempts: 1}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "/missing", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	err = client.Do(req, nil)
+	if err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Fatalf("expected status code in error, got %v", err)
+	}
+}
+
+func TestNewRequestWithJSONBody(t *testing.T) {
+	client, err := New(Options{BaseURL: "https://example.com"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	body := map[string]string{"name": "test-repo"}
+	req, err := client.NewRequest(context.Background(), http.MethodPost, "/repos", body)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	if req.Header.Get("Content-Type") != "application/json" {
+		t.Fatalf("expected Content-Type application/json, got %q", req.Header.Get("Content-Type"))
+	}
+
+	// Verify body is JSON
+	data, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	var parsed map[string]string
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if parsed["name"] != "test-repo" {
+		t.Fatalf("unexpected body: %v", parsed)
+	}
+
+	// Verify GetBody works for retries
+	if req.GetBody == nil {
+		t.Fatal("expected GetBody to be set")
+	}
+	body2, err := req.GetBody()
+	if err != nil {
+		t.Fatalf("GetBody: %v", err)
+	}
+	data2, _ := io.ReadAll(body2)
+	if !bytes.Equal(data, data2) {
+		t.Fatalf("GetBody returned different content")
+	}
+}
+
+func TestNewRequestSetsBasicAuth(t *testing.T) {
+	client, err := New(Options{BaseURL: "https://example.com", Username: "admin", Password: "token"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "/api", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	user, pass, ok := req.BasicAuth()
+	if !ok {
+		t.Fatal("expected basic auth to be set")
+	}
+	if user != "admin" || pass != "token" {
+		t.Fatalf("basic auth = %s:%s, want admin:token", user, pass)
+	}
+}
+
+func TestNewRequestRejectsEmptyPath(t *testing.T) {
+	client, err := New(Options{BaseURL: "https://example.com"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_, err = client.NewRequest(context.Background(), http.MethodGet, "", nil)
+	if err == nil {
+		t.Fatal("expected error for empty path")
+	}
+}
+
+func TestNewRequiresBaseURL(t *testing.T) {
+	_, err := New(Options{})
+	if err == nil {
+		t.Fatal("expected error for empty base URL")
+	}
+}
+
+func TestNewRequiresScheme(t *testing.T) {
+	_, err := New(Options{BaseURL: "example.com"})
+	if err == nil {
+		t.Fatal("expected error for URL without scheme")
+	}
+}
+
+func TestDoWithIOWriter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("raw response body"))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{BaseURL: server.URL})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "/stream", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := client.Do(req, &buf); err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if buf.String() != "raw response body" {
+		t.Fatalf("expected 'raw response body', got %q", buf.String())
+	}
+}
+
+func TestDoNilRequest(t *testing.T) {
+	client, err := New(Options{BaseURL: "https://example.com"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := client.Do(nil, nil); err == nil {
+		t.Fatal("expected error for nil request")
+	}
+}
+
+func TestClientRetriesOn429(t *testing.T) {
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&hits, 1)
+		if count == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload{Message: "ok"})
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{
+		BaseURL: server.URL,
+		Retry: RetryPolicy{
+			MaxAttempts:    3,
+			InitialBackoff: 10 * time.Millisecond,
+			MaxBackoff:     20 * time.Millisecond,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "/api", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	var out payload
+	if err := client.Do(req, &out); err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if out.Message != "ok" {
+		t.Fatalf("expected ok, got %q", out.Message)
+	}
+	if hits != 2 {
+		t.Fatalf("expected 2 attempts, got %d", hits)
+	}
+}
+
+func TestShouldRetryStatus(t *testing.T) {
+	tests := []struct {
+		code int
+		want bool
+	}{
+		{200, false},
+		{201, false},
+		{400, false},
+		{401, false},
+		{403, false},
+		{404, false},
+		{429, true},
+		{500, true},
+		{502, true},
+		{503, true},
+		{599, true},
+	}
+	for _, tt := range tests {
+		if got := shouldRetryStatus(tt.code); got != tt.want {
+			t.Errorf("shouldRetryStatus(%d) = %v, want %v", tt.code, got, tt.want)
+		}
+	}
+}
+
+func TestUpdateRateLimitAtlassianHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Attempt-RateLimit-Limit", "200")
+		w.Header().Set("X-Attempt-RateLimit-Remaining", "150")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload{Message: "ok"})
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{BaseURL: server.URL})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "/api", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	var out payload
+	if err := client.Do(req, &out); err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+
+	rate := client.RateLimitState()
+	if rate.Limit != 200 || rate.Remaining != 150 {
+		t.Fatalf("expected 200/150, got %d/%d", rate.Limit, rate.Remaining)
+	}
+	if rate.Source != "atlassian" {
+		t.Fatalf("expected source 'atlassian', got %q", rate.Source)
+	}
+}
+
+func TestDoDiscardsBodyWhenVNil(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"key":"value"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{BaseURL: server.URL})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "/api", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	// Should not error even though v is nil
+	if err := client.Do(req, nil); err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+}
+
+func TestNewRequestAbsoluteURL(t *testing.T) {
+	client, err := New(Options{BaseURL: "https://example.com"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "https://other.com/api/test", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	if got := req.URL.String(); got != "https://other.com/api/test" {
+		t.Fatalf("expected absolute URL to be preserved, got %s", got)
 	}
 }


### PR DESCRIPTION
## Summary

- Add comprehensive tests across config, httpx, bbcloud, bbdc, cmdutil, format, and TESTING.md
- 1,895 lines of new test coverage with no production code changes
- Raises test coverage from ~9.8% toward ~16%

Split from #52 for independent review. No dependency on #54.

## Packages covered

| Package | New tests | Highlights |
|---|---|---|
| `internal/config` | 14 tests | Load/Save round-trip, token stripping, CRUD, nil map init |
| `pkg/bbcloud` | 16 tests | Repos, pipelines, UUID normalization, CurrentUser |
| `pkg/bbdc` | 12 tests | Pagination, limit, auth headers, state filtering |
| `pkg/cmdutil` | 10 tests | Output flag validation, URL normalization |
| `pkg/format` | 11 tests | YAML/template rendering, jq edge cases |
| `pkg/httpx` | 15 tests | Error decoding, retry, rate limits, body encoding |

## Test plan

- [x] `go build ./...` passes
- [x] `golangci-lint run` — 0 issues
- [x] `go test ./...` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)