### PR TITLE
feat(pr): add --with-default-reviewers flag (DC)

### DIFF
--- a/pkg/bbcloud/pullrequests.go
+++ b/pkg/bbcloud/pullrequests.go
@@ -254,6 +254,55 @@ func (c *Client) CreatePullRequest(ctx context.Context, workspace, repoSlug stri
 	return &pr, nil
 }
 
+// EffectiveDefaultReviewer represents a reviewer returned by the
+// effective-default-reviewers endpoint, which wraps each user in a nested object.
+type EffectiveDefaultReviewer struct {
+	User User `json:"user"`
+}
+
+// GetEffectiveDefaultReviewers returns the effective default reviewers for a repository.
+func (c *Client) GetEffectiveDefaultReviewers(ctx context.Context, workspace, repoSlug string) ([]User, error) {
+	if workspace == "" || repoSlug == "" {
+		return nil, fmt.Errorf("workspace and repository slug are required")
+	}
+
+	path := fmt.Sprintf("/repositories/%s/%s/effective-default-reviewers?pagelen=100",
+		url.PathEscape(workspace),
+		url.PathEscape(repoSlug),
+	)
+
+	var users []User
+	for path != "" {
+		req, err := c.http.NewRequest(ctx, "GET", path, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var page struct {
+			Values []EffectiveDefaultReviewer `json:"values"`
+			Next   string                     `json:"next"`
+		}
+		if err := c.http.Do(req, &page); err != nil {
+			return nil, err
+		}
+
+		for _, v := range page.Values {
+			users = append(users, v.User)
+		}
+
+		if page.Next == "" {
+			break
+		}
+		nextURL, err := url.Parse(page.Next)
+		if err != nil {
+			return nil, err
+		}
+		path = nextURL.RequestURI()
+	}
+
+	return users, nil
+}
+
 // UpdatePullRequestInput configures PR updates. Use pointers to distinguish
 // between "not set" and "set to empty string" for clearing fields.
 type UpdatePullRequestInput struct {

--- a/pkg/bbcloud/pullrequests_test.go
+++ b/pkg/bbcloud/pullrequests_test.go
@@ -542,3 +542,99 @@ func TestApprovePullRequestValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestGetEffectiveDefaultReviewers(t *testing.T) {
+	var gotMethod, gotPath string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"values": []map[string]any{
+				{"user": map[string]any{"username": "alice", "display_name": "Alice A", "uuid": "{aaa}"}},
+				{"user": map[string]any{"username": "bob", "display_name": "Bob B", "uuid": "{bbb}"}},
+			},
+		})
+	}))
+
+	users, err := client.GetEffectiveDefaultReviewers(context.Background(), "myworkspace", "my-repo")
+	if err != nil {
+		t.Fatalf("GetEffectiveDefaultReviewers: %v", err)
+	}
+	if gotMethod != "GET" {
+		t.Errorf("method = %s, want GET", gotMethod)
+	}
+	if gotPath != "/repositories/myworkspace/my-repo/effective-default-reviewers" {
+		t.Errorf("path = %q, want /repositories/myworkspace/my-repo/effective-default-reviewers", gotPath)
+	}
+	if len(users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(users))
+	}
+	if users[0].Username != "alice" {
+		t.Errorf("users[0].Username = %q, want alice", users[0].Username)
+	}
+	if users[0].Display != "Alice A" {
+		t.Errorf("users[0].Display = %q, want Alice A", users[0].Display)
+	}
+	if users[1].Username != "bob" {
+		t.Errorf("users[1].Username = %q, want bob", users[1].Username)
+	}
+}
+
+func TestGetEffectiveDefaultReviewersPagination(t *testing.T) {
+	calls := 0
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		if calls == 1 {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values": []map[string]any{
+					{"user": map[string]any{"username": "alice"}},
+				},
+				"next": "http://" + r.Host + "/repositories/ws/repo/effective-default-reviewers?pagelen=100&page=2",
+			})
+		} else {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values": []map[string]any{
+					{"user": map[string]any{"username": "bob"}},
+				},
+			})
+		}
+	}))
+
+	users, err := client.GetEffectiveDefaultReviewers(context.Background(), "ws", "repo")
+	if err != nil {
+		t.Fatalf("GetEffectiveDefaultReviewers: %v", err)
+	}
+	if len(users) != 2 {
+		t.Fatalf("expected 2 users across pages, got %d", len(users))
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 API calls for pagination, got %d", calls)
+	}
+}
+
+func TestGetEffectiveDefaultReviewersValidation(t *testing.T) {
+	client, err := bbcloud.New(bbcloud.Options{
+		BaseURL: "http://localhost", Username: "u", Token: "t",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name      string
+		workspace string
+		repo      string
+	}{
+		{"empty workspace", "", "repo"},
+		{"empty repo", "ws", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := client.GetEffectiveDefaultReviewers(context.Background(), tt.workspace, tt.repo)
+			if err == nil {
+				t.Error("expected error")
+			}
+		})
+	}
+}

--- a/pkg/bbdc/reviewers.go
+++ b/pkg/bbdc/reviewers.go
@@ -4,12 +4,38 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 )
 
 // ReviewerGroup represents a Bitbucket default reviewer group association.
 type ReviewerGroup struct {
 	Name string `json:"name"`
 	ID   int    `json:"id"`
+}
+
+type defaultReviewerCondition struct {
+	ID                int                       `json:"id"`
+	SourceRefMatcher  defaultReviewerRefMatcher `json:"sourceRefMatcher"`
+	TargetRefMatcher  defaultReviewerRefMatcher `json:"targetRefMatcher"`
+	Reviewers         []defaultReviewerGroup    `json:"reviewers"`
+	ReviewerGroups    []defaultReviewerGroup    `json:"reviewerGroups"`
+	RequiredApprovals int                       `json:"requiredApprovals"`
+}
+
+type defaultReviewerRefMatcher struct {
+	ID        string `json:"id"`
+	DisplayID string `json:"displayId"`
+	Type      struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"type"`
+}
+
+type defaultReviewerGroup struct {
+	ID          int64  `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Users       []User `json:"users"`
 }
 
 // ListReviewerGroups returns reviewer groups associated with a repository's default reviewers.
@@ -34,6 +60,58 @@ func (c *Client) ListReviewerGroups(ctx context.Context, projectKey, repoSlug st
 	}
 
 	return payload.Values, nil
+}
+
+// GetDefaultReviewers returns the users required as reviewers for a pull request
+// from sourceRef to targetRef in the given repository.
+func (c *Client) GetDefaultReviewers(ctx context.Context, projectKey, repoSlug, sourceRef, targetRef string) ([]User, error) {
+	if projectKey == "" || repoSlug == "" {
+		return nil, fmt.Errorf("project key and repository slug are required")
+	}
+
+	endpoint := fmt.Sprintf("/rest/default-reviewers/1.0/projects/%s/repos/%s/reviewers",
+		url.PathEscape(projectKey),
+		url.PathEscape(repoSlug),
+	)
+
+	params := url.Values{}
+	if sourceRef != "" {
+		params.Set("sourceRefId", normalizeRefID(sourceRef))
+	}
+	if targetRef != "" {
+		params.Set("targetRefId", normalizeRefID(targetRef))
+	}
+	if len(params) > 0 {
+		endpoint += "?" + params.Encode()
+	}
+
+	req, err := c.http.NewRequest(ctx, "GET", endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create default reviewers request: %w", err)
+	}
+
+	var conditions []defaultReviewerCondition
+	if err := c.http.Do(req, &conditions); err != nil {
+		return nil, fmt.Errorf("fetch default reviewers: %w", err)
+	}
+
+	reviewers := make([]User, 0)
+	seen := make(map[string]struct{})
+	for _, condition := range conditions {
+		groups := append([]defaultReviewerGroup{}, condition.Reviewers...)
+		groups = append(groups, condition.ReviewerGroups...)
+		for _, group := range groups {
+			for _, user := range group.Users {
+				if _, ok := seen[user.Name]; ok {
+					continue
+				}
+				seen[user.Name] = struct{}{}
+				reviewers = append(reviewers, user)
+			}
+		}
+	}
+
+	return reviewers, nil
 }
 
 // AddReviewerGroup adds a reviewer group to the repository default reviewers.
@@ -72,4 +150,11 @@ func (c *Client) RemoveReviewerGroup(ctx context.Context, projectKey, repoSlug, 
 		return err
 	}
 	return c.http.Do(req, nil)
+}
+
+func normalizeRefID(ref string) string {
+	if strings.HasPrefix(ref, "refs/") {
+		return ref
+	}
+	return "refs/heads/" + ref
 }

--- a/pkg/bbdc/reviewers_test.go
+++ b/pkg/bbdc/reviewers_test.go
@@ -1,0 +1,139 @@
+package bbdc_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/avivsinai/bitbucket-cli/pkg/bbdc"
+)
+
+func TestGetDefaultReviewers(t *testing.T) {
+	var gotMethod, gotPath, gotQuery string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"id": 1,
+				"sourceRefMatcher": map[string]any{
+					"id":        "refs/heads/feature/x",
+					"displayId": "feature/x",
+				},
+				"targetRefMatcher": map[string]any{
+					"id":        "refs/heads/main",
+					"displayId": "main",
+				},
+				"requiredApprovals": 1,
+				"reviewers": []map[string]any{
+					{
+						"id":   101,
+						"name": "backend-team",
+						"users": []map[string]any{
+							{"name": "alice", "slug": "alice", "id": 10, "displayName": "Alice"},
+							{"name": "bob", "slug": "bob", "id": 20, "displayName": "Bob"},
+						},
+					},
+				},
+			},
+		})
+	}))
+
+	users, err := client.GetDefaultReviewers(context.Background(), "PROJ", "my-repo", "feature/x", "main")
+	if err != nil {
+		t.Fatalf("GetDefaultReviewers: %v", err)
+	}
+	if gotMethod != "GET" {
+		t.Errorf("method = %s, want GET", gotMethod)
+	}
+	if gotPath != "/rest/default-reviewers/1.0/projects/PROJ/repos/my-repo/reviewers" {
+		t.Errorf("path = %q, want /rest/default-reviewers/1.0/projects/PROJ/repos/my-repo/reviewers", gotPath)
+	}
+	if gotQuery != "sourceRefId=refs%2Fheads%2Ffeature%2Fx&targetRefId=refs%2Fheads%2Fmain" {
+		t.Errorf("query = %q, want sourceRefId=refs%%2Fheads%%2Ffeature%%2Fx&targetRefId=refs%%2Fheads%%2Fmain", gotQuery)
+	}
+	if len(users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(users))
+	}
+	if users[0].Name != "alice" {
+		t.Errorf("users[0].Name = %q, want alice", users[0].Name)
+	}
+	if users[1].Name != "bob" {
+		t.Errorf("users[1].Name = %q, want bob", users[1].Name)
+	}
+}
+
+func TestGetDefaultReviewersDedup(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"id": 1,
+				"reviewers": []map[string]any{
+					{
+						"id":   101,
+						"name": "backend-team",
+						"users": []map[string]any{
+							{"name": "alice", "slug": "alice", "id": 10},
+							{"name": "bob", "slug": "bob", "id": 20},
+						},
+					},
+				},
+			},
+			{
+				"id": 2,
+				"reviewers": []map[string]any{
+					{
+						"id":   102,
+						"name": "frontend-team",
+						"users": []map[string]any{
+							{"name": "alice", "slug": "alice", "id": 10},
+							{"name": "charlie", "slug": "charlie", "id": 30},
+						},
+					},
+				},
+			},
+		})
+	}))
+
+	users, err := client.GetDefaultReviewers(context.Background(), "PROJ", "my-repo", "feature/x", "main")
+	if err != nil {
+		t.Fatalf("GetDefaultReviewers: %v", err)
+	}
+	if len(users) != 3 {
+		t.Fatalf("expected 3 users, got %d", len(users))
+	}
+	if users[0].Name != "alice" || users[1].Name != "bob" || users[2].Name != "charlie" {
+		t.Fatalf("unexpected user order/content: %#v", users)
+	}
+}
+
+func TestGetDefaultReviewersValidation(t *testing.T) {
+	client, err := bbdc.New(bbdc.Options{
+		BaseURL: "http://localhost", Username: "u", Token: "t",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		project string
+		repo    string
+	}{
+		{name: "empty project", project: "", repo: "repo"},
+		{name: "empty repo", project: "PROJ", repo: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := client.GetDefaultReviewers(context.Background(), tt.project, tt.repo, "feature/x", "main")
+			if err == nil {
+				t.Error("expected error")
+			}
+		})
+	}
+}

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -583,15 +583,38 @@ func firstPRLinkCloud(pr *bbcloud.PullRequest) string {
 }
 
 type createOptions struct {
-	Project     string
-	Workspace   string
-	Repo        string
-	Title       string
-	Source      string
-	Target      string
-	Description string
-	Reviewers   []string
-	CloseSource bool
+	Project              string
+	Workspace            string
+	Repo                 string
+	Title                string
+	Source               string
+	Target               string
+	Description          string
+	Reviewers            []string
+	CloseSource          bool
+	WithDefaultReviewers bool
+}
+
+// mergeReviewers combines explicit reviewer names with default reviewer users,
+// deduplicating across both lists. The nameFunc extracts a username string
+// from each default user value.
+func mergeReviewers[T any](explicit []string, defaults []T, nameFunc func(T) string) []string {
+	seen := make(map[string]bool, len(explicit)+len(defaults))
+	var merged []string
+	for _, r := range explicit {
+		if r != "" && !seen[r] {
+			seen[r] = true
+			merged = append(merged, r)
+		}
+	}
+	for _, u := range defaults {
+		name := nameFunc(u)
+		if name != "" && !seen[name] {
+			seen[name] = true
+			merged = append(merged, name)
+		}
+	}
+	return merged
 }
 
 func newCreateCmd(f *cmdutil.Factory) *cobra.Command {
@@ -613,6 +636,7 @@ func newCreateCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&opts.Target, "target", "", "Target branch (required)")
 	cmd.Flags().StringSliceVar(&opts.Reviewers, "reviewer", nil, "Reviewers to request (repeatable)")
 	cmd.Flags().BoolVar(&opts.CloseSource, "close-source", false, "Close source branch on merge")
+	cmd.Flags().BoolVar(&opts.WithDefaultReviewers, "with-default-reviewers", false, "Add repository default reviewers (Data Center only)")
 
 	_ = cmd.MarkFlagRequired("title")
 	_ = cmd.MarkFlagRequired("source")
@@ -649,12 +673,21 @@ func runCreate(cmd *cobra.Command, f *cmdutil.Factory, opts *createOptions) erro
 		ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
 		defer cancel()
 
+		reviewers := opts.Reviewers
+		if opts.WithDefaultReviewers {
+			defaultUsers, err := client.GetDefaultReviewers(ctx, projectKey, repoSlug, opts.Source, opts.Target)
+			if err != nil {
+				return fmt.Errorf("fetching default reviewers: %w", err)
+			}
+			reviewers = mergeReviewers(reviewers, defaultUsers, func(u bbdc.User) string { return u.Name })
+		}
+
 		pr, err := client.CreatePullRequest(ctx, projectKey, repoSlug, bbdc.CreatePROptions{
 			Title:        opts.Title,
 			Description:  opts.Description,
 			SourceBranch: opts.Source,
 			TargetBranch: opts.Target,
-			Reviewers:    opts.Reviewers,
+			Reviewers:    reviewers,
 			CloseSource:  opts.CloseSource,
 		})
 		if err != nil {
@@ -680,6 +713,10 @@ func runCreate(cmd *cobra.Command, f *cmdutil.Factory, opts *createOptions) erro
 
 		ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
 		defer cancel()
+
+		if opts.WithDefaultReviewers {
+			return fmt.Errorf("--with-default-reviewers is not yet supported for Bitbucket Cloud (see https://github.com/avivsinai/bitbucket-cli/issues/67)")
+		}
 
 		pr, err := client.CreatePullRequest(ctx, workspace, repoSlug, bbcloud.CreatePullRequestInput{
 			Title:       opts.Title,

--- a/pkg/cmd/pr/pr_test.go
+++ b/pkg/cmd/pr/pr_test.go
@@ -2895,3 +2895,75 @@ func TestListWorkspaceCloudURLFallback(t *testing.T) {
 		t.Errorf("PR without slug should fallback to URL parsing and show 'repo-from-url', got:\n%s", output)
 	}
 }
+
+func TestMergeReviewers(t *testing.T) {
+	type user struct{ Name string }
+	nameFunc := func(u user) string { return u.Name }
+
+	tests := []struct {
+		name     string
+		explicit []string
+		defaults []user
+		want     []string
+	}{
+		{
+			name:     "no defaults",
+			explicit: []string{"alice"},
+			defaults: nil,
+			want:     []string{"alice"},
+		},
+		{
+			name:     "no explicit",
+			explicit: nil,
+			defaults: []user{{"alice"}, {"bob"}},
+			want:     []string{"alice", "bob"},
+		},
+		{
+			name:     "dedup overlap",
+			explicit: []string{"alice", "charlie"},
+			defaults: []user{{"alice"}, {"bob"}},
+			want:     []string{"alice", "charlie", "bob"},
+		},
+		{
+			name:     "both empty",
+			explicit: nil,
+			defaults: nil,
+			want:     nil,
+		},
+		{
+			name:     "skip empty username",
+			explicit: nil,
+			defaults: []user{{"alice"}, {""}},
+			want:     []string{"alice"},
+		},
+		{
+			name:     "dedup explicit duplicates",
+			explicit: []string{"alice", "alice", "bob"},
+			defaults: nil,
+			want:     []string{"alice", "bob"},
+		},
+		{
+			name:     "dedup across both",
+			explicit: []string{"alice", "alice"},
+			defaults: []user{{"alice"}, {"bob"}, {"bob"}},
+			want:     []string{"alice", "bob"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeReviewers(tt.explicit, tt.defaults, nameFunc)
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("mergeReviewers() = %v, want %v", got, tt.want)
+			}
+			for i, v := range got {
+				if v != tt.want[i] {
+					t.Errorf("mergeReviewers()[%d] = %q, want %q", i, v, tt.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `--with-default-reviewers` flag to `bkt pr create` that automatically fetches and merges repository default reviewers
- **Data Center**: Properly unmarshals `RestPullRequestCondition[]` responses, flattens nested reviewer groups/users, normalizes branch names to full ref IDs, and deduplicates across conditions and explicit `--reviewer` values
- **Cloud**: Returns explicit unsupported error pending UUID-based reviewer identity migration. Client implementation (`GetEffectiveDefaultReviewers`) is in place and tested for follow-up work
- Generic `mergeReviewers` helper with full deduplication (including explicit reviewer duplicates)

Supersedes #68 by @jenspalmqvist — thanks for the original contribution!

Refs #67

## Test plan
- [x] `go test ./...` passes (all packages)
- [x] DC client tests with docs-shaped `RestPullRequestCondition` payloads
- [x] DC deduplication test (same user across multiple conditions)
- [x] DC validation tests (empty project/repo)
- [x] DC ref normalization (short branch names → `refs/heads/...`)
- [x] Cloud `GetEffectiveDefaultReviewers` tests (nested user, pagination, validation)
- [x] `mergeReviewers` table-driven tests (7 cases)
- [ ] Cloud `--with-default-reviewers` returns explicit error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Reviewed by Codex (staff engineer)