### PR TITLE
docs(changelog): populate Unreleased for upcoming 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented here. The format follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Added
+- OAuth 2.0 infrastructure for Cloud login in the new `pkg/oauth` package, plus a `TokenRefresher` hook on `httpx.Client` for transparent 401-driven token refresh. Phase 1 only; login-command wiring is not included yet (#137).
+- Unit test coverage for `bkt branch` and `bkt branch protect` subcommands (#143).
+- Unit test coverage for `bkt context` subcommands (#143).
+- Unit test coverage for `bkt project list` (#144).
+- Unit test coverage for `bkt webhook` subcommands (#145).
 
 ## [0.20.0] - 2026-04-09
 ### Added


### PR DESCRIPTION
## Summary
Fills the empty [Unreleased] section with entries for #137, #143, #144, #145. Required before running scripts/release.sh 0.21.0 — the script will otherwise refuse on an empty Unreleased (or produce an empty release entry with --allow-empty).

## Test plan
- [x] Visual diff review
- [x] CHANGELOG.md still parses as valid markdown