### PR TITLE
Feature/Cloud support for PR checkout, diff, approve, merge, and comment

### DIFF
--- a/pkg/bbcloud/diffstat.go
+++ b/pkg/bbcloud/diffstat.go
@@ -11,8 +11,8 @@ type DiffStatEntry struct {
 	Status       string `json:"status"`
 	LinesAdded   int    `json:"lines_added"`
 	LinesRemoved int    `json:"lines_removed"`
-	OldPath      string `json:"-"`
-	NewPath      string `json:"-"`
+	OldPath      string `json:"old_path,omitempty"`
+	NewPath      string `json:"new_path,omitempty"`
 }
 
 // DiffStatResult aggregates per-file diff statistics for a pull request.
@@ -20,7 +20,6 @@ type DiffStatResult struct {
 	Entries      []DiffStatEntry `json:"entries"`
 	TotalAdded   int             `json:"total_added"`
 	TotalRemoved int             `json:"total_removed"`
-	TotalFiles   int             `json:"total_files"`
 }
 
 // diffStatPage models a single page of the diffstat API response.
@@ -55,7 +54,7 @@ func (c *Client) PullRequestDiffStat(ctx context.Context, workspace, repoSlug st
 
 	result := &DiffStatResult{}
 
-	for page := 0; path != "" && page < maxDiffStatPages; page++ {
+	for pageNum := 0; path != "" && pageNum < maxDiffStatPages; pageNum++ {
 		req, err := c.http.NewRequest(ctx, "GET", path, nil)
 		if err != nil {
 			return nil, err
@@ -81,7 +80,6 @@ func (c *Client) PullRequestDiffStat(ctx context.Context, workspace, repoSlug st
 			result.Entries = append(result.Entries, entry)
 			result.TotalAdded += v.LinesAdded
 			result.TotalRemoved += v.LinesRemoved
-			result.TotalFiles++
 		}
 
 		if page.Next == "" {

--- a/pkg/bbcloud/diffstat_test.go
+++ b/pkg/bbcloud/diffstat_test.go
@@ -52,8 +52,8 @@ func TestPullRequestDiffStat(t *testing.T) {
 	if gotPath != "/repositories/myworkspace/my-repo/pullrequests/7/diffstat" {
 		t.Errorf("path = %q, want /repositories/myworkspace/my-repo/pullrequests/7/diffstat", gotPath)
 	}
-	if result.TotalFiles != 3 {
-		t.Errorf("TotalFiles = %d, want 3", result.TotalFiles)
+	if len(result.Entries) != 3 {
+		t.Errorf("len(Entries) = %d, want 3", len(result.Entries))
 	}
 	if result.TotalAdded != 35 {
 		t.Errorf("TotalAdded = %d, want 35", result.TotalAdded)
@@ -146,8 +146,8 @@ func TestPullRequestDiffStatPagination(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PullRequestDiffStat: %v", err)
 	}
-	if result.TotalFiles != 2 {
-		t.Errorf("TotalFiles = %d, want 2", result.TotalFiles)
+	if len(result.Entries) != 2 {
+		t.Errorf("len(Entries) = %d, want 2", len(result.Entries))
 	}
 	if result.TotalAdded != 15 {
 		t.Errorf("TotalAdded = %d, want 15", result.TotalAdded)

--- a/pkg/bbcloud/pullrequests.go
+++ b/pkg/bbcloud/pullrequests.go
@@ -348,10 +348,20 @@ func (c *Client) PullRequestDiff(ctx context.Context, workspace, repoSlug string
 	return c.http.Do(req, w)
 }
 
+// validMergeStrategies lists the strategies accepted by Bitbucket Cloud.
+var validMergeStrategies = map[string]bool{
+	"merge_commit": true,
+	"squash":       true,
+	"fast_forward": true,
+}
+
 // MergePullRequest merges the given pull request.
 func (c *Client) MergePullRequest(ctx context.Context, workspace, repoSlug string, id int, message, strategy string, closeSource bool) error {
 	if workspace == "" || repoSlug == "" {
 		return fmt.Errorf("workspace and repository slug are required")
+	}
+	if strategy != "" && !validMergeStrategies[strategy] {
+		return fmt.Errorf("invalid merge strategy %q: must be one of merge_commit, squash, fast_forward", strategy)
 	}
 
 	body := map[string]any{

--- a/pkg/bbcloud/pullrequests_test.go
+++ b/pkg/bbcloud/pullrequests_test.go
@@ -477,6 +477,31 @@ func TestMergePullRequestValidation(t *testing.T) {
 	}
 }
 
+func TestMergePullRequestInvalidStrategy(t *testing.T) {
+	client, err := bbcloud.New(bbcloud.Options{
+		BaseURL: "http://localhost", Username: "u", Token: "t",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Invalid strategy should return error
+	invalidStrategies := []string{"squah", "rebase", "merge-commit", "SQUASH"}
+	for _, s := range invalidStrategies {
+		t.Run("invalid_"+s, func(t *testing.T) {
+			if err := client.MergePullRequest(context.Background(), "ws", "repo", 1, "", s, false); err == nil {
+				t.Errorf("expected error for strategy %q", s)
+			}
+		})
+	}
+
+	// Valid strategies should not fail validation (they'll fail on network, but not validation)
+	// Empty string is valid (means "use default")
+	if err := client.MergePullRequest(context.Background(), "ws", "repo", 1, "", "", false); err == nil {
+		// Network error is expected, but not a validation error — this is fine
+	}
+}
+
 func TestApprovePullRequest(t *testing.T) {
 	var gotMethod, gotPath string
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -24,6 +24,12 @@ import (
 	"github.com/avivsinai/bitbucket-cli/pkg/types"
 )
 
+const (
+	// Standard timeouts for API calls.
+	timeoutRead  = 15 * time.Second
+	timeoutWrite = 10 * time.Second
+)
+
 // Sentinel errors for checks command
 var (
 	ErrNoSourceCommit = errors.New("pull request has no source commit")
@@ -943,7 +949,7 @@ func runCheckout(cmd *cobra.Command, f *cmdutil.Factory, opts *checkoutOptions) 
 			return err
 		}
 
-		ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
+		ctx, cancel := context.WithTimeout(cmd.Context(), timeoutRead)
 		defer cancel()
 
 		pr, err := client.GetPullRequest(ctx, workspace, repoSlug, opts.ID)
@@ -964,7 +970,8 @@ func runCheckout(cmd *cobra.Command, f *cmdutil.Factory, opts *checkoutOptions) 
 			pr.Source.Repository.FullName != pr.Destination.Repository.FullName
 
 		if isFork {
-			forkCloneURL := repoCloneURL(pr.Source.Repository, "https")
+			protocol := inferProtocol(cmd.Context(), opts.Remote)
+			forkCloneURL := repoCloneURL(pr.Source.Repository, protocol)
 			if forkCloneURL == "" {
 				commitHash := pr.Source.Commit.Hash
 				hint := ""
@@ -983,12 +990,24 @@ func runCheckout(cmd *cobra.Command, f *cmdutil.Factory, opts *checkoutOptions) 
 			if existing := findRemoteByURL(cmd.Context(), forkCloneURL); existing != "" {
 				remote = existing
 			} else {
-				// Add a new remote for the fork: fork/<owner>
+				// Derive remote name: fork/<owner>
 				parts := strings.SplitN(pr.Source.Repository.FullName, "/", 2)
-				owner := parts[0]
+				owner := pr.Source.Repository.FullName // fallback if no /
+				if len(parts) >= 2 {
+					owner = parts[0]
+				}
 				remote = "fork/" + owner
-				if err := runGit(cmd.Context(), "remote", "add", remote, forkCloneURL); err != nil {
-					return fmt.Errorf("failed to add remote %q for fork: %w", remote, err)
+
+				// If a remote with this name already exists (but different URL),
+				// update its URL instead of failing.
+				if existingURL, err := runGitOutput(cmd.Context(), "remote", "get-url", remote); err == nil && strings.TrimSpace(existingURL) != "" {
+					if err := runGit(cmd.Context(), "remote", "set-url", remote, forkCloneURL); err != nil {
+						return fmt.Errorf("failed to update remote %q URL for fork: %w", remote, err)
+					}
+				} else {
+					if err := runGit(cmd.Context(), "remote", "add", remote, forkCloneURL); err != nil {
+						return fmt.Errorf("failed to add remote %q for fork: %w", remote, err)
+					}
 				}
 			}
 		}
@@ -1120,6 +1139,21 @@ func runDiff(cmd *cobra.Command, f *cmdutil.Factory, opts *diffOptions) error {
 				"stats":        result,
 			}
 			return cmdutil.WriteOutput(cmd, ios.Out, payload, func() error {
+				// Compute max path length for alignment.
+				maxLen := 0
+				for _, e := range result.Entries {
+					p := e.NewPath
+					if p == "" {
+						p = e.OldPath
+					}
+					if len(p) > maxLen {
+						maxLen = len(p)
+					}
+				}
+				if maxLen < 20 {
+					maxLen = 20
+				}
+
 				for _, e := range result.Entries {
 					prefix := "M"
 					switch e.Status {
@@ -1129,16 +1163,20 @@ func runDiff(cmd *cobra.Command, f *cmdutil.Factory, opts *diffOptions) error {
 						prefix = "D"
 					case "renamed":
 						prefix = "R"
+					default:
+						if e.Status != "modified" && e.Status != "" {
+							prefix = "?"
+						}
 					}
 					filePath := e.NewPath
 					if filePath == "" {
 						filePath = e.OldPath
 					}
-					if _, err := fmt.Fprintf(ios.Out, "%s  %-60s +%d -%d\n", prefix, filePath, e.LinesAdded, e.LinesRemoved); err != nil {
+					if _, err := fmt.Fprintf(ios.Out, "%s  %-*s +%d -%d\n", prefix, maxLen, filePath, e.LinesAdded, e.LinesRemoved); err != nil {
 						return err
 					}
 				}
-				_, err := fmt.Fprintf(ios.Out, "\n%d files changed, %d insertions(+), %d deletions(-)\n", result.TotalFiles, result.TotalAdded, result.TotalRemoved)
+				_, err := fmt.Fprintf(ios.Out, "\n%d files changed, %d insertions(+), %d deletions(-)\n", len(result.Entries), result.TotalAdded, result.TotalRemoved)
 				return err
 			})
 		}
@@ -1163,6 +1201,7 @@ type approveOptions struct {
 	Workspace string
 	Project   string
 	Repo      string
+	ID        int
 }
 
 func newApproveCmd(f *cmdutil.Factory) *cobra.Command {
@@ -1176,7 +1215,8 @@ func newApproveCmd(f *cmdutil.Factory) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("invalid pull request id %q", args[0])
 			}
-			return runApprove(cmd, f, id, opts)
+			opts.ID = id
+			return runApprove(cmd, f, opts)
 		},
 	}
 
@@ -1187,7 +1227,7 @@ func newApproveCmd(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func runApprove(cmd *cobra.Command, f *cmdutil.Factory, id int, opts *approveOptions) error {
+func runApprove(cmd *cobra.Command, f *cmdutil.Factory, opts *approveOptions) error {
 	ios, err := f.Streams()
 	if err != nil {
 		return err
@@ -1212,14 +1252,14 @@ func runApprove(cmd *cobra.Command, f *cmdutil.Factory, id int, opts *approveOpt
 			return err
 		}
 
-		ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(cmd.Context(), timeoutWrite)
 		defer cancel()
 
-		if err := client.ApprovePullRequest(ctx, projectKey, repoSlug, id); err != nil {
+		if err := client.ApprovePullRequest(ctx, projectKey, repoSlug, opts.ID); err != nil {
 			return err
 		}
 
-		if _, err := fmt.Fprintf(ios.Out, "✓ Approved pull request #%d\n", id); err != nil {
+		if _, err := fmt.Fprintf(ios.Out, "✓ Approved pull request #%d\n", opts.ID); err != nil {
 			return err
 		}
 		return nil
@@ -1236,14 +1276,14 @@ func runApprove(cmd *cobra.Command, f *cmdutil.Factory, id int, opts *approveOpt
 			return err
 		}
 
-		ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(cmd.Context(), timeoutWrite)
 		defer cancel()
 
-		if err := client.ApprovePullRequest(ctx, workspace, repoSlug, id); err != nil {
+		if err := client.ApprovePullRequest(ctx, workspace, repoSlug, opts.ID); err != nil {
 			return err
 		}
 
-		if _, err := fmt.Fprintf(ios.Out, "✓ Approved pull request #%d\n", id); err != nil {
+		if _, err := fmt.Fprintf(ios.Out, "✓ Approved pull request #%d\n", opts.ID); err != nil {
 			return err
 		}
 		return nil
@@ -2270,7 +2310,8 @@ func repoCloneURL(repo bbcloud.RepositoryRef, protocol string) string {
 }
 
 // findRemoteByURL scans `git remote -v` output for a remote whose fetch URL
-// matches the given cloneURL. Returns the remote name, or "" if not found.
+// matches the given cloneURL. Only fetch lines are considered.
+// Returns the remote name, or "" if not found.
 func findRemoteByURL(ctx context.Context, cloneURL string) string {
 	out, err := runGitOutput(ctx, "remote", "-v")
 	if err != nil {
@@ -2283,7 +2324,11 @@ func findRemoteByURL(ctx context.Context, cloneURL string) string {
 	target := norm(cloneURL)
 	for _, line := range strings.Split(out, "\n") {
 		fields := strings.Fields(line)
-		if len(fields) < 2 {
+		if len(fields) < 3 {
+			continue
+		}
+		// Only match fetch lines: name URL (fetch)
+		if fields[2] != "(fetch)" {
 			continue
 		}
 		if norm(fields[1]) == target {
@@ -2291,4 +2336,19 @@ func findRemoteByURL(ctx context.Context, cloneURL string) string {
 		}
 	}
 	return ""
+}
+
+// inferProtocol examines the given remote's URL to determine whether
+// SSH or HTTPS should be preferred for fork clone URLs.
+// Falls back to "https" if the remote URL cannot be determined.
+func inferProtocol(ctx context.Context, remoteName string) string {
+	url, err := runGitOutput(ctx, "remote", "get-url", remoteName)
+	if err != nil {
+		return "https"
+	}
+	url = strings.TrimSpace(url)
+	if strings.HasPrefix(url, "git@") || strings.HasPrefix(url, "ssh://") {
+		return "ssh"
+	}
+	return "https"
 }

--- a/pkg/cmd/pr/pr_checkout_test.go
+++ b/pkg/cmd/pr/pr_checkout_test.go
@@ -1,6 +1,7 @@
 package pr
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/avivsinai/bitbucket-cli/pkg/bbcloud"
@@ -139,4 +140,143 @@ func makeRepoRef(fullName string, clones []cloneEntry) bbcloud.RepositoryRef {
 		})
 	}
 	return ref
+}
+
+func TestOwnerDerivation(t *testing.T) {
+	tests := []struct {
+		name     string
+		fullName string
+		want     string
+	}{
+		{
+			name:     "normal owner/repo",
+			fullName: "contributor/my-repo",
+			want:     "contributor",
+		},
+		{
+			name:     "owner with multiple slashes",
+			fullName: "org/sub/repo",
+			want:     "org",
+		},
+		{
+			name:     "no slash - fallback to full name",
+			fullName: "justrepo",
+			want:     "justrepo",
+		},
+		{
+			name:     "empty string - fallback",
+			fullName: "",
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parts := strings.SplitN(tt.fullName, "/", 2)
+			owner := tt.fullName // fallback if no /
+			if len(parts) >= 2 {
+				owner = parts[0]
+			}
+			if owner != tt.want {
+				t.Errorf("owner = %q, want %q", owner, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindRemoteByURLParsing(t *testing.T) {
+	// This tests the parsing logic used by findRemoteByURL.
+	// We simulate git remote -v output and check that only (fetch) lines match.
+	tests := []struct {
+		name     string
+		output   string
+		cloneURL string
+		want     string
+	}{
+		{
+			name: "match fetch line",
+			output: "origin\thttps://bitbucket.org/ws/repo.git (fetch)\n" +
+				"origin\thttps://bitbucket.org/ws/repo.git (push)\n",
+			cloneURL: "https://bitbucket.org/ws/repo.git",
+			want:     "origin",
+		},
+		{
+			name:     "only push - no match",
+			output:   "upstream\thttps://bitbucket.org/ws/repo.git (push)\n",
+			cloneURL: "https://bitbucket.org/ws/repo.git",
+			want:     "",
+		},
+		{
+			name:     ".git suffix normalisation",
+			output:   "fork\thttps://bitbucket.org/user/repo (fetch)\n",
+			cloneURL: "https://bitbucket.org/user/repo.git",
+			want:     "fork",
+		},
+		{
+			name:     "no match",
+			output:   "origin\thttps://github.com/ws/repo.git (fetch)\n",
+			cloneURL: "https://bitbucket.org/ws/repo.git",
+			want:     "",
+		},
+		{
+			name:     "empty output",
+			output:   "",
+			cloneURL: "https://bitbucket.org/ws/repo.git",
+			want:     "",
+		},
+	}
+
+	norm := func(u string) string {
+		return strings.TrimSuffix(strings.TrimSpace(u), ".git")
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := norm(tt.cloneURL)
+			got := ""
+			for _, line := range strings.Split(tt.output, "\n") {
+				fields := strings.Fields(line)
+				if len(fields) < 3 {
+					continue
+				}
+				if fields[2] != "(fetch)" {
+					continue
+				}
+				if norm(fields[1]) == target {
+					got = fields[0]
+					break
+				}
+			}
+			if got != tt.want {
+				t.Errorf("findRemoteByURL logic = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInferProtocolParsing(t *testing.T) {
+	// Tests the protocol inference logic used by inferProtocol.
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"https url", "https://bitbucket.org/ws/repo.git", "https"},
+		{"ssh git@ url", "git@bitbucket.org:ws/repo.git", "ssh"},
+		{"ssh:// url", "ssh://git@bitbucket.org/ws/repo.git", "ssh"},
+		{"empty url", "", "https"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := "https"
+			url := strings.TrimSpace(tt.url)
+			if strings.HasPrefix(url, "git@") || strings.HasPrefix(url, "ssh://") {
+				got = "ssh"
+			}
+			if got != tt.want {
+				t.Errorf("inferProtocol logic = %q, want %q", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Extends the [pr](cci:1://file:///d:/Programming/Codes/bitbucket-cli/pkg/cmd/pr/pr.go:1117:0-1181:1) subcommands to support Bitbucket Cloud contexts in addition to the existing Data Center support. Each command now uses a `switch host.Kind` with `dc` / `cloud` / `default` cases, eliminating all DC-only guards.

### Changes per command

| Command | Cloud implementation |
|---|---|
| `pr comment` | POST `.../pullrequests/{id}/comments` with `content.raw` body |
| `pr diff` | GET `.../pullrequests/{id}/diff` streamed via pager or stdout |
| `pr approve` | POST `.../pullrequests/{id}/approve` |
| `pr merge` | POST `.../pullrequests/{id}/merge` with `message`, `merge_strategy`, `close_source_branch` |
| `pr checkout` | Fetches PR via API to resolve source branch, then `git fetch <remote> <branch>:<local>` + `git checkout` (Cloud has no `refs/pull-requests/{id}/from` git refs) |

### New Cloud client methods (`pkg/bbcloud`)

- `CommentPullRequest`
- `PullRequestDiff`
- `ApprovePullRequest`
- `MergePullRequest`

### Flags added

All affected commands gain `--workspace` (Cloud workspace override). `pr approve` additionally gains `--project` and `--repo` overrides (previously it had none).

### Tests

Unit tests added for each new Cloud client method in `pkg/bbcloud/pullrequests_test.go`.