### PR TITLE
chore(release): v0.20.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ All notable changes to this project will be documented here. The format follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
+## [0.20.0] - 2026-04-09
 ### Added
 - Deprecation warning on all `bkt issue` subcommands for Bitbucket Cloud contexts, ahead of the August 20, 2026 Issues/Wikis sunset (#139).
 - Generated per-command skill rule files and rewritten `SKILL.md` via `cmd/docgen` pipeline (#133).
 - Unit tests for `bkt pr comments` covering Data Center and Cloud code paths, state filtering, and empty results (#140).
+
 
 ## [0.19.0] - 2026-04-07
 ### Added

--- a/skills/bkt/SKILL.md
+++ b/skills/bkt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bkt
-version: 0.19.0
+version: 0.20.0
 description: Bitbucket CLI for Data Center and Cloud. Use when users need to manage repositories, pull requests, branches, issues, webhooks, or pipelines in Bitbucket. Triggers include "bitbucket", "bkt", "pull request", "PR", "repo list", "branch create", "Bitbucket Data Center", "Bitbucket Cloud", "keyring timeout".
 metadata:
   short-description: Bitbucket CLI for repos, PRs, branches


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.20.0`
- aligns skill/plugin metadata to `0.20.0`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.20.0`, publishes the release, and publishes skills in the same workflow run