### PR TITLE
fix(security): harden auth, git, and extensions

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,6 +91,11 @@ func Load() (*Config, error) {
 	if cfg.Hosts == nil {
 		cfg.Hosts = make(map[string]*Host)
 	}
+	for key, host := range cfg.Hosts {
+		if host != nil && host.Token != "" {
+			fmt.Fprintf(os.Stderr, "WARNING: host %q has a plaintext token in %s; rerun `bkt auth login` to move it into secure storage and remove the token field from config.yml\n", key, path)
+		}
+	}
 
 	return cfg, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -309,6 +310,54 @@ func TestLoadInitializesNilMaps(t *testing.T) {
 	}
 	if cfg.Hosts == nil {
 		t.Fatal("expected Hosts to be initialized")
+	}
+}
+
+func TestLoadWarnsOnPlaintextToken(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BKT_CONFIG_DIR", dir)
+
+	data := strings.Join([]string{
+		"version: 1",
+		"hosts:",
+		"  main:",
+		"    kind: dc",
+		"    base_url: https://bitbucket.example.com",
+		"    username: admin",
+		"    token: plaintext-token",
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(dir, "config.yml"), []byte(data), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() {
+		os.Stderr = oldStderr
+	})
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	warning, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if cfg.Hosts["main"].Token != "plaintext-token" {
+		t.Fatalf("expected token to be loaded from config, got %q", cfg.Hosts["main"].Token)
+	}
+	if !strings.Contains(string(warning), `WARNING: host "main" has a plaintext token`) {
+		t.Fatalf("expected plaintext-token warning, got %q", string(warning))
 	}
 }
 

--- a/pkg/bbcloud/client_test.go
+++ b/pkg/bbcloud/client_test.go
@@ -358,6 +358,21 @@ func newTestClient(t *testing.T, handler http.Handler) *Client {
 	return client
 }
 
+func newTestClientWithBasePath(t *testing.T, basePath string, handler http.Handler) *Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{
+		BaseURL: server.URL + basePath,
+		Retry:   httpx.RetryPolicy{MaxAttempts: 1},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return client
+}
+
 func TestNewDefaultsBaseURL(t *testing.T) {
 	client, err := New(Options{})
 	if err != nil {
@@ -677,6 +692,39 @@ func TestCurrentUser(t *testing.T) {
 	}
 	if user.Username != "admin" {
 		t.Fatalf("expected admin, got %q", user.Username)
+	}
+}
+
+func TestCurrentUserPreservesVersionedBasePath(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/2.0/user" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(User{Username: "admin", Display: "Admin User"})
+	})
+
+	client := newTestClientWithBasePath(t, "/2.0", handler)
+	user, err := client.CurrentUser(context.Background())
+	if err != nil {
+		t.Fatalf("CurrentUser: %v", err)
+	}
+	if user.Username != "admin" {
+		t.Fatalf("expected admin, got %q", user.Username)
+	}
+}
+
+func TestPingPreservesVersionedBasePath(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/2.0/user" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	client := newTestClientWithBasePath(t, "/2.0", handler)
+	if err := client.Ping(context.Background()); err != nil {
+		t.Fatalf("Ping: %v", err)
 	}
 }
 

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -51,6 +51,7 @@ type loginOptions struct {
 	Username           string
 	Token              string
 	AllowInsecureStore bool
+	AllowHTTP          bool
 	Web                bool
 }
 
@@ -73,8 +74,9 @@ func newLoginCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.Flags().StringVar(&opts.Kind, "kind", opts.Kind, "Bitbucket deployment kind (dc or cloud)")
 	cmd.Flags().StringVar(&opts.Username, "username", "", "Username (DC: PAT owner, Cloud: Atlassian email for API tokens)")
-	cmd.Flags().StringVar(&opts.Token, "token", "", "Authentication token (DC: PAT, Cloud: API token)")
+	cmd.Flags().StringVar(&opts.Token, "token", "", "Authentication token (DC: PAT, Cloud: API token). WARNING: visible in process list and shell history; prefer the interactive prompt")
 	cmd.Flags().BoolVar(&opts.AllowInsecureStore, "allow-insecure-store", false, "Allow encrypted fallback secret storage when no OS keychain is available")
+	cmd.Flags().BoolVar(&opts.AllowHTTP, "allow-http", false, "Allow http:// URLs for login even though credentials will be sent in plaintext")
 	cmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open browser to create token, then prompt for credentials")
 
 	return cmd
@@ -105,6 +107,19 @@ func runLogin(cmd *cobra.Command, f *cmdutil.Factory, opts *loginOptions) error 
 	baseURL, err := cmdutil.NormalizeBaseURL(opts.Host)
 	if err != nil {
 		return err
+	}
+	if strings.HasPrefix(baseURL, "http://") {
+		if !opts.AllowHTTP {
+			return fmt.Errorf("http:// URLs are not allowed by default; rerun with --allow-http if you understand the credentials will be sent in plaintext")
+		}
+		if _, err := fmt.Fprintln(ios.ErrOut, "WARNING: using http:// will send credentials in plaintext"); err != nil {
+			return err
+		}
+	}
+	if opts.Token != "" {
+		if _, err := fmt.Fprintln(ios.ErrOut, "WARNING: --token is visible in process listings and shell history; prefer the interactive prompt"); err != nil {
+			return err
+		}
 	}
 
 	kind := strings.ToLower(opts.Kind)

--- a/pkg/cmd/auth/auth_test.go
+++ b/pkg/cmd/auth/auth_test.go
@@ -56,6 +56,28 @@ func TestLoginFlagHelpTextNoAppPassword(t *testing.T) {
 	}
 }
 
+func TestLoginFlagHelpTextWarnsAboutTokenExposure(t *testing.T) {
+	cfg := &config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	}
+	f, _, _ := newAuthTestFactory(cfg)
+
+	cmd := newLoginCmd(f)
+
+	tokenFlag := cmd.Flag("token")
+	if tokenFlag == nil {
+		t.Fatal("expected --token flag")
+	}
+	if !strings.Contains(tokenFlag.Usage, "process list") {
+		t.Fatalf("--token flag should warn about process-list exposure, got: %s", tokenFlag.Usage)
+	}
+
+	if cmd.Flag("allow-http") == nil {
+		t.Fatal("expected --allow-http flag")
+	}
+}
+
 func TestCloudLoginPromptsNoAppPassword(t *testing.T) {
 	// Verify that the cloud login prompt constants don't mention "app password".
 	// This ensures users aren't confused by old terminology since Bitbucket Cloud
@@ -117,6 +139,70 @@ func TestRunLogoutBlockedWhenEnvTokenSet(t *testing.T) {
 	want := "BKT_TOKEN environment variable is set; token is externally managed. Unset BKT_TOKEN to use auth logout"
 	if err.Error() != want {
 		t.Fatalf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestRunLoginRejectsHTTPWithoutAllowHTTP(t *testing.T) {
+	cfg := &config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	}
+	f, _, _ := newAuthTestFactory(cfg)
+
+	err := runLogin(&cobra.Command{}, f, &loginOptions{Host: "http://bitbucket.example.com"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	want := "http:// URLs are not allowed by default; rerun with --allow-http if you understand the credentials will be sent in plaintext"
+	if err.Error() != want {
+		t.Fatalf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestRunLoginWarnsOnTokenFlag(t *testing.T) {
+	cfg := &config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	}
+	f, _, stderr := newAuthTestFactory(cfg)
+
+	err := runLogin(&cobra.Command{}, f, &loginOptions{
+		Host:  "https://bitbucket.example.com",
+		Token: "secret-token",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err.Error() != "username is required when not running in a TTY" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(stderr.String(), "WARNING: --token is visible in process listings and shell history") {
+		t.Fatalf("expected token warning, got stderr:\n%s", stderr.String())
+	}
+}
+
+func TestRunLoginWarnsOnAllowHTTP(t *testing.T) {
+	cfg := &config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	}
+	f, _, stderr := newAuthTestFactory(cfg)
+
+	err := runLogin(&cobra.Command{}, f, &loginOptions{
+		Host:      "http://bitbucket.example.com",
+		AllowHTTP: true,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err.Error() != "username is required when not running in a TTY" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(stderr.String(), "WARNING: using http:// will send credentials in plaintext") {
+		t.Fatalf("expected http warning, got stderr:\n%s", stderr.String())
 	}
 }
 

--- a/pkg/cmd/extension/extension.go
+++ b/pkg/cmd/extension/extension.go
@@ -15,6 +15,39 @@ import (
 	"github.com/avivsinai/bitbucket-cli/pkg/cmdutil"
 )
 
+var sensitiveEnvPrefixes = []string{
+	"BKT_TOKEN=",
+	"BKT_KEYRING_PASSPHRASE=",
+	"BKT_ALLOW_INSECURE_STORE=",
+}
+
+func validateExtensionName(name string) error {
+	if name == "" {
+		return fmt.Errorf("extension name is required")
+	}
+	if strings.Contains(name, "/") || strings.Contains(name, "\\") || strings.Contains(name, "..") {
+		return fmt.Errorf("invalid extension name %q: must not contain path separators or '..'", name)
+	}
+	return nil
+}
+
+func filterSensitiveEnv() []string {
+	var filtered []string
+	for _, env := range os.Environ() {
+		sensitive := false
+		for _, prefix := range sensitiveEnvPrefixes {
+			if strings.HasPrefix(env, prefix) {
+				sensitive = true
+				break
+			}
+		}
+		if !sensitive {
+			filtered = append(filtered, env)
+		}
+	}
+	return filtered
+}
+
 // NewCmdExtension manages external bkt extensions.
 func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
@@ -100,7 +133,7 @@ func runExtensionInstall(cmd *cobra.Command, f *cmdutil.Factory, repo string) er
 		return fmt.Errorf("extension %q is already installed", name)
 	}
 
-	args := []string{"clone", repo, destination}
+	args := []string{"clone", "--", repo, destination}
 	gitCmd := exec.CommandContext(cmd.Context(), "git", args...)
 	gitCmd.Stdout = ios.Out
 	gitCmd.Stderr = ios.ErrOut
@@ -198,6 +231,10 @@ func runExtensionList(cmd *cobra.Command, f *cmdutil.Factory) error {
 }
 
 func runExtensionRemove(cmd *cobra.Command, f *cmdutil.Factory, name string) error {
+	if err := validateExtensionName(name); err != nil {
+		return err
+	}
+
 	ios, err := f.Streams()
 	if err != nil {
 		return err
@@ -226,6 +263,10 @@ func runExtensionRemove(cmd *cobra.Command, f *cmdutil.Factory, name string) err
 }
 
 func runExtensionExec(cmd *cobra.Command, f *cmdutil.Factory, name string, args []string) error {
+	if err := validateExtensionName(name); err != nil {
+		return err
+	}
+
 	ios, err := f.Streams()
 	if err != nil {
 		return err
@@ -254,7 +295,7 @@ func runExtensionExec(cmd *cobra.Command, f *cmdutil.Factory, name string, args 
 	cmdExec.Stderr = ios.ErrOut
 	cmdExec.Stdin = ios.In
 	cmdExec.Dir = dir
-	cmdExec.Env = append(os.Environ(),
+	cmdExec.Env = append(filterSensitiveEnv(),
 		fmt.Sprintf("BKT_EXTENSION_DIR=%s", dir),
 		fmt.Sprintf("BKT_EXTENSION_NAME=%s", name),
 	)

--- a/pkg/cmd/extension/extension_test.go
+++ b/pkg/cmd/extension/extension_test.go
@@ -1,0 +1,240 @@
+package extension
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/avivsinai/bitbucket-cli/internal/config"
+	"github.com/avivsinai/bitbucket-cli/pkg/cmdutil"
+	"github.com/avivsinai/bitbucket-cli/pkg/iostreams"
+)
+
+func TestValidateExtensionName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{name: "accepts simple name", input: "demo"},
+		{name: "accepts dots", input: "demo.v2"},
+		{name: "rejects slash", input: "demo/test", wantErr: `invalid extension name "demo/test": must not contain path separators or '..'`},
+		{name: "rejects backslash", input: `demo\test`, wantErr: `invalid extension name "demo\\test": must not contain path separators or '..'`},
+		{name: "rejects traversal", input: "../demo", wantErr: `invalid extension name "../demo": must not contain path separators or '..'`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateExtensionName(tt.input)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateExtensionName returned error: %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if err.Error() != tt.wantErr {
+				t.Fatalf("error = %q, want %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRunExtensionRemoveRejectsTraversalName(t *testing.T) {
+	err := runExtensionRemove(&cobra.Command{}, nil, "../demo")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err.Error() != `invalid extension name "../demo": must not contain path separators or '..'` {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunExtensionExecRejectsTraversalName(t *testing.T) {
+	err := runExtensionExec(&cobra.Command{}, nil, "../demo", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err.Error() != `invalid extension name "../demo": must not contain path separators or '..'` {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunExtensionInstallUsesDoubleDash(t *testing.T) {
+	f, _, stderr := newExtensionTestFactory(t)
+	helperDir := t.TempDir()
+	argsFile := filepath.Join(helperDir, "git-args.txt")
+
+	t.Setenv("EXTENSION_GIT_ARGS_FILE", argsFile)
+	t.Setenv("PATH", helperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	writeGitHelperScript(t, filepath.Join(helperDir, gitHelperName()))
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+
+	if err := runExtensionInstall(cmd, f, "--upload-pack=evil"); err != nil {
+		t.Fatalf("runExtensionInstall returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", argsFile, err)
+	}
+
+	got := strings.Split(strings.TrimSpace(string(data)), "\n")
+	want := []string{"clone", "--", "--upload-pack=evil", filepath.Join(extensionParentRootForTest(f), "--upload-pack=evil")}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("git args = %#v, want %#v", got, want)
+	}
+	if !strings.Contains(stderr.String(), "warning:") {
+		t.Fatalf("expected missing-executable warning, got stderr:\n%s", stderr.String())
+	}
+}
+
+func TestRunExtensionExecFiltersSensitiveEnv(t *testing.T) {
+	f, stdout, _ := newExtensionTestFactory(t)
+	cfg, err := f.ResolveConfig()
+	if err != nil {
+		t.Fatalf("ResolveConfig: %v", err)
+	}
+
+	t.Setenv("GO_WANT_EXTENSION_HELPER_PROCESS", "1")
+	t.Setenv("BKT_TOKEN", "secret-token")
+	t.Setenv("BKT_KEYRING_PASSPHRASE", "secret-passphrase")
+	t.Setenv("BKT_ALLOW_INSECURE_STORE", "1")
+
+	helperPath := filepath.Join(extensionRootForTest(cfg), helperExecutableName("demo"))
+	if err := os.MkdirAll(filepath.Dir(helperPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	copyTestBinary(t, helperPath)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+
+	err = runExtensionExec(cmd, f, "demo", []string{"-test.run=TestExtensionHelperProcess"})
+	if err != nil {
+		t.Fatalf("runExtensionExec returned error: %v", err)
+	}
+
+	got := strings.TrimSpace(stdout.String())
+	if got != "|||demo" {
+		t.Fatalf("stdout = %q, want %q", got, "|||demo")
+	}
+}
+
+func TestExtensionHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_EXTENSION_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	fmt.Printf("%s|%s|%s|%s",
+		os.Getenv("BKT_TOKEN"),
+		os.Getenv("BKT_KEYRING_PASSPHRASE"),
+		os.Getenv("BKT_ALLOW_INSECURE_STORE"),
+		os.Getenv("BKT_EXTENSION_NAME"),
+	)
+	os.Exit(0)
+}
+
+func newExtensionTestFactory(t *testing.T) (*cmdutil.Factory, *strings.Builder, *strings.Builder) {
+	t.Helper()
+
+	cfgDir := t.TempDir()
+	t.Setenv("BKT_CONFIG_DIR", cfgDir)
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+
+	var stdout, stderr strings.Builder
+	f := &cmdutil.Factory{
+		ExecutableName: "bkt",
+		IOStreams: &iostreams.IOStreams{
+			Out:    &stdout,
+			ErrOut: &stderr,
+			In:     io.NopCloser(strings.NewReader("")),
+		},
+		Config: func() (*config.Config, error) {
+			return cfg, nil
+		},
+	}
+
+	return f, &stdout, &stderr
+}
+
+func extensionRootForTest(cfg *config.Config) string {
+	return filepath.Join(filepath.Dir(cfg.Path()), "extensions", "demo")
+}
+
+func extensionParentRootForTest(f *cmdutil.Factory) string {
+	cfg, err := f.ResolveConfig()
+	if err != nil {
+		panic(err)
+	}
+	return filepath.Join(filepath.Dir(cfg.Path()), "extensions")
+}
+
+func helperExecutableName(name string) string {
+	if runtime.GOOS == "windows" {
+		return "bkt-" + name + ".exe"
+	}
+	return "bkt-" + name
+}
+
+func copyTestBinary(t *testing.T, target string) {
+	t.Helper()
+
+	src, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", src, err)
+	}
+
+	mode := os.FileMode(0o755)
+	if runtime.GOOS == "windows" {
+		mode = 0o644
+	}
+	if err := os.WriteFile(target, data, mode); err != nil {
+		t.Fatalf("WriteFile(%s): %v", target, err)
+	}
+}
+
+func writeGitHelperScript(t *testing.T, target string) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		script := "@echo off\r\n(\r\nfor %%a in (%*) do echo %%a\r\n) > \"%EXTENSION_GIT_ARGS_FILE%\"\r\n"
+		if err := os.WriteFile(target, []byte(script), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", target, err)
+		}
+		return
+	}
+
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$EXTENSION_GIT_ARGS_FILE\"\n"
+	if err := os.WriteFile(target, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(%s): %v", target, err)
+	}
+}
+
+func gitHelperName() string {
+	if runtime.GOOS == "windows" {
+		return "git.bat"
+	}
+	return "git"
+}

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -1023,6 +1023,9 @@ func runCheckout(cmd *cobra.Command, f *cmdutil.Factory, opts *checkoutOptions) 
 					"cannot checkout fork-based PR #%d: source repository %q has no clone URL available%s",
 					opts.ID, pr.Source.Repository.FullName, hint)
 			}
+			if err := cmdutil.ValidateGitPositionalArg(forkCloneURL, "fork clone URL"); err != nil {
+				return err
+			}
 
 			// Reuse an existing remote if one already points to the fork.
 			if existing := findRemoteByURL(cmd.Context(), forkCloneURL); existing != "" {

--- a/pkg/cmd/repo/repo.go
+++ b/pkg/cmd/repo/repo.go
@@ -889,7 +889,7 @@ func selectCloneURLCloud(repo bbcloud.Repository, useSSH bool) (string, error) {
 }
 
 func runGitClone(cmd *cobra.Command, out, errOut io.Writer, in io.Reader, cloneURL, dest string) error {
-	args := []string{"clone", cloneURL}
+	args := []string{"clone", "--", cloneURL}
 	if dest != "" {
 		args = append(args, dest)
 	}

--- a/pkg/cmd/repo/repo_git_test.go
+++ b/pkg/cmd/repo/repo_git_test.go
@@ -1,0 +1,65 @@
+package repo
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestRunGitCloneUsesDoubleDash(t *testing.T) {
+	helperDir := t.TempDir()
+	argsFile := filepath.Join(helperDir, "git-args.txt")
+
+	t.Setenv("REPO_GIT_ARGS_FILE", argsFile)
+	t.Setenv("PATH", helperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	writeGitHelperScript(t, filepath.Join(helperDir, gitHelperName()))
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	err := runGitClone(cmd, os.Stdout, os.Stderr, strings.NewReader(""), "https://bitbucket.example.com/scm/PROJ/repo.git", "target-dir")
+	if err != nil {
+		t.Fatalf("runGitClone returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", argsFile, err)
+	}
+
+	got := strings.Split(strings.TrimSpace(string(data)), "\n")
+	want := []string{"clone", "--", "https://bitbucket.example.com/scm/PROJ/repo.git", "target-dir"}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("git args = %#v, want %#v", got, want)
+	}
+}
+
+func writeGitHelperScript(t *testing.T, target string) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		script := "@echo off\r\n(\r\nfor %%a in (%*) do echo %%a\r\n) > \"%REPO_GIT_ARGS_FILE%\"\r\n"
+		if err := os.WriteFile(target, []byte(script), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", target, err)
+		}
+		return
+	}
+
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$REPO_GIT_ARGS_FILE\"\n"
+	if err := os.WriteFile(target, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(%s): %v", target, err)
+	}
+}
+
+func gitHelperName() string {
+	if runtime.GOOS == "windows" {
+		return "git.bat"
+	}
+	return "git"
+}

--- a/pkg/cmdutil/git.go
+++ b/pkg/cmdutil/git.go
@@ -1,0 +1,19 @@
+package cmdutil
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidateGitPositionalArg rejects values that git would parse as flags when
+// passed to subcommands that do not support a "--" separator.
+func ValidateGitPositionalArg(value, description string) error {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return fmt.Errorf("%s is required", description)
+	}
+	if strings.HasPrefix(trimmed, "-") {
+		return fmt.Errorf("invalid %s %q: must not start with '-'", description, value)
+	}
+	return nil
+}

--- a/pkg/cmdutil/git_test.go
+++ b/pkg/cmdutil/git_test.go
@@ -1,0 +1,49 @@
+package cmdutil
+
+import "testing"
+
+func TestValidateGitPositionalArg(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       string
+		description string
+		wantErr     string
+	}{
+		{
+			name:        "accepts normal url",
+			value:       "https://bitbucket.example.com/scm/PROJ/repo.git",
+			description: "clone URL",
+		},
+		{
+			name:        "rejects empty value",
+			value:       "",
+			description: "repository",
+			wantErr:     "repository is required",
+		},
+		{
+			name:        "rejects option like value",
+			value:       "--upload-pack=evil",
+			description: "fork clone URL",
+			wantErr:     `invalid fork clone URL "--upload-pack=evil": must not start with '-'`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateGitPositionalArg(tt.value, tt.description)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateGitPositionalArg returned error: %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if err.Error() != tt.wantErr {
+				t.Fatalf("error = %q, want %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/httpx/client.go
+++ b/pkg/httpx/client.go
@@ -412,11 +412,7 @@ func (c *Client) shouldRetry(attempts int, status int) bool {
 	return attempts+1 < c.retry.MaxAttempts
 }
 
-func (c *Client) backoff(ctx context.Context, attempts int, resp *http.Response) (bool, error) {
-	if attempts >= c.retry.MaxAttempts {
-		return false, nil
-	}
-
+func (c *Client) retryDelay(attempts int, resp *http.Response) time.Duration {
 	delay := c.retry.InitialBackoff
 	if attempts > 1 {
 		delay *= time.Duration(1 << (attempts - 1))
@@ -428,10 +424,26 @@ func (c *Client) backoff(ctx context.Context, attempts int, resp *http.Response)
 	if resp != nil {
 		if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
 			if secs, err := strconv.Atoi(retryAfter); err == nil {
-				delay = time.Duration(secs) * time.Second
+				retryAfterDelay := time.Duration(secs) * time.Second
+				if retryAfterDelay > 60*time.Second {
+					retryAfterDelay = 60 * time.Second
+				}
+				if retryAfterDelay > 0 {
+					delay = retryAfterDelay
+				}
 			}
 		}
 	}
+
+	return delay
+}
+
+func (c *Client) backoff(ctx context.Context, attempts int, resp *http.Response) (bool, error) {
+	if attempts >= c.retry.MaxAttempts {
+		return false, nil
+	}
+
+	delay := c.retryDelay(attempts, resp)
 
 	if delay <= 0 {
 		select {

--- a/pkg/httpx/client_test.go
+++ b/pkg/httpx/client_test.go
@@ -665,6 +665,54 @@ func TestClientRetriesOn429(t *testing.T) {
 	}
 }
 
+func TestRetryDelayCapsRetryAfter(t *testing.T) {
+	client, err := New(Options{
+		BaseURL: "https://example.com",
+		Retry: RetryPolicy{
+			MaxAttempts:    3,
+			InitialBackoff: 10 * time.Millisecond,
+			MaxBackoff:     20 * time.Millisecond,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	resp := &http.Response{
+		Header: http.Header{
+			"Retry-After": []string{"3600"},
+		},
+	}
+
+	if got := client.retryDelay(0, resp); got != 60*time.Second {
+		t.Fatalf("retryDelay = %v, want %v", got, 60*time.Second)
+	}
+}
+
+func TestRetryDelayIgnoresNonPositiveRetryAfter(t *testing.T) {
+	client, err := New(Options{
+		BaseURL: "https://example.com",
+		Retry: RetryPolicy{
+			MaxAttempts:    3,
+			InitialBackoff: 10 * time.Millisecond,
+			MaxBackoff:     20 * time.Millisecond,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	resp := &http.Response{
+		Header: http.Header{
+			"Retry-After": []string{"0"},
+		},
+	}
+
+	if got := client.retryDelay(0, resp); got != 10*time.Millisecond {
+		t.Fatalf("retryDelay = %v, want %v", got, 10*time.Millisecond)
+	}
+}
+
 func TestShouldRetryStatus(t *testing.T) {
 	tests := []struct {
 		code int


### PR DESCRIPTION
## Summary

This hardening pass brings in the validated parts of the open security report while keeping behavior compatible with existing host and auth flows.

- harden git invocation boundaries for clone and fork-remote operations
- block extension traversal in `remove`/`exec` and strip sensitive env from extension subprocesses
- add `auth login` warnings for `--token` and explicit opt-in for `http://` login
- cap `Retry-After` backoff to 60 seconds
- warn when plaintext tokens are loaded from `config.yml`
- add regression coverage proving Bitbucket Cloud user requests preserve `/2.0`

## Notes

- Issue `#70` turned out to be stale on current `master`: the Cloud client already resolves `"/user"` against a `/2.0` base URL correctly. This PR adds regression tests for that behavior.
- This work supersedes the mergeable parts of external PR `#69`, but re-implements them in narrower, reviewed changes.

## Testing

- `go test ./...`
- `go test ./internal/config ./pkg/bbcloud ./pkg/httpx ./pkg/cmd/auth ./pkg/cmdutil ./pkg/cmd/extension ./pkg/cmd/repo ./pkg/cmd/pr`
- Attempted `go test -race` on the changed package set, but the local machine ran out of disk space during link (`no space left on device`)
