### PR TITLE
fix(security): harden extension system, credential handling, and git invocations

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,6 +92,14 @@ func Load() (*Config, error) {
 		cfg.Hosts = make(map[string]*Host)
 	}
 
+	// Warn if any host has a plaintext token in the config file.
+	// Tokens should only be stored in the OS keyring.
+	for key, h := range cfg.Hosts {
+		if h.Token != "" {
+			fmt.Fprintf(os.Stderr, "WARNING: host %q has a plaintext token in %s — move it to the keyring via `bkt auth login` and remove the token field from the config file\n", key, path)
+		}
+	}
+
 	return cfg, nil
 }
 

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -51,6 +51,7 @@ type loginOptions struct {
 	Username           string
 	Token              string
 	AllowInsecureStore bool
+	AllowHTTP          bool
 	Web                bool
 }
 
@@ -73,8 +74,9 @@ func newLoginCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.Flags().StringVar(&opts.Kind, "kind", opts.Kind, "Bitbucket deployment kind (dc or cloud)")
 	cmd.Flags().StringVar(&opts.Username, "username", "", "Username (DC: PAT owner, Cloud: Atlassian email for API tokens)")
-	cmd.Flags().StringVar(&opts.Token, "token", "", "Authentication token (DC: PAT, Cloud: API token)")
+	cmd.Flags().StringVar(&opts.Token, "token", "", "Authentication token (DC: PAT, Cloud: API token). WARNING: visible in process list and shell history; prefer the interactive prompt or BKT_TOKEN env var")
 	cmd.Flags().BoolVar(&opts.AllowInsecureStore, "allow-insecure-store", false, "Allow encrypted fallback secret storage when no OS keychain is available")
+	cmd.Flags().BoolVar(&opts.AllowHTTP, "allow-http", false, "Allow http:// URLs (credentials will be sent in plaintext)")
 	cmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open browser to create token, then prompt for credentials")
 
 	return cmd
@@ -102,9 +104,28 @@ func runLogin(cmd *cobra.Command, f *cmdutil.Factory, opts *loginOptions) error 
 		}
 	}
 
-	baseURL, err := cmdutil.NormalizeBaseURL(opts.Host)
-	if err != nil {
-		return err
+	var baseURL string
+	if opts.AllowHTTP {
+		baseURL, err = cmdutil.NormalizeBaseURLAllowHTTP(opts.Host)
+		if err != nil {
+			return err
+		}
+		if strings.HasPrefix(baseURL, "http://") {
+			if _, warnErr := fmt.Fprintln(ios.ErrOut, "WARNING: using http:// — credentials will be transmitted in plaintext"); warnErr != nil {
+				return warnErr
+			}
+		}
+	} else {
+		baseURL, err = cmdutil.NormalizeBaseURL(opts.Host)
+		if err != nil {
+			return err
+		}
+	}
+
+	if opts.Token != "" {
+		if _, warnErr := fmt.Fprintln(ios.ErrOut, "WARNING: --token is visible in process listings and shell history; prefer the interactive prompt or BKT_TOKEN env var"); warnErr != nil {
+			return warnErr
+		}
 	}
 
 	kind := strings.ToLower(opts.Kind)

--- a/pkg/cmd/extension/extension.go
+++ b/pkg/cmd/extension/extension.go
@@ -15,6 +15,47 @@ import (
 	"github.com/avivsinai/bitbucket-cli/pkg/cmdutil"
 )
 
+// sensitiveEnvPrefixes lists environment variable prefixes that must not be
+// forwarded to extension subprocesses. Extensions are arbitrary third-party
+// code and should not receive credentials.
+var sensitiveEnvPrefixes = []string{
+	"BKT_TOKEN=",
+	"BKT_KEYRING_PASSPHRASE=",
+	"BKT_ALLOW_INSECURE_STORE=",
+}
+
+// validateExtensionName rejects names that contain path separators or
+// traversal sequences, preventing directory escape via "../" in
+// extension remove/exec operations.
+func validateExtensionName(name string) error {
+	if name == "" {
+		return fmt.Errorf("extension name is required")
+	}
+	if strings.Contains(name, "/") || strings.Contains(name, "\\") || strings.Contains(name, "..") {
+		return fmt.Errorf("invalid extension name %q: must not contain path separators or '..'", name)
+	}
+	return nil
+}
+
+// filterSensitiveEnv returns a copy of the environment with sensitive
+// variables removed.
+func filterSensitiveEnv() []string {
+	var filtered []string
+	for _, env := range os.Environ() {
+		sensitive := false
+		for _, prefix := range sensitiveEnvPrefixes {
+			if strings.HasPrefix(env, prefix) {
+				sensitive = true
+				break
+			}
+		}
+		if !sensitive {
+			filtered = append(filtered, env)
+		}
+	}
+	return filtered
+}
+
 // NewCmdExtension manages external bkt extensions.
 func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
@@ -100,7 +141,11 @@ func runExtensionInstall(cmd *cobra.Command, f *cmdutil.Factory, repo string) er
 		return fmt.Errorf("extension %q is already installed", name)
 	}
 
-	args := []string{"clone", repo, destination}
+	if strings.HasPrefix(repo, "-") {
+		return fmt.Errorf("invalid repository %q: must not start with '-'", repo)
+	}
+
+	args := []string{"clone", "--", repo, destination}
 	gitCmd := exec.CommandContext(cmd.Context(), "git", args...)
 	gitCmd.Stdout = ios.Out
 	gitCmd.Stderr = ios.ErrOut
@@ -198,6 +243,10 @@ func runExtensionList(cmd *cobra.Command, f *cmdutil.Factory) error {
 }
 
 func runExtensionRemove(cmd *cobra.Command, f *cmdutil.Factory, name string) error {
+	if err := validateExtensionName(name); err != nil {
+		return err
+	}
+
 	ios, err := f.Streams()
 	if err != nil {
 		return err
@@ -226,6 +275,10 @@ func runExtensionRemove(cmd *cobra.Command, f *cmdutil.Factory, name string) err
 }
 
 func runExtensionExec(cmd *cobra.Command, f *cmdutil.Factory, name string, args []string) error {
+	if err := validateExtensionName(name); err != nil {
+		return err
+	}
+
 	ios, err := f.Streams()
 	if err != nil {
 		return err
@@ -254,7 +307,7 @@ func runExtensionExec(cmd *cobra.Command, f *cmdutil.Factory, name string, args 
 	cmdExec.Stderr = ios.ErrOut
 	cmdExec.Stdin = ios.In
 	cmdExec.Dir = dir
-	cmdExec.Env = append(os.Environ(),
+	cmdExec.Env = append(filterSensitiveEnv(),
 		fmt.Sprintf("BKT_EXTENSION_DIR=%s", dir),
 		fmt.Sprintf("BKT_EXTENSION_NAME=%s", name),
 	)

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -1001,6 +1001,10 @@ func runCheckout(cmd *cobra.Command, f *cmdutil.Factory, opts *checkoutOptions) 
 
 				// If a remote with this name already exists (but different URL),
 				// update its URL instead of failing.
+				// Validate the fork clone URL to prevent git flag injection from API-sourced data.
+				if strings.HasPrefix(forkCloneURL, "-") {
+					return fmt.Errorf("invalid fork clone URL %q: must not start with '-'", forkCloneURL)
+				}
 				if existingURL, err := runGitOutput(cmd.Context(), "remote", "get-url", remote); err == nil && strings.TrimSpace(existingURL) != "" {
 					if err := runGit(cmd.Context(), "remote", "set-url", remote, forkCloneURL); err != nil {
 						return fmt.Errorf("failed to update remote %q URL for fork: %w", remote, err)

--- a/pkg/cmd/repo/repo.go
+++ b/pkg/cmd/repo/repo.go
@@ -889,7 +889,8 @@ func selectCloneURLCloud(repo bbcloud.Repository, useSSH bool) (string, error) {
 }
 
 func runGitClone(cmd *cobra.Command, out, errOut io.Writer, in io.Reader, cloneURL, dest string) error {
-	args := []string{"clone", cloneURL}
+	// Use "--" to prevent API-sourced URLs from being interpreted as git flags.
+	args := []string{"clone", "--", cloneURL}
 	if dest != "" {
 		args = append(args, dest)
 	}

--- a/pkg/cmdutil/url.go
+++ b/pkg/cmdutil/url.go
@@ -7,8 +7,18 @@ import (
 )
 
 // NormalizeBaseURL ensures the Bitbucket base URL includes a scheme and has no
-// trailing slash.
+// trailing slash. HTTP URLs are rejected by default; use AllowHTTP to permit them.
 func NormalizeBaseURL(raw string) (string, error) {
+	return normalizeBaseURL(raw, false)
+}
+
+// NormalizeBaseURLAllowHTTP is like NormalizeBaseURL but permits http:// URLs.
+// Callers should warn the user that credentials will be transmitted in plaintext.
+func NormalizeBaseURLAllowHTTP(raw string) (string, error) {
+	return normalizeBaseURL(raw, true)
+}
+
+func normalizeBaseURL(raw string, allowHTTP bool) (string, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return "", fmt.Errorf("host is required")
@@ -22,6 +32,9 @@ func NormalizeBaseURL(raw string) (string, error) {
 	}
 	if u.Scheme == "" {
 		u.Scheme = "https"
+	}
+	if u.Scheme == "http" && !allowHTTP {
+		return "", fmt.Errorf("http:// URLs are not allowed (credentials would be sent in plaintext); use --allow-http to override")
 	}
 	u.Path = strings.TrimSuffix(u.Path, "/")
 	u.RawQuery = ""

--- a/pkg/cmdutil/url_test.go
+++ b/pkg/cmdutil/url_test.go
@@ -14,7 +14,7 @@ func TestNormalizeBaseURL(t *testing.T) {
 		{"missing scheme", "example.com", "https://example.com", false},
 		{"with path", "https://example.com/bitbucket", "https://example.com/bitbucket", false},
 		{"with trailing slash and path", "https://example.com/bitbucket/", "https://example.com/bitbucket", false},
-		{"http scheme", "http://example.com", "http://example.com", false},
+		{"http scheme rejected", "http://example.com", "", true},
 		{"with query", "https://example.com?foo=bar", "https://example.com", false},
 		{"with fragment", "https://example.com#section", "https://example.com", false},
 		{"whitespace", "  https://example.com  ", "https://example.com", false},
@@ -31,6 +31,32 @@ func TestNormalizeBaseURL(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("NormalizeBaseURL(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeBaseURLAllowHTTP(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"http allowed", "http://example.com", "http://example.com", false},
+		{"https still works", "https://example.com", "https://example.com", false},
+		{"missing scheme defaults to https", "example.com", "https://example.com", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeBaseURLAllowHTTP(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NormalizeBaseURLAllowHTTP(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("NormalizeBaseURLAllowHTTP(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/pkg/httpx/client.go
+++ b/pkg/httpx/client.go
@@ -428,7 +428,15 @@ func (c *Client) backoff(ctx context.Context, attempts int, resp *http.Response)
 	if resp != nil {
 		if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
 			if secs, err := strconv.Atoi(retryAfter); err == nil {
-				delay = time.Duration(secs) * time.Second
+				retryDelay := time.Duration(secs) * time.Second
+				// Cap Retry-After to prevent server-controlled denial of service.
+				const maxRetryAfter = 60 * time.Second
+				if retryDelay > maxRetryAfter {
+					retryDelay = maxRetryAfter
+				}
+				if retryDelay > 0 {
+					delay = retryDelay
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Security hardening pass addressing 9 vulnerabilities found during a comprehensive code review. Changes span the extension system, credential handling, HTTP client, and all git subprocess invocations.

## Vulnerabilities Addressed

### Critical

#### 1. Path Traversal in Extension `remove`/`exec`
**`pkg/cmd/extension/extension.go:200-262`**

The extension `name` argument was passed directly to `filepath.Join(root, name)` with no sanitization. `filepath.Join` collapses `..` components, allowing traversal outside the extensions directory:

```
bkt extension remove "../../../some/path"   →  os.RemoveAll() on arbitrary path
bkt extension exec "../../../usr/bin/evil"  →  executes arbitrary binary
```

**Fix:** Added `validateExtensionName()` that rejects names containing path separators (`/`, `\`) or `..` sequences.

#### 2. HTTP Downgrade — Credentials Sent in Plaintext
**`pkg/cmdutil/url.go:16` / `pkg/cmd/auth/auth.go:105`**

`NormalizeBaseURL` accepted `http://` URLs without warning. All subsequent API calls including the `Authorization: Basic` header were sent over cleartext HTTP.

**Fix:** `NormalizeBaseURL` now rejects `http://` by default. Added `NormalizeBaseURLAllowHTTP()` and a `--allow-http` flag to `bkt auth login` that prints a visible warning.

---

### High

#### 3. Extension Subprocesses Inherit `BKT_TOKEN`
**`pkg/cmd/extension/extension.go:257`**

Extensions received the full parent environment via `os.Environ()`, including `BKT_TOKEN` and `BKT_KEYRING_PASSPHRASE`. Any third-party extension silently received the API token.

**Fix:** Added `filterSensitiveEnv()` that strips `BKT_TOKEN`, `BKT_KEYRING_PASSPHRASE`, and `BKT_ALLOW_INSECURE_STORE` from the extension subprocess environment.

#### 4. Git Flag Injection in Extension Install
**`pkg/cmd/extension/extension.go:103`**

The user-supplied `repo` argument was passed to `git clone` without a `--` separator. A repo starting with `--` would be interpreted as a git flag.

**Fix:** Added `--` separator and validation that `repo` doesn't start with `-`.

#### 5. Git Flag Injection in `repo clone` / `pr checkout`
**`pkg/cmd/repo/repo.go:892` / `pkg/cmd/pr/pr.go:1009`**

API-returned clone URLs were passed to `git clone` / `git remote add` without protection against flag injection.

**Fix:** Added `--` separator in `runGitClone`, and URL prefix validation in PR checkout.

#### 6. `--token` Flag Exposes Credentials in Process List
**`pkg/cmd/auth/auth.go:76`**

`bkt auth login --token <value>` exposed the token in `ps aux`, `/proc/<pid>/cmdline`, and shell history.

**Fix:** Added a runtime warning when `--token` is used, and updated the flag description to recommend alternatives.

---

### Medium

#### 7. Unbounded `Retry-After` Sleep (DoS)
**`pkg/httpx/client.go:429-432`**

The `Retry-After` header value was trusted without an upper bound. A malicious server could hang the CLI indefinitely.

**Fix:** Capped `Retry-After` to a maximum of 60 seconds.

#### 8. Config File Token Persistence Risk
**`internal/config/config.go:43-48`**

While `MarshalYAML` correctly strips tokens on write, `yaml.Unmarshal` would silently read a token from `config.yml` if manually added, bypassing the keyring without warning.

**Fix:** Added a warning to stderr on config load when plaintext tokens are detected.

#### 9. Debug Mode URL Logging
**`pkg/httpx/client.go:233-234`** — Not modified; noted as lower priority since credentials are in headers not URLs.

---

## Files Changed

| File | Changes |
|------|---------|
| `pkg/cmd/extension/extension.go` | Path traversal validation, env filtering, git `--` separator |
| `pkg/cmdutil/url.go` | Reject `http://` by default, add `NormalizeBaseURLAllowHTTP` |
| `pkg/cmdutil/url_test.go` | Updated tests for new behavior, added `AllowHTTP` tests |
| `pkg/cmd/auth/auth.go` | `--allow-http` flag, `--token` warning |
| `pkg/cmd/repo/repo.go` | `--` separator in `git clone` |
| `pkg/cmd/pr/pr.go` | URL validation before `git remote add/set-url` |
| `pkg/httpx/client.go` | Cap `Retry-After` to 60s |
| `internal/config/config.go` | Warn on plaintext token in config |

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (including updated URL tests)
- [ ] `bkt extension remove "../../../tmp"` is rejected with error
- [ ] `bkt extension exec "../foo"` is rejected with error
- [ ] `bkt auth login http://example.com` fails without `--allow-http`
- [ ] `bkt auth login --allow-http http://example.com` works with warning
- [ ] `bkt auth login --token <value>` prints warning to stderr
- [ ] Extensions no longer see `BKT_TOKEN` in their environment
- [ ] `bkt repo clone` works normally with HTTPS/SSH URLs