### PR TITLE
chore(release): v0.21.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@ All notable changes to this project will be documented here. The format follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
+## [0.21.0] - 2026-04-10
 ### Added
 - OAuth 2.0 infrastructure for Cloud login in the new `pkg/oauth` package, plus a `TokenRefresher` hook on `httpx.Client` for transparent 401-driven token refresh. Phase 1 only; login-command wiring is not included yet (#137).
 - Unit test coverage for `bkt branch` and `bkt branch protect` subcommands (#143).
 - Unit test coverage for `bkt context` subcommands (#143).
 - Unit test coverage for `bkt project list` (#144).
 - Unit test coverage for `bkt webhook` subcommands (#145).
+
 
 ## [0.20.0] - 2026-04-09
 ### Added

--- a/skills/bkt/SKILL.md
+++ b/skills/bkt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bkt
-version: 0.20.0
+version: 0.21.0
 description: Bitbucket CLI for Data Center and Cloud. Use when users need to manage repositories, pull requests, branches, issues, webhooks, or pipelines in Bitbucket. Triggers include "bitbucket", "bkt", "pull request", "PR", "repo list", "branch create", "Bitbucket Data Center", "Bitbucket Cloud", "keyring timeout".
 metadata:
   short-description: Bitbucket CLI for repos, PRs, branches


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.21.0`
- aligns skill/plugin metadata to `0.21.0`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.21.0`, publishes the release, and publishes skills in the same workflow run