### PR TITLE
feat(issue): add deprecation warning for Bitbucket Cloud Issues sunset

### DIFF
--- a/pkg/cmd/issue/issue.go
+++ b/pkg/cmd/issue/issue.go
@@ -22,6 +22,21 @@ func NewCmdIssue(f *cmdutil.Factory) *cobra.Command {
 
 Note: The issue tracker is only available for Bitbucket Cloud. Bitbucket Data Center
 uses Jira for issue tracking.`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			ios, err := f.Streams()
+			if err != nil {
+				return nil // swallow — subcommand will handle
+			}
+			override := cmdutil.FlagValue(cmd, "context")
+			_, _, host, err := cmdutil.ResolveContext(f, cmd, override)
+			if err != nil {
+				return nil // swallow — subcommand prints its own error
+			}
+			if host.Kind == "cloud" {
+				fmt.Fprintln(ios.ErrOut, "WARNING: Bitbucket Cloud is removing native Issues on August 20, 2026. Migrate to Jira for issue tracking.")
+			}
+			return nil
+		},
 	}
 
 	cmd.AddCommand(newListCmd(f))

--- a/pkg/cmd/issue/issue_deprecation_test.go
+++ b/pkg/cmd/issue/issue_deprecation_test.go
@@ -1,0 +1,81 @@
+package issue
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/bitbucket-cli/internal/config"
+	"github.com/avivsinai/bitbucket-cli/pkg/cmdutil"
+	"github.com/avivsinai/bitbucket-cli/pkg/iostreams"
+)
+
+func TestDeprecationWarning(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         *config.Config
+		wantWarning bool
+	}{
+		{
+			name: "cloud context prints warning",
+			cfg: &config.Config{
+				ActiveContext: "default",
+				Contexts: map[string]*config.Context{
+					"default": {Host: "cloud", Workspace: "ws", DefaultRepo: "repo"},
+				},
+				Hosts: map[string]*config.Host{
+					"cloud": {Kind: "cloud", BaseURL: "https://api.bitbucket.org/2.0", Token: "t"},
+				},
+			},
+			wantWarning: true,
+		},
+		{
+			name: "dc context does not print warning",
+			cfg: &config.Config{
+				ActiveContext: "default",
+				Contexts: map[string]*config.Context{
+					"default": {Host: "mydc", DefaultRepo: "repo"},
+				},
+				Hosts: map[string]*config.Host{
+					"mydc": {Kind: "dc", BaseURL: "https://bitbucket.example.com", Token: "t"},
+				},
+			},
+			wantWarning: false,
+		},
+		{
+			name: "no context does not crash",
+			cfg: &config.Config{
+				Contexts: map[string]*config.Context{},
+				Hosts:    map[string]*config.Host{},
+			},
+			wantWarning: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stderr strings.Builder
+			f := &cmdutil.Factory{
+				AppVersion:     "test",
+				ExecutableName: "bkt",
+				IOStreams: &iostreams.IOStreams{
+					Out:    &strings.Builder{},
+					ErrOut: &stderr,
+				},
+				Config: func() (*config.Config, error) {
+					return tt.cfg, nil
+				},
+			}
+
+			cmd := NewCmdIssue(f)
+			cmd.SilenceErrors = true
+			cmd.SilenceUsage = true
+			cmd.SetArgs([]string{"list"})
+			_ = cmd.Execute() // subcommand fails (no API) but PersistentPreRunE runs first
+
+			got := strings.Contains(stderr.String(), "WARNING: Bitbucket Cloud is removing native Issues")
+			if got != tt.wantWarning {
+				t.Errorf("warning present = %v, want %v; stderr = %q", got, tt.wantWarning, stderr.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a `PersistentPreRunE` hook to `bkt issue` that prints a deprecation warning to stderr when the active context is Bitbucket Cloud
- Warning text: "WARNING: Bitbucket Cloud is removing native Issues on August 20, 2026. Migrate to Jira for issue tracking."
- Errors from context resolution are silently swallowed so subcommands handle them normally

Closes #135

## Test plan

- [x] `go test ./pkg/cmd/issue/...` — table-driven tests cover cloud (warning present), DC (no warning), and no-context (no crash) cases
- [x] `go test ./...` — full suite passes
- [x] `go build ./cmd/bkt && go run ./cmd/bkt --help` — smoke test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)