### PR TITLE
fix(context): bootstrap host entry from BKT_TOKEN when host not found

### DIFF
--- a/pkg/cmd/context/context.go
+++ b/pkg/cmd/context/context.go
@@ -8,7 +8,9 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/avivsinai/bitbucket-cli/internal/config"
+	"github.com/avivsinai/bitbucket-cli/internal/secret"
 	"github.com/avivsinai/bitbucket-cli/pkg/cmdutil"
+	"github.com/avivsinai/bitbucket-cli/pkg/iostreams"
 )
 
 // NewCmdContext returns the context management command tree.
@@ -44,6 +46,8 @@ type createOptions struct {
 	Workspace string
 	Repo      string
 	SetActive bool
+	Kind      string
+	BaseURL   string
 }
 
 func newCreateCmd(f *cmdutil.Factory) *cobra.Command {
@@ -74,6 +78,8 @@ without requiring flags.`,
 	cmd.Flags().StringVar(&opts.Workspace, "workspace", "", "Default Bitbucket workspace (Cloud)")
 	cmd.Flags().StringVar(&opts.Repo, "repo", "", "Default repository slug")
 	cmd.Flags().BoolVar(&opts.SetActive, "set-active", false, "Set the new context as active")
+	cmd.Flags().StringVar(&opts.Kind, "kind", "", `Host kind: "dc" or "cloud" (required when bootstrapping via BKT_TOKEN)`)
+	cmd.Flags().StringVar(&opts.BaseURL, "base-url", "", "Host base URL (defaults to https://<host>)")
 
 	return cmd
 }
@@ -106,7 +112,13 @@ func runCreate(cmd *cobra.Command, f *cmdutil.Factory, name string, opts *create
 		}
 		host, ok = cfg.Hosts[hostKey]
 		if !ok {
-			return fmt.Errorf("host %q not found; run `%s auth login` first", opts.Host, f.ExecutableName)
+			if secret.TokenFromEnv() == "" {
+				return fmt.Errorf("host %q not found; run `%s auth login` first", opts.Host, f.ExecutableName)
+			}
+			host, hostKey, err = bootstrapHost(ios, cfg, hostKey, opts)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -151,6 +163,37 @@ func runCreate(cmd *cobra.Command, f *cmdutil.Factory, name string, opts *create
 		}
 	}
 	return nil
+}
+
+// bootstrapHost creates a minimal host entry when BKT_TOKEN is set and the
+// host doesn't exist yet. This avoids the deadlock where `auth login` refuses
+// to run when BKT_TOKEN is set.
+func bootstrapHost(ios *iostreams.IOStreams, cfg *config.Config, hostKey string, opts *createOptions) (*config.Host, string, error) {
+	kind := strings.ToLower(strings.TrimSpace(opts.Kind))
+	if kind != "dc" && kind != "cloud" {
+		return nil, "", fmt.Errorf("--kind is required when bootstrapping a new host via BKT_TOKEN (use \"dc\" or \"cloud\")")
+	}
+
+	baseURL := strings.TrimSpace(opts.BaseURL)
+	if baseURL != "" {
+		var err error
+		baseURL, err = cmdutil.NormalizeBaseURL(baseURL)
+		if err != nil {
+			return nil, "", fmt.Errorf("normalize base URL: %w", err)
+		}
+		hostKey, err = cmdutil.HostKeyFromURL(baseURL)
+		if err != nil {
+			return nil, "", err
+		}
+	} else {
+		baseURL = "https://" + hostKey
+	}
+
+	host := &config.Host{Kind: kind, BaseURL: baseURL}
+	cfg.SetHost(hostKey, host)
+
+	fmt.Fprintf(ios.ErrOut, "Bootstrapped host %q (%s) from BKT_TOKEN\n", hostKey, kind)
+	return host, hostKey, nil
 }
 
 func newUseCmd(f *cmdutil.Factory) *cobra.Command {

--- a/pkg/cmd/context/context_test.go
+++ b/pkg/cmd/context/context_test.go
@@ -1,0 +1,186 @@
+package context_test
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/bitbucket-cli/internal/config"
+	"github.com/avivsinai/bitbucket-cli/pkg/cmd/root"
+	"github.com/avivsinai/bitbucket-cli/pkg/cmdutil"
+	"github.com/avivsinai/bitbucket-cli/pkg/iostreams"
+
+	gocontext "context"
+)
+
+func runCLI(t *testing.T, cfg *config.Config, args ...string) (string, string, error) {
+	t.Helper()
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	ios := &iostreams.IOStreams{
+		In:     io.NopCloser(bytes.NewReader(nil)),
+		Out:    stdout,
+		ErrOut: stderr,
+	}
+
+	factory := &cmdutil.Factory{
+		AppVersion:     "test",
+		ExecutableName: "bkt",
+		IOStreams:       ios,
+		Config: func() (*config.Config, error) {
+			return cfg, nil
+		},
+	}
+
+	rootCmd, err := root.NewCmdRoot(factory)
+	if err != nil {
+		t.Fatalf("NewCmdRoot: %v", err)
+	}
+	rootCmd.SetArgs(args)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(stderr)
+
+	t.Setenv("BKT_NO_UPDATE_CHECK", "1")
+	t.Setenv("NO_COLOR", "1")
+
+	rootCmd.SilenceUsage = true
+
+	err = rootCmd.ExecuteContext(gocontext.Background())
+	return stdout.String(), stderr.String(), err
+}
+
+func TestContextCreateBootstrap(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		envToken      string
+		cfg           *config.Config
+		wantErr       string
+		wantStdout    string
+		wantStderr    string
+		wantHostKind  string
+		wantHostKey   string
+	}{
+		{
+			name:     "bootstrap dc with BKT_TOKEN",
+			args:     []string{"context", "create", "work", "--host", "bitbucket.example.com", "--kind", "dc", "--project", "PROJ"},
+			envToken: "test-token",
+			cfg: &config.Config{
+				Contexts: map[string]*config.Context{},
+				Hosts:    map[string]*config.Host{},
+			},
+			wantStdout:   "Created context",
+			wantStderr:   "Bootstrapped host",
+			wantHostKind: "dc",
+			wantHostKey:  "bitbucket.example.com",
+		},
+		{
+			name:     "bootstrap cloud with BKT_TOKEN",
+			args:     []string{"context", "create", "oss", "--host", "bitbucket.org", "--kind", "cloud", "--workspace", "myteam"},
+			envToken: "test-token",
+			cfg: &config.Config{
+				Contexts: map[string]*config.Context{},
+				Hosts:    map[string]*config.Host{},
+			},
+			wantStdout:   "Created context",
+			wantStderr:   "Bootstrapped host",
+			wantHostKind: "cloud",
+			wantHostKey:  "bitbucket.org",
+		},
+		{
+			name:     "bootstrap fails without --kind when BKT_TOKEN set",
+			args:     []string{"context", "create", "work", "--host", "bitbucket.example.com", "--project", "PROJ"},
+			envToken: "test-token",
+			cfg: &config.Config{
+				Contexts: map[string]*config.Context{},
+				Hosts:    map[string]*config.Host{},
+			},
+			wantErr: "--kind is required when bootstrapping a new host via BKT_TOKEN",
+		},
+		{
+			name:     "without BKT_TOKEN missing host returns auth login error",
+			args:     []string{"context", "create", "work", "--host", "bitbucket.example.com", "--project", "PROJ"},
+			envToken: "",
+			cfg: &config.Config{
+				Contexts: map[string]*config.Context{},
+				Hosts:    map[string]*config.Host{},
+			},
+			wantErr: "run `bkt auth login` first",
+		},
+		{
+			name:     "base-url overrides default URL",
+			args:     []string{"context", "create", "work", "--host", "bitbucket.example.com", "--kind", "dc", "--project", "PROJ", "--base-url", "https://bb.internal:8443"},
+			envToken: "test-token",
+			cfg: &config.Config{
+				Contexts: map[string]*config.Context{},
+				Hosts:    map[string]*config.Host{},
+			},
+			wantStdout:   "Created context",
+			wantStderr:   "Bootstrapped host",
+			wantHostKind: "dc",
+			wantHostKey:  "bb.internal:8443",
+		},
+		{
+			name: "existing host works without bootstrap",
+			args: []string{"context", "create", "work", "--host", "bitbucket.example.com", "--project", "PROJ"},
+			cfg: &config.Config{
+				Contexts: map[string]*config.Context{},
+				Hosts: map[string]*config.Host{
+					"bitbucket.example.com": {
+						Kind:    "dc",
+						BaseURL: "https://bitbucket.example.com",
+					},
+				},
+			},
+			wantStdout:   "Created context",
+			wantHostKind: "dc",
+			wantHostKey:  "bitbucket.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("BKT_TOKEN", tt.envToken)
+
+			// Use a temp dir so Save() doesn't touch real config.
+			cfgDir := t.TempDir()
+			t.Setenv("BKT_CONFIG_DIR", cfgDir)
+
+			stdout, stderr, err := runCLI(t, tt.cfg, tt.args...)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v (stderr=%s)", err, stderr)
+			}
+
+			if tt.wantStdout != "" && !strings.Contains(stdout, tt.wantStdout) {
+				t.Errorf("stdout missing %q, got %q", tt.wantStdout, stdout)
+			}
+
+			if tt.wantStderr != "" && !strings.Contains(stderr, tt.wantStderr) {
+				t.Errorf("stderr missing %q, got %q", tt.wantStderr, stderr)
+			}
+
+			if tt.wantHostKey != "" {
+				host, ok := tt.cfg.Hosts[tt.wantHostKey]
+				if !ok {
+					t.Fatalf("expected host %q in config, hosts: %v", tt.wantHostKey, tt.cfg.Hosts)
+				}
+				if host.Kind != tt.wantHostKind {
+					t.Errorf("expected host kind %q, got %q", tt.wantHostKind, host.Kind)
+				}
+			}
+		})
+	}
+}

--- a/pkg/cmd/context/context_test.go
+++ b/pkg/cmd/context/context_test.go
@@ -28,7 +28,7 @@ func runCLI(t *testing.T, cfg *config.Config, args ...string) (string, string, e
 	factory := &cmdutil.Factory{
 		AppVersion:     "test",
 		ExecutableName: "bkt",
-		IOStreams:       ios,
+		IOStreams:      ios,
 		Config: func() (*config.Config, error) {
 			return cfg, nil
 		},
@@ -53,15 +53,15 @@ func runCLI(t *testing.T, cfg *config.Config, args ...string) (string, string, e
 
 func TestContextCreateBootstrap(t *testing.T) {
 	tests := []struct {
-		name          string
-		args          []string
-		envToken      string
-		cfg           *config.Config
-		wantErr       string
-		wantStdout    string
-		wantStderr    string
-		wantHostKind  string
-		wantHostKey   string
+		name         string
+		args         []string
+		envToken     string
+		cfg          *config.Config
+		wantErr      string
+		wantStdout   string
+		wantStderr   string
+		wantHostKind string
+		wantHostKey  string
 	}{
 		{
 			name:     "bootstrap dc with BKT_TOKEN",


### PR DESCRIPTION
## Summary
- When `BKT_TOKEN` is set and the host doesn't exist in config, `context create` now bootstraps a minimal host entry using the new `--kind` flag
- Adds `--kind` (dc/cloud) and `--base-url` flags to `context create`
- Unblocks headless/CI workflows that rely on `BKT_TOKEN`

Closes #134

## Test plan
- [x] 6 table-driven tests covering bootstrap DC, Cloud, missing --kind, no BKT_TOKEN, --base-url override, existing host
- [x] `go test ./...` passes
- [x] `go build ./cmd/bkt` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)