### PR TITLE
feat: add created_on and updated_on timestamps to PR list output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+- `created_on` and `updated_on` timestamp fields to `PullRequest` structs for both Bitbucket Cloud and Data Center.
+- `bkt pr list` output now includes the creation timestamp in the format `YYYY-MM-DD HH:MM` for both Cloud and Data Center PR listings.
+
 ## [0.16.4] - 2026-04-02
 ### Fixed
 - Passed the temp release-notes path directly to GoReleaser so GitHub Actions preserves the `--release-notes` argument during publishing.

--- a/pkg/bbcloud/pullrequests.go
+++ b/pkg/bbcloud/pullrequests.go
@@ -28,10 +28,12 @@ type RepositoryRef struct {
 
 // PullRequest models a Bitbucket Cloud pull request.
 type PullRequest struct {
-	ID     int    `json:"id"`
-	Title  string `json:"title"`
-	State  string `json:"state"`
-	Author struct {
+	ID        int    `json:"id"`
+	Title     string `json:"title"`
+	State     string `json:"state"`
+	CreatedOn string `json:"created_on"`
+	UpdatedOn string `json:"updated_on"`
+	Author    struct {
 		DisplayName string `json:"display_name"`
 		Username    string `json:"username"`
 	} `json:"author"`

--- a/pkg/bbdc/client.go
+++ b/pkg/bbdc/client.go
@@ -99,6 +99,8 @@ type PullRequest struct {
 	Description string `json:"description"`
 	State       string `json:"state"`
 	Version     int    `json:"version"`
+	CreatedDate int64  `json:"createdDate"`
+	UpdatedDate int64  `json:"updatedDate"`
 	Author      struct {
 		User User `json:"user"`
 	} `json:"author"`

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -162,7 +162,8 @@ func runList(cmd *cobra.Command, f *cmdutil.Factory, opts *listOptions) error {
 
 			for _, pr := range prs {
 				author := cmdutil.FirstNonEmpty(pr.Author.User.FullName, pr.Author.User.Name)
-				if _, err := fmt.Fprintf(ios.Out, "#%d\t%-8s\t%s\n", pr.ID, pr.State, pr.Title); err != nil {
+				created := time.UnixMilli(pr.CreatedDate).Format("2006-01-02 15:04")
+				if _, err := fmt.Fprintf(ios.Out, "#%d\t%-8s\t%s\t%s\n", pr.ID, pr.State, created, pr.Title); err != nil {
 					return err
 				}
 				if _, err := fmt.Fprintf(ios.Out, "    %s -> %s\tby %s\n", pr.FromRef.DisplayID, pr.ToRef.DisplayID, author); err != nil {
@@ -227,7 +228,9 @@ func runList(cmd *cobra.Command, f *cmdutil.Factory, opts *listOptions) error {
 
 			for _, pr := range prs {
 				author := cmdutil.FirstNonEmpty(pr.Author.DisplayName, pr.Author.Username)
-				if _, err := fmt.Fprintf(ios.Out, "#%d\t%-8s\t%s\n", pr.ID, pr.State, pr.Title); err != nil {
+				created, _ := time.Parse(time.RFC3339, pr.CreatedOn)
+				createdStr := created.Format("2006-01-02 15:04")
+				if _, err := fmt.Fprintf(ios.Out, "#%d\t%-8s\t%s\t%s\n", pr.ID, pr.State, createdStr, pr.Title); err != nil {
 					return err
 				}
 				if _, err := fmt.Fprintf(ios.Out, "    %s -> %s\tby %s\n", pr.Source.Branch.Name, pr.Destination.Branch.Name, author); err != nil {
@@ -273,6 +276,7 @@ func runListDashboardDC(cmd *cobra.Command, f *cmdutil.Factory, ios *iostreams.I
 
 		for _, pr := range prs {
 			author := cmdutil.FirstNonEmpty(pr.Author.User.FullName, pr.Author.User.Name)
+			created := time.UnixMilli(pr.CreatedDate).Format("2006-01-02 15:04")
 			// Use ToRef.Repository (destination) to show where the PR merges into,
 			// which is more useful for fork-based PRs than the source repo
 			repoInfo := ""
@@ -282,7 +286,7 @@ func runListDashboardDC(cmd *cobra.Command, f *cmdutil.Factory, ios *iostreams.I
 					repoInfo = pr.ToRef.Repository.Project.Key + "/" + repoInfo
 				}
 			}
-			if _, err := fmt.Fprintf(ios.Out, "#%d\t%-8s\t%s\n", pr.ID, pr.State, pr.Title); err != nil {
+			if _, err := fmt.Fprintf(ios.Out, "#%d\t%-8s\t%s\t%s\n", pr.ID, pr.State, created, pr.Title); err != nil {
 				return err
 			}
 			if repoInfo != "" {
@@ -349,13 +353,15 @@ func runListWorkspaceCloud(cmd *cobra.Command, f *cmdutil.Factory, ios *iostream
 
 		for _, pr := range prs {
 			author := cmdutil.FirstNonEmpty(pr.Author.DisplayName, pr.Author.Username)
+			created, _ := time.Parse(time.RFC3339, pr.CreatedOn)
+			createdStr := created.Format("2006-01-02 15:04")
 			// Use Destination.Repository.Slug (where PR merges into) as primary source,
 			// fall back to URL parsing for backwards compatibility
 			repoInfo := pr.Destination.Repository.Slug
 			if repoInfo == "" {
 				repoInfo = extractRepoFromCloudPRLink(pr.Links.HTML.Href)
 			}
-			if _, err := fmt.Fprintf(ios.Out, "#%d\t%-8s\t%s\n", pr.ID, pr.State, pr.Title); err != nil {
+			if _, err := fmt.Fprintf(ios.Out, "#%d\t%-8s\t%s\t%s\n", pr.ID, pr.State, createdStr, pr.Title); err != nil {
 				return err
 			}
 			if repoInfo != "" {


### PR DESCRIPTION
- Add CreatedDate/UpdatedDate fields to bbdc.PullRequest (Data Center)
- Add CreatedOn/UpdatedOn fields to bbcloud.PullRequest (Cloud)
- Update bkt pr list output to show creation timestamp in YYYY-MM-DD HH:MM format
- Support both repository-specific and dashboard/workspace PR listings
- Update CHANGELOG.md with unreleased changes

The timestamp is displayed in the default text output to help users identify when pull requests were created at a glance.

## Summary

This adds created_on & updated_on timestamps to the output of the PR subcommands. Only the created_on is added to the normal output (i.e. when not using `--json`). When using `--json`, the output includes both created_on & updated_on.

## Testing

- [x] `make fmt`
- [x] `make test`
- [x] `make build`

## Screenshots / recordings

**Please note: I've had to block out sensitive info from the following screenshots. I only have company work in Bitbucket.**

<img width="1791" height="755" alt="2026-03-19_11-30" src="https://github.com/user-attachments/assets/5fafcf20-357e-47b2-a0bc-6acb810d3b01" />
<img width="672" height="43" alt="image (2)" src="https://github.com/user-attachments/assets/fb1a4172-020f-4993-b0b4-559beb071790" />

## Checklist

- [x] Adds or updates documentation
- [x] Updates `CHANGELOG.md`
- [x] Signed commits (`git commit -s`)

## Notes for reviewers

These code changes were made by my OpenClaw Agent. I do not have much Go knowledge, but I have been writing code for close to 15 years and could somewhat see that the changes are sensible.
