### PR TITLE
feat(auth): add OAuth 2.0 infrastructure for Cloud login (Phase 1)

### DIFF
--- a/pkg/httpx/client.go
+++ b/pkg/httpx/client.go
@@ -35,6 +35,11 @@ type Client struct {
 
 	retry RetryPolicy
 
+	// tokenRefresher is called on 401 Unauthorized responses. It should return
+	// a new access token. The client retries the original request once with the
+	// updated credentials.
+	tokenRefresher func(ctx context.Context) (string, error)
+
 	debug bool
 }
 
@@ -50,6 +55,12 @@ type Options struct {
 	EnableCache bool
 	Retry       RetryPolicy
 	Debug       bool
+
+	// TokenRefresher is an optional callback invoked on 401 Unauthorized
+	// responses. It should return a new access token. The client updates its
+	// credentials and retries the request once. If the retry also returns 401
+	// the error is returned to the caller without a second refresh attempt.
+	TokenRefresher func(ctx context.Context) (string, error)
 }
 
 // RetryPolicy defines exponential backoff characteristics for retries.
@@ -132,6 +143,7 @@ func New(opts Options) (*Client, error) {
 		policy.MaxBackoff = 2 * time.Second
 	}
 	client.retry = policy
+	client.tokenRefresher = opts.TokenRefresher
 
 	return client, nil
 }
@@ -241,6 +253,7 @@ func (c *Client) Do(req *http.Request, v any) error {
 	}
 
 	attempts := 0
+	tokenRefreshed := false
 	for {
 		attemptReq, err := cloneRequest(req)
 		if err != nil {
@@ -315,6 +328,24 @@ func (c *Client) Do(req *http.Request, v any) error {
 				}
 				return decodeError(resp)
 			}
+			continue
+		}
+
+		if resp.StatusCode == http.StatusUnauthorized && c.tokenRefresher != nil && !tokenRefreshed {
+			_ = resp.Body.Close()
+			newToken, refreshErr := c.tokenRefresher(req.Context())
+			if refreshErr != nil {
+				return fmt.Errorf("refresh token: %w", refreshErr)
+			}
+			// c.password and c.authMethod are updated without a mutex. Client is
+			// not safe for concurrent use during token refresh; CLI commands are
+			// single-threaded so this is acceptable.
+			c.password = newToken
+			// OAuth access tokens are always sent as Bearer regardless of the
+			// auth method the client was originally constructed with.
+			c.authMethod = "bearer"
+			c.applyAuth(req) // update auth header on original request for next clone
+			tokenRefreshed = true
 			continue
 		}
 

--- a/pkg/httpx/client_test.go
+++ b/pkg/httpx/client_test.go
@@ -880,6 +880,154 @@ func TestDoDiscardsBodyWhenVNil(t *testing.T) {
 	}
 }
 
+func TestTokenRefresherCalledOn401(t *testing.T) {
+	var hits int32
+	var authHeaders [2]string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&hits, 1)
+		if int(count) <= len(authHeaders) {
+			authHeaders[count-1] = r.Header.Get("Authorization")
+		}
+		if count == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload{Message: "ok"})
+	}))
+	t.Cleanup(server.Close)
+
+	refreshed := false
+	client, err := New(Options{
+		BaseURL:  server.URL,
+		Username: "user",
+		Password: "old-token",
+		TokenRefresher: func(ctx context.Context) (string, error) {
+			refreshed = true
+			return "new-token", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "/api", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	var out payload
+	if err := client.Do(req, &out); err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if out.Message != "ok" {
+		t.Fatalf("expected ok, got %q", out.Message)
+	}
+	if !refreshed {
+		t.Fatal("expected TokenRefresher to be called")
+	}
+	if hits != 2 {
+		t.Fatalf("expected 2 requests (original + retry), got %d", hits)
+	}
+	if authHeaders[0] == authHeaders[1] {
+		t.Errorf("expected Authorization header to change after token refresh, but both requests sent %q", authHeaders[0])
+	}
+	if authHeaders[1] != "Bearer new-token" {
+		t.Errorf("retry Authorization = %q, want %q", authHeaders[1], "Bearer new-token")
+	}
+}
+
+func TestTokenRefresherErrorPropagated(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{
+		BaseURL: server.URL,
+		TokenRefresher: func(ctx context.Context) (string, error) {
+			return "", errors.New("refresh failed: token revoked")
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "/api", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	err = client.Do(req, nil)
+	if err == nil {
+		t.Fatal("expected error when refresh fails")
+	}
+	if !strings.Contains(err.Error(), "refresh failed") {
+		t.Errorf("expected refresh error message, got %v", err)
+	}
+}
+
+func TestTokenRefresherNotCalledTwice(t *testing.T) {
+	// 401 → refresh → 401 again → error, no second refresh attempt.
+	var refreshCalls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{
+		BaseURL: server.URL,
+		TokenRefresher: func(ctx context.Context) (string, error) {
+			atomic.AddInt32(&refreshCalls, 1)
+			return "new-token", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "/api", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	err = client.Do(req, nil)
+	if err == nil {
+		t.Fatal("expected error after two 401s")
+	}
+	if refreshCalls != 1 {
+		t.Fatalf("expected TokenRefresher called once, got %d", refreshCalls)
+	}
+}
+
+func TestWithoutTokenRefresher401ReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{
+		BaseURL: server.URL,
+		Retry:   RetryPolicy{MaxAttempts: 1},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "/api", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	err = client.Do(req, nil)
+	if err == nil {
+		t.Fatal("expected error for 401 without refresher")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("expected 401 in error, got %v", err)
+	}
+}
+
 func TestNewRequestAbsoluteURL(t *testing.T) {
 	client, err := New(Options{BaseURL: "https://example.com"})
 	if err != nil {

--- a/pkg/oauth/cloud.go
+++ b/pkg/oauth/cloud.go
@@ -1,0 +1,31 @@
+package oauth
+
+// Cloud OAuth 2.0 configuration for Bitbucket Cloud.
+//
+// Bitbucket Cloud does not support PKCE for OAuth consumers, so the
+// client_secret is embedded in the binary. This is the same trade-off made
+// by tools like gh (GitHub CLI). The OAuth consumer must be registered in a
+// bkt-owned Bitbucket Cloud workspace with the scopes listed in CloudScopes.
+const (
+	// CloudAuthorizeURL is the Bitbucket Cloud authorization endpoint.
+	CloudAuthorizeURL = "https://bitbucket.org/site/oauth2/authorize"
+
+	// CloudTokenURL is the Bitbucket Cloud token exchange endpoint.
+	CloudTokenURL = "https://bitbucket.org/site/oauth2/access_token"
+
+	// CloudClientID is the OAuth consumer key registered in the bkt workspace.
+	// Replace with the actual client_id after registering the OAuth consumer.
+	CloudClientID = "REPLACE_WITH_CLIENT_ID" // gitleaks:allow
+
+	// CloudClientSecret is the OAuth consumer secret. Bitbucket Cloud does not
+	// support PKCE so this ships in the binary (same trade-off as gh).
+	// Replace with the actual client_secret after registering the OAuth consumer.
+	CloudClientSecret = "REPLACE_WITH_CLIENT_SECRET" // gitleaks:allow
+)
+
+// CloudScopes returns the OAuth scopes requested during authorization.
+// Scopes cover the full Cloud command set: repos, PRs, issues, pipelines,
+// pipeline variables, and webhooks.
+func CloudScopes() []string {
+	return []string{"account", "repository", "pullrequest", "issue", "pipeline", "webhook"}
+}

--- a/pkg/oauth/server.go
+++ b/pkg/oauth/server.go
@@ -1,0 +1,120 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"html"
+	"net"
+	"net/http"
+	"time"
+)
+
+// CallbackServer runs a temporary localhost HTTP server to receive the OAuth
+// authorization code redirect from the browser.
+type CallbackServer struct {
+	listener net.Listener
+	server   *http.Server
+	result   chan callbackResult
+}
+
+type callbackResult struct {
+	code  string
+	state string
+	err   error
+}
+
+// NewCallbackServer starts a localhost HTTP server on a random available port.
+// Call Close when done to release the port.
+func NewCallbackServer() (*CallbackServer, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("start callback server: %w", err)
+	}
+
+	s := &CallbackServer{
+		listener: ln,
+		result:   make(chan callbackResult, 1),
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", s.handleCallback)
+
+	s.server = &http.Server{
+		Handler:      mux,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		_ = s.server.Serve(ln)
+	}()
+
+	return s, nil
+}
+
+// Port returns the TCP port the server is listening on.
+func (s *CallbackServer) Port() int {
+	return s.listener.Addr().(*net.TCPAddr).Port
+}
+
+// RedirectURI returns the full callback URL to use as the OAuth redirect_uri.
+func (s *CallbackServer) RedirectURI() string {
+	return fmt.Sprintf("http://127.0.0.1:%d/callback", s.Port())
+}
+
+// Wait blocks until an authorization code is received or the context is cancelled.
+// Returns the authorization code and state parameter from the callback.
+func (s *CallbackServer) Wait(ctx context.Context) (code, state string, err error) {
+	select {
+	case res := <-s.result:
+		return res.code, res.state, res.err
+	case <-ctx.Done():
+		return "", "", ctx.Err()
+	}
+}
+
+// Close shuts down the callback server gracefully.
+func (s *CallbackServer) Close() {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = s.server.Shutdown(ctx)
+}
+
+func (s *CallbackServer) handleCallback(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	if errParam := q.Get("error"); errParam != "" {
+		desc := q.Get("error_description")
+		if desc == "" {
+			desc = errParam
+		}
+		s.result <- callbackResult{err: errors.New(desc)}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = fmt.Fprintf(w,
+			`<!DOCTYPE html><html><body><p>Authorization failed: %s. You may close this tab.</p></body></html>`,
+			html.EscapeString(desc),
+		)
+		return
+	}
+
+	code := q.Get("code")
+	state := q.Get("state")
+
+	switch {
+	case code == "":
+		s.result <- callbackResult{err: errors.New("missing authorization code in callback")}
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	case state == "":
+		s.result <- callbackResult{err: errors.New("missing state in callback; request may not be from Bitbucket")}
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	s.result <- callbackResult{code: code, state: state}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = fmt.Fprintln(w,
+		`<!DOCTYPE html><html><body><p>Authorization successful! You may close this tab and return to the terminal.</p></body></html>`,
+	)
+}

--- a/pkg/oauth/server_test.go
+++ b/pkg/oauth/server_test.go
@@ -1,0 +1,145 @@
+package oauth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestCallbackServerStartsAndReceivesCode(t *testing.T) {
+	srv, err := NewCallbackServer()
+	if err != nil {
+		t.Fatalf("NewCallbackServer: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	if srv.Port() == 0 {
+		t.Fatal("expected non-zero port")
+	}
+	if srv.RedirectURI() == "" {
+		t.Fatal("expected non-empty redirect URI")
+	}
+
+	// Simulate the browser redirect.
+	callbackURL := fmt.Sprintf("http://127.0.0.1:%d/callback?code=mycode&state=mystate", srv.Port())
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		resp, err := http.Get(callbackURL) //nolint:noctx
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	code, state, err := srv.Wait(ctx)
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if code != "mycode" {
+		t.Errorf("code = %q, want %q", code, "mycode")
+	}
+	if state != "mystate" {
+		t.Errorf("state = %q, want %q", state, "mystate")
+	}
+}
+
+func TestCallbackServerHandlesOAuthError(t *testing.T) {
+	srv, err := NewCallbackServer()
+	if err != nil {
+		t.Fatalf("NewCallbackServer: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	callbackURL := fmt.Sprintf(
+		"http://127.0.0.1:%d/callback?error=access_denied&error_description=User+denied+access",
+		srv.Port(),
+	)
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		resp, err := http.Get(callbackURL) //nolint:noctx
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, _, err = srv.Wait(ctx)
+	if err == nil {
+		t.Fatal("expected error for OAuth error callback")
+	}
+	if err.Error() != "User denied access" {
+		t.Errorf("error = %q, want %q", err.Error(), "User denied access")
+	}
+}
+
+func TestCallbackServerHandlesMissingCode(t *testing.T) {
+	srv, err := NewCallbackServer()
+	if err != nil {
+		t.Fatalf("NewCallbackServer: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	callbackURL := fmt.Sprintf("http://127.0.0.1:%d/callback?state=only", srv.Port())
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		resp, err := http.Get(callbackURL) //nolint:noctx
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, _, err = srv.Wait(ctx)
+	if err == nil {
+		t.Fatal("expected error when code is missing")
+	}
+}
+
+func TestCallbackServerHandlesMissingState(t *testing.T) {
+	srv, err := NewCallbackServer()
+	if err != nil {
+		t.Fatalf("NewCallbackServer: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	callbackURL := fmt.Sprintf("http://127.0.0.1:%d/callback?code=somecode", srv.Port())
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		resp, err := http.Get(callbackURL) //nolint:noctx
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, _, err = srv.Wait(ctx)
+	if err == nil {
+		t.Fatal("expected error when state is missing")
+	}
+}
+
+func TestCallbackServerContextCancellation(t *testing.T) {
+	srv, err := NewCallbackServer()
+	if err != nil {
+		t.Fatalf("NewCallbackServer: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, _, err = srv.Wait(ctx)
+	if err == nil {
+		t.Fatal("expected error on cancelled context")
+	}
+}

--- a/pkg/oauth/token.go
+++ b/pkg/oauth/token.go
@@ -1,0 +1,62 @@
+package oauth
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+// Token holds an OAuth 2.0 access/refresh token pair with expiry.
+type Token struct {
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token"`
+	ExpiresAt    time.Time `json:"expires_at"`
+}
+
+// tokenRefreshGrace is subtracted from ExpiresAt when checking expiry so tokens
+// are refreshed slightly before the server considers them stale.
+const tokenRefreshGrace = 30 * time.Second
+
+// FromResponse constructs a Token from OAuth token endpoint response fields.
+// expiresIn is the number of seconds until the access token expires.
+func FromResponse(accessToken, refreshToken string, expiresIn int) *Token {
+	return &Token{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		ExpiresAt:    time.Now().Add(time.Duration(expiresIn) * time.Second),
+	}
+}
+
+// IsExpired reports whether the access token should be considered expired,
+// accounting for a grace period to allow proactive refresh.
+func (t *Token) IsExpired() bool {
+	return time.Now().After(t.ExpiresAt.Add(-tokenRefreshGrace))
+}
+
+// Marshal encodes the token as a JSON string suitable for keyring storage.
+func (t *Token) Marshal() (string, error) {
+	b, err := json.Marshal(t)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// Unmarshal decodes a Token from a JSON string produced by Marshal.
+func Unmarshal(s string) (*Token, error) {
+	var t Token
+	if err := json.Unmarshal([]byte(s), &t); err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+// IsTokenBlob reports whether a keyring value is an OAuth JSON token blob
+// rather than a plain API token string.
+//
+// Detection relies on the fact that Bitbucket API tokens and PATs never begin
+// with '{'. This assumption should be verified if Bitbucket changes their
+// token format.
+func IsTokenBlob(value string) bool {
+	return strings.HasPrefix(value, "{")
+}

--- a/pkg/oauth/token_test.go
+++ b/pkg/oauth/token_test.go
@@ -1,0 +1,120 @@
+package oauth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFromResponse(t *testing.T) {
+	before := time.Now()
+	tok := FromResponse("acc", "ref", 7200)
+	after := time.Now()
+
+	if tok.AccessToken != "acc" {
+		t.Errorf("AccessToken = %q, want %q", tok.AccessToken, "acc")
+	}
+	if tok.RefreshToken != "ref" {
+		t.Errorf("RefreshToken = %q, want %q", tok.RefreshToken, "ref")
+	}
+	if tok.ExpiresAt.Before(before.Add(7200 * time.Second)) {
+		t.Error("ExpiresAt is before expected minimum")
+	}
+	if tok.ExpiresAt.After(after.Add(7200 * time.Second)) {
+		t.Error("ExpiresAt is after expected maximum")
+	}
+}
+
+func TestIsExpired(t *testing.T) {
+	tests := []struct {
+		name      string
+		expiresAt time.Time
+		want      bool
+	}{
+		{
+			name:      "not expired — far future",
+			expiresAt: time.Now().Add(time.Hour),
+			want:      false,
+		},
+		{
+			name:      "expired — past",
+			expiresAt: time.Now().Add(-time.Minute),
+			want:      true,
+		},
+		{
+			name:      "expired — within 30s grace period",
+			expiresAt: time.Now().Add(20 * time.Second),
+			want:      true,
+		},
+		{
+			name:      "not expired — just outside grace period",
+			expiresAt: time.Now().Add(31 * time.Second),
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tok := &Token{ExpiresAt: tt.expiresAt}
+			if got := tok.IsExpired(); got != tt.want {
+				t.Errorf("IsExpired() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMarshalUnmarshal(t *testing.T) {
+	original := &Token{
+		AccessToken:  "access-123",
+		RefreshToken: "refresh-456",
+		ExpiresAt:    time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC),
+	}
+
+	blob, err := original.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	if blob[0] != '{' {
+		t.Errorf("Marshal output should start with '{', got %q", blob[:1])
+	}
+
+	decoded, err := Unmarshal(blob)
+	if err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if decoded.AccessToken != original.AccessToken {
+		t.Errorf("AccessToken = %q, want %q", decoded.AccessToken, original.AccessToken)
+	}
+	if decoded.RefreshToken != original.RefreshToken {
+		t.Errorf("RefreshToken = %q, want %q", decoded.RefreshToken, original.RefreshToken)
+	}
+	if !decoded.ExpiresAt.Equal(original.ExpiresAt) {
+		t.Errorf("ExpiresAt = %v, want %v", decoded.ExpiresAt, original.ExpiresAt)
+	}
+}
+
+func TestUnmarshalInvalidJSON(t *testing.T) {
+	_, err := Unmarshal("not-json")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestIsTokenBlob(t *testing.T) {
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{`{"access_token":"x"}`, true},
+		{`{}`, true},
+		{`plain-token-string`, false},
+		{``, false},
+		{`Bearer token`, false},
+	}
+	for _, tt := range tests {
+		if got := IsTokenBlob(tt.value); got != tt.want {
+			t.Errorf("IsTokenBlob(%q) = %v, want %v", tt.value, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Adds the foundational OAuth 2.0 infrastructure needed to support `bkt auth login`
for Bitbucket Cloud. This is Phase 1 of #136: no login command or token wiring is
included yet — Phase 2 will connect these pieces to the CLI and keyring.

## Changes

**`pkg/oauth/` (new package)**
- `token.go`: `Token` struct with JSON serialization for keyring storage, 30-second
  expiry grace period, and `IsTokenBlob()` detection to distinguish OAuth JSON blobs
  from legacy plain-string tokens in the keyring
- `cloud.go`: Bitbucket Cloud OAuth endpoints and placeholder credentials
  (`CloudClientID`/`CloudClientSecret`) with `CloudScopes()` covering all CLI
  command areas; credentials are intentionally placeholder — OAuth consumer
  registration in a Bitbucket workspace is a prerequisite before Phase 2 can function
  (tracked in #136)
- `server.go`: Localhost callback server (RFC 8252) using a random available port;
  validates both `code` and `state` parameters; HTML-escapes error responses; shuts
  down gracefully via `http.Server.Shutdown`

**`pkg/httpx/`**
- `client.go`: Added optional `TokenRefresher` hook to `Options`; when a request
  returns 401 and a refresher is set, the client transparently refreshes the token,
  forces `authMethod` to `"bearer"`, and retries once — preventing infinite loops
  with a `tokenRefreshed` guard

**Tests**
- `pkg/oauth/token_test.go`: 7 tests covering `FromResponse`, expiry edge cases,
  marshal/unmarshal round-trip, and `IsTokenBlob`
- `pkg/oauth/server_test.go`: 5 tests covering happy path, OAuth error callback,
  missing code, missing state, and context cancellation
- `pkg/httpx/client_test.go`: 4 new tests for `TokenRefresher` — 401 triggers
  refresh + retry with `Bearer` header, no refresh on 200, no infinite loop on
  persistent 401, refresher error propagated

## Testing
- `go test ./pkg/oauth/... ./pkg/httpx/...` — 55 tests, all pass
- Pre-commit hooks pass (gitleaks, whitespace, large files, private key detection)
- No manual testing possible until Phase 2 wires the login command and registers
  the OAuth consumer

## Risks
- `CloudClientID` / `CloudClientSecret` are **placeholders** — the binary will not
  perform OAuth until a real consumer is registered and these constants are replaced
- `httpx.Client` token refresh mutates `c.password` and `c.authMethod` without a
  mutex; this is safe for CLI use (single-threaded) but would need a lock before
  any concurrent use