### PR TITLE
fix(ci): bump Go version to 1.25 to match go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: Verify gofmt
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: Install Syft
         run: brew install syft


### PR DESCRIPTION
## Summary

- Bump `actions/setup-go` from Go 1.24 to 1.25 in CI and release workflows
- Required after #79 merged `golang.org/x/term v0.41.0` which declares `go 1.25.0` in its module

## Test plan

- [ ] CI build job passes with Go 1.25
- [ ] Release workflow validates (no tag push needed to verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)