### PR TITLE
fix: alias pr update to pr edit

### DIFF
--- a/pkg/cmd/pr/edit_alias_test.go
+++ b/pkg/cmd/pr/edit_alias_test.go
@@ -18,4 +18,18 @@ func TestEditCommandResolution(t *testing.T) {
 			t.Fatalf("pr update --help failed: %v", err)
 		}
 	})
+
+	t.Run("help output matches", func(t *testing.T) {
+		editOut, _, err := runCLI(t, cfg, "pr", "edit", "--help")
+		if err != nil {
+			t.Fatalf("pr edit --help failed: %v", err)
+		}
+		updateOut, _, err := runCLI(t, cfg, "pr", "update", "--help")
+		if err != nil {
+			t.Fatalf("pr update --help failed: %v", err)
+		}
+		if editOut != updateOut {
+			t.Errorf("help output differs between 'pr edit' and 'pr update'\nedit:\n%s\nupdate:\n%s", editOut, updateOut)
+		}
+	})
 }

--- a/pkg/cmd/pr/edit_alias_test.go
+++ b/pkg/cmd/pr/edit_alias_test.go
@@ -1,0 +1,21 @@
+package pr_test
+
+import "testing"
+
+func TestEditCommandResolution(t *testing.T) {
+	cfg := dcConfig("http://localhost")
+
+	t.Run("canonical name", func(t *testing.T) {
+		_, _, err := runCLI(t, cfg, "pr", "edit", "--help")
+		if err != nil {
+			t.Fatalf("pr edit --help failed: %v", err)
+		}
+	})
+
+	t.Run("update alias", func(t *testing.T) {
+		_, _, err := runCLI(t, cfg, "pr", "update", "--help")
+		if err != nil {
+			t.Fatalf("pr update --help failed: %v", err)
+		}
+	})
+}

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -1285,9 +1285,10 @@ type editOptions struct {
 func newEditCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &editOptions{}
 	cmd := &cobra.Command{
-		Use:   "edit <id>",
-		Short: "Edit a pull request",
-		Long:  "Edit a pull request's title, description, and/or reviewers.",
+		Use:     "edit <id>",
+		Aliases: []string{"update"},
+		Short:   "Edit a pull request",
+		Long:    "Edit a pull request's title, description, and/or reviewers.",
 		Example: `  # Update pull request title
   bkt pr edit 123 --title "New feature: user authentication"
 

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -1288,7 +1288,7 @@ func newEditCmd(f *cmdutil.Factory) *cobra.Command {
 		Use:     "edit <id>",
 		Aliases: []string{"update"},
 		Short:   "Edit a pull request",
-		Long:    "Edit a pull request's title, description, and/or reviewers.",
+		Long:    "Edit a pull request's title, description, and/or reviewers. Also available as 'pr update'.",
 		Example: `  # Update pull request title
   bkt pr edit 123 --title "New feature: user authentication"
 

--- a/skills/bkt/rules/auth.md
+++ b/skills/bkt/rules/auth.md
@@ -178,3 +178,4 @@ bkt auth status [flags]
   # Get status as JSON
   bkt auth status --output json
 ```
+

--- a/skills/bkt/rules/pr.md
+++ b/skills/bkt/rules/pr.md
@@ -603,6 +603,8 @@ bkt pr diff <id> [flags]
 
 Edit a pull request's title, description, and/or reviewers.
 
+**Alias:** `update`
+
 ### Usage
 
 ```
@@ -1364,4 +1366,3 @@ bkt pr view <id> [flags]
   # View a pull request in a different repository
   bkt pr view 10 --repo my-other-repo
 ```
-

--- a/skills/bkt/rules/pr.md
+++ b/skills/bkt/rules/pr.md
@@ -601,7 +601,7 @@ bkt pr diff <id> [flags]
 
 ## bkt pr edit
 
-Edit a pull request's title, description, and/or reviewers.
+Edit a pull request's title, description, and/or reviewers. Also available as 'pr update'.
 
 **Alias:** `update`
 
@@ -1366,3 +1366,4 @@ bkt pr view <id> [flags]
   # View a pull request in a different repository
   bkt pr view 10 --repo my-other-repo
 ```
+


### PR DESCRIPTION
## Summary
Add `bkt pr update` as an alias of `bkt pr edit` so agent and user command resolution can match the more intuitive verb. The motivation is to improve command resolving for agents and automation that may naturally choose `update` over `edit` for modifying an existing pull request.

## Changes
- Added the `update` Cobra alias to the `pr edit` command.
- Added a focused command-resolution test covering both `pr edit` and `pr update`.
- Regenerated the `skills/bkt` PR rule doc so the alias is reflected in agent-facing help.

## Testing
- `pre-commit run --files pkg/cmd/pr/pr.go pkg/cmd/pr/edit_alias_test.go skills/bkt/rules/pr.md`
- `go test ./pkg/cmd/pr`

## Risks
- None.
