### PR TITLE
feat: add default reviewers to pr edit

### DIFF
--- a/pkg/bbcloud/client.go
+++ b/pkg/bbcloud/client.go
@@ -145,6 +145,16 @@ func LooksLikeUUID(s string) bool {
 	return uuidPattern.MatchString(strings.TrimSpace(s))
 }
 
+// accountIDPattern matches Atlassian Account IDs: a numeric prefix, a colon,
+// then a UUID (e.g. "557058:12345678-1234-1234-1234-123456789abc").
+var accountIDPattern = regexp.MustCompile(`^\d+:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// LooksLikeAccountID returns true if s matches the Atlassian Account ID
+// format (numeric prefix + colon + UUID).
+func LooksLikeAccountID(s string) bool {
+	return accountIDPattern.MatchString(strings.TrimSpace(s))
+}
+
 // PipelinePage encapsulates paginated pipeline results.
 type PipelinePage struct {
 	Values []Pipeline `json:"values"`

--- a/pkg/bbcloud/client_test.go
+++ b/pkg/bbcloud/client_test.go
@@ -400,6 +400,33 @@ func TestLooksLikeUUID(t *testing.T) {
 	}
 }
 
+func TestLooksLikeAccountID(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"557058:12345678-1234-1234-1234-123456789abc", true},
+		{" 557058:12345678-1234-1234-1234-123456789abc ", true}, // trimmed
+		{"712020:abcdef01-2345-6789-abcd-ef0123456789", true},
+		{"alice", false},
+		{"{550e8400-e29b-41d4-a716-446655440000}", false}, // UUID, not account ID
+		{"550e8400-e29b-41d4-a716-446655440000", false},   // bare UUID
+		{"bob_smith", false},
+		{"user.name", false},
+		{"", false},
+		{":", false},
+		{"abc:12345678-1234-1234-1234-123456789abc", false}, // non-numeric prefix
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := LooksLikeAccountID(tt.input)
+			if got != tt.want {
+				t.Errorf("LooksLikeAccountID(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func newTestClient(t *testing.T, handler http.Handler) *Client {
 	t.Helper()
 	server := httptest.NewServer(handler)

--- a/pkg/bbcloud/pullrequests.go
+++ b/pkg/bbcloud/pullrequests.go
@@ -37,6 +37,7 @@ type PullRequest struct {
 	Author    struct {
 		DisplayName string `json:"display_name"`
 		Username    string `json:"username"`
+		UUID        string `json:"uuid"`
 	} `json:"author"`
 	Source struct {
 		Branch struct {

--- a/pkg/bbcloud/pullrequests.go
+++ b/pkg/bbcloud/pullrequests.go
@@ -38,6 +38,7 @@ type PullRequest struct {
 		DisplayName string `json:"display_name"`
 		Username    string `json:"username"`
 		UUID        string `json:"uuid"`
+		AccountID   string `json:"account_id"`
 	} `json:"author"`
 	Source struct {
 		Branch struct {

--- a/pkg/bbcloud/pullrequests.go
+++ b/pkg/bbcloud/pullrequests.go
@@ -241,11 +241,7 @@ func (c *Client) CreatePullRequest(ctx context.Context, workspace, repoSlug stri
 	if len(input.Reviewers) > 0 {
 		var reviewers []map[string]string
 		for _, reviewer := range input.Reviewers {
-			if LooksLikeUUID(reviewer) {
-				reviewers = append(reviewers, map[string]string{"uuid": NormalizeUUID(reviewer)})
-			} else {
-				reviewers = append(reviewers, map[string]string{"username": reviewer})
-			}
+			reviewers = append(reviewers, reviewerIdentity(reviewer))
 		}
 		body["reviewers"] = reviewers
 	}
@@ -316,6 +312,17 @@ func (c *Client) GetEffectiveDefaultReviewers(ctx context.Context, workspace, re
 	return users, nil
 }
 
+// reviewerIdentity returns the correct API identity map for a reviewer string.
+func reviewerIdentity(reviewer string) map[string]string {
+	if LooksLikeUUID(reviewer) {
+		return map[string]string{"uuid": NormalizeUUID(reviewer)}
+	}
+	if LooksLikeAccountID(reviewer) {
+		return map[string]string{"account_id": reviewer}
+	}
+	return map[string]string{"username": reviewer}
+}
+
 // UpdatePullRequestInput configures PR updates. Use pointers to distinguish
 // between "not set" and "set to empty string" for clearing fields.
 type UpdatePullRequestInput struct {
@@ -346,11 +353,7 @@ func (c *Client) UpdatePullRequest(ctx context.Context, workspace, repoSlug stri
 	if input.Reviewers != nil {
 		reviewers := make([]map[string]string, 0, len(input.Reviewers))
 		for _, reviewer := range input.Reviewers {
-			if LooksLikeUUID(reviewer) {
-				reviewers = append(reviewers, map[string]string{"uuid": NormalizeUUID(reviewer)})
-			} else {
-				reviewers = append(reviewers, map[string]string{"username": reviewer})
-			}
+			reviewers = append(reviewers, reviewerIdentity(reviewer))
 		}
 		body["reviewers"] = reviewers
 	}

--- a/pkg/bbcloud/pullrequests_test.go
+++ b/pkg/bbcloud/pullrequests_test.go
@@ -784,9 +784,19 @@ func TestCreatePullRequestReviewerAutoDetect(t *testing.T) {
 			wantFields: []string{"username"},
 		},
 		{
+			name:       "account_id",
+			reviewers:  []string{"557058:12345678-1234-1234-1234-123456789abc"},
+			wantFields: []string{"account_id"},
+		},
+		{
 			name:       "mixed",
 			reviewers:  []string{"{550e8400-e29b-41d4-a716-446655440000}", "bob"},
 			wantFields: []string{"uuid", "username"},
+		},
+		{
+			name:       "mixed all three",
+			reviewers:  []string{"{550e8400-e29b-41d4-a716-446655440000}", "bob", "557058:12345678-1234-1234-1234-123456789abc"},
+			wantFields: []string{"uuid", "username", "account_id"},
 		},
 	}
 
@@ -1147,7 +1157,7 @@ func TestUpdatePullRequestWithReviewers(t *testing.T) {
 	}))
 
 	_, err := client.UpdatePullRequest(context.Background(), "ws", "repo", 1, bbcloud.UpdatePullRequestInput{
-		Reviewers: []string{"alice", "{550e8400-e29b-41d4-a716-446655440000}"},
+		Reviewers: []string{"alice", "{550e8400-e29b-41d4-a716-446655440000}", "557058:12345678-1234-1234-1234-123456789abc"},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1157,8 +1167,8 @@ func TestUpdatePullRequestWithReviewers(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected reviewers array, got %v", gotBody["reviewers"])
 	}
-	if len(reviewers) != 2 {
-		t.Fatalf("expected 2 reviewers, got %d", len(reviewers))
+	if len(reviewers) != 3 {
+		t.Fatalf("expected 3 reviewers, got %d", len(reviewers))
 	}
 
 	r0 := reviewers[0].(map[string]any)
@@ -1168,6 +1178,71 @@ func TestUpdatePullRequestWithReviewers(t *testing.T) {
 	r1 := reviewers[1].(map[string]any)
 	if r1["uuid"] != "{550e8400-e29b-41d4-a716-446655440000}" {
 		t.Errorf("expected second reviewer by uuid, got %v", r1)
+	}
+	r2 := reviewers[2].(map[string]any)
+	if r2["account_id"] != "557058:12345678-1234-1234-1234-123456789abc" {
+		t.Errorf("expected third reviewer by account_id, got %v", r2)
+	}
+}
+
+func TestUpdatePullRequestReviewerAutoDetect(t *testing.T) {
+	tests := []struct {
+		name       string
+		reviewers  []string
+		wantFields []string
+	}{
+		{
+			name:       "uuid",
+			reviewers:  []string{"{550e8400-e29b-41d4-a716-446655440000}"},
+			wantFields: []string{"uuid"},
+		},
+		{
+			name:       "username",
+			reviewers:  []string{"alice"},
+			wantFields: []string{"username"},
+		},
+		{
+			name:       "account_id",
+			reviewers:  []string{"557058:12345678-1234-1234-1234-123456789abc"},
+			wantFields: []string{"account_id"},
+		},
+		{
+			name:       "mixed all three",
+			reviewers:  []string{"alice", "{550e8400-e29b-41d4-a716-446655440000}", "557058:12345678-1234-1234-1234-123456789abc"},
+			wantFields: []string{"username", "uuid", "account_id"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotBody map[string]any
+			client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewDecoder(r.Body).Decode(&gotBody)
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{"id": 1, "title": "PR"})
+			}))
+
+			_, err := client.UpdatePullRequest(context.Background(), "ws", "repo", 1, bbcloud.UpdatePullRequestInput{
+				Reviewers: tt.reviewers,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			reviewers, ok := gotBody["reviewers"].([]any)
+			if !ok {
+				t.Fatal("reviewers missing from request body")
+			}
+			if len(reviewers) != len(tt.wantFields) {
+				t.Fatalf("expected %d reviewers, got %d", len(tt.wantFields), len(reviewers))
+			}
+			for i, field := range tt.wantFields {
+				rev := reviewers[i].(map[string]any)
+				if _, ok := rev[field]; !ok {
+					t.Errorf("reviewer[%d]: expected %q field, got keys %v", i, field, rev)
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -885,11 +885,12 @@ func editCloudReviewers(w io.Writer, current []bbcloud.User, add, remove []strin
 			}
 		}
 		if !removed {
-			if u.UUID != "" {
+			switch {
+			case u.UUID != "":
 				result = append(result, u.UUID)
-			} else if u.Username != "" {
+			case u.Username != "":
 				result = append(result, u.Username)
-			} else if u.AccountID != "" {
+			case u.AccountID != "":
 				result = append(result, u.AccountID)
 			}
 		}
@@ -910,12 +911,10 @@ func editCloudReviewers(w io.Writer, current []bbcloud.User, add, remove []strin
 			// Suppress warning when the overlap is only with freshly-merged
 			// default reviewers, not with pre-existing PR reviewers.
 			wasPreExisting := false
-			if preExisting != nil {
-				for _, u := range preExisting {
-					if matchesCloudUser(u, r) {
-						wasPreExisting = true
-						break
-					}
+			for _, u := range preExisting {
+				if matchesCloudUser(u, r) {
+					wasPreExisting = true
+					break
 				}
 			}
 			if preExisting == nil || wasPreExisting || added[key] {

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -683,10 +683,10 @@ type createOptions struct {
 	Draft                bool
 }
 
-// mergeReviewers combines explicit reviewer names with default reviewer users,
-// deduplicating across both lists. The nameFunc extracts a username string
-// from each default user value.
-func mergeReviewers[T any](explicit []string, defaults []T, nameFunc func(T) string) []string {
+// mergeCreateReviewers combines explicit reviewer names with default reviewer
+// users during PR creation, deduplicating across both lists. The nameFunc
+// extracts a username string from each default user value.
+func mergeCreateReviewers[T any](explicit []string, defaults []T, nameFunc func(T) string) []string {
 	seen := make(map[string]bool, len(explicit)+len(defaults))
 	var merged []string
 	for _, r := range explicit {
@@ -705,11 +705,12 @@ func mergeReviewers[T any](explicit []string, defaults []T, nameFunc func(T) str
 	return merged
 }
 
-// mergeCloudReviewers combines explicit reviewer strings with default reviewer
-// users for Bitbucket Cloud, deduplicating across username and UUID formats.
+// mergeCloudCreateReviewers combines explicit reviewer strings with default
+// reviewer users for Bitbucket Cloud during PR creation, deduplicating across
+// username and UUID formats.
 // A default reviewer is skipped if any explicit entry matches by username or
 // by normalized UUID. Defaults without a username are identified by UUID.
-func mergeCloudReviewers(explicit []string, defaults []bbcloud.User) []string {
+func mergeCloudCreateReviewers(explicit []string, defaults []bbcloud.User) []string {
 	seen := make(map[string]bool, len(explicit)+len(defaults))
 	var merged []string
 
@@ -778,7 +779,7 @@ func reviewerOverlap(add, remove []string) string {
 // editDCReviewers computes the new reviewer list for a DC pull request by
 // adding and removing reviewers from the current list. Warnings for
 // already-present additions or missing removals are written to w.
-func editDCReviewers(w io.Writer, current []bbdc.PullRequestReviewer, add, remove []string) []bbdc.PullRequestReviewer {
+func editDCReviewers(w io.Writer, current []bbdc.PullRequestReviewer, add, remove []string, preExisting []bbdc.PullRequestReviewer) []bbdc.PullRequestReviewer {
 	removeSet := make(map[string]bool, len(remove))
 	for _, name := range remove {
 		removeSet[name] = true
@@ -802,10 +803,19 @@ func editDCReviewers(w io.Writer, current []bbdc.PullRequestReviewer, add, remov
 		}
 	}
 
+	// Build set of pre-existing reviewer names to suppress warnings for
+	// reviewers that were only added via default-reviewer merge.
+	preExistingNames := make(map[string]bool, len(preExisting))
+	for _, r := range preExisting {
+		preExistingNames[r.User.Name] = true
+	}
+
 	added := make(map[string]bool)
 	for _, name := range add {
 		if currentNames[name] || added[name] {
-			fmt.Fprintf(w, "warning: reviewer %q is already on this pull request\n", name)
+			if preExisting == nil || preExistingNames[name] || added[name] {
+				fmt.Fprintf(w, "warning: reviewer %q is already on this pull request\n", name)
+			}
 		} else {
 			added[name] = true
 			result = append(result, bbdc.PullRequestReviewer{User: bbdc.User{Name: name}})
@@ -821,7 +831,7 @@ func matchesCloudUser(u bbcloud.User, input string) bool {
 	if bbcloud.LooksLikeUUID(input) {
 		return u.UUID == bbcloud.NormalizeUUID(input)
 	}
-	return u.Username == input
+	return u.Username == input || u.AccountID == input
 }
 
 // editCloudReviewers computes the new reviewer list for a Cloud pull request.
@@ -831,7 +841,7 @@ func matchesCloudUser(u bbcloud.User, input string) bool {
 //
 // Returns an error if the same identity appears in both add and remove via
 // different identifier formats (e.g. username in add, UUID in remove).
-func editCloudReviewers(w io.Writer, current []bbcloud.User, add, remove []string) ([]string, error) {
+func editCloudReviewers(w io.Writer, current []bbcloud.User, add, remove []string, preExisting []bbcloud.User) ([]string, error) {
 	// Cross-identity overlap check: resolve add and remove against current
 	// reviewers to detect the same person referenced by different formats.
 	for _, a := range add {
@@ -879,6 +889,8 @@ func editCloudReviewers(w io.Writer, current []bbcloud.User, add, remove []strin
 				result = append(result, u.UUID)
 			} else if u.Username != "" {
 				result = append(result, u.Username)
+			} else if u.AccountID != "" {
+				result = append(result, u.AccountID)
 			}
 		}
 	}
@@ -895,7 +907,20 @@ func editCloudReviewers(w io.Writer, current []bbcloud.User, add, remove []strin
 			}
 		}
 		if alreadyOnPR || added[key] {
-			fmt.Fprintf(w, "warning: reviewer %q is already on this pull request\n", r)
+			// Suppress warning when the overlap is only with freshly-merged
+			// default reviewers, not with pre-existing PR reviewers.
+			wasPreExisting := false
+			if preExisting != nil {
+				for _, u := range preExisting {
+					if matchesCloudUser(u, r) {
+						wasPreExisting = true
+						break
+					}
+				}
+			}
+			if preExisting == nil || wasPreExisting || added[key] {
+				fmt.Fprintf(w, "warning: reviewer %q is already on this pull request\n", r)
+			}
 		} else {
 			added[key] = true
 			result = append(result, r)
@@ -1000,7 +1025,7 @@ func runCreate(cmd *cobra.Command, f *cmdutil.Factory, opts *createOptions) erro
 			if err != nil {
 				return err
 			}
-			reviewers = mergeReviewers(reviewers, defaultUsers, func(u bbdc.User) string { return u.Name })
+			reviewers = mergeCreateReviewers(reviewers, defaultUsers, func(u bbdc.User) string { return u.Name })
 		}
 
 		pr, err := client.CreatePullRequest(ctx, projectKey, repoSlug, bbdc.CreatePROptions{
@@ -1055,7 +1080,7 @@ func runCreate(cmd *cobra.Command, f *cmdutil.Factory, opts *createOptions) erro
 			if err != nil {
 				return err
 			}
-			reviewers = mergeCloudReviewers(reviewers, defaultUsers)
+			reviewers = mergeCloudCreateReviewers(reviewers, defaultUsers)
 		}
 
 		pr, err := client.CreatePullRequest(ctx, workspace, repoSlug, bbcloud.CreatePullRequestInput{
@@ -1347,7 +1372,7 @@ func newEditCmd(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func mergeDCPRReviewers(current []bbdc.PullRequestReviewer, defaults []bbdc.User) []bbdc.PullRequestReviewer {
+func mergeDCEditReviewers(current []bbdc.PullRequestReviewer, defaults []bbdc.User) []bbdc.PullRequestReviewer {
 	seen := make(map[string]bool, len(current)+len(defaults))
 	result := make([]bbdc.PullRequestReviewer, 0, len(current)+len(defaults))
 
@@ -1371,7 +1396,7 @@ func mergeDCPRReviewers(current []bbdc.PullRequestReviewer, defaults []bbdc.User
 	return result
 }
 
-func mergeCloudPRReviewers(current, defaults []bbcloud.User) []bbcloud.User {
+func mergeCloudEditReviewers(current, defaults []bbcloud.User) []bbcloud.User {
 	seen := make(map[string]bool, len(current)+len(defaults))
 	result := make([]bbcloud.User, 0, len(current)+len(defaults))
 
@@ -1428,6 +1453,10 @@ func cloudReviewerIDs(reviewers []bbcloud.User) []string {
 		}
 		if reviewer.Username != "" {
 			ids = append(ids, reviewer.Username)
+			continue
+		}
+		if reviewer.AccountID != "" {
+			ids = append(ids, reviewer.AccountID)
 		}
 	}
 	return ids
@@ -1492,10 +1521,12 @@ func getCloudDefaultReviewers(ctx context.Context, client *bbcloud.Client, works
 }
 
 func runEdit(cmd *cobra.Command, f *cmdutil.Factory, opts *editOptions) error {
-	ios, _ := f.Streams()
+	ios, err := f.Streams()
+	if err != nil {
+		return err
+	}
 
 	override := cmdutil.FlagValue(cmd, "context")
-	var err error
 	_, ctxCfg, host, err := cmdutil.ResolveContext(f, cmd, override)
 	if err != nil {
 		return err
@@ -1534,15 +1565,17 @@ func runEdit(cmd *cobra.Command, f *cmdutil.Factory, opts *editOptions) error {
 		}
 
 		newReviewers := pr.Reviewers
+		var preExistingDC []bbdc.PullRequestReviewer
 		if opts.WithDefaultReviewers {
+			preExistingDC = newReviewers
 			defaultUsers, err := getDCDefaultReviewers(ctx, client, projectKey, repoSlug, pr.FromRef.ID, pr.ToRef.ID)
 			if err != nil {
 				return err
 			}
-			newReviewers = mergeDCPRReviewers(newReviewers, defaultUsers)
+			newReviewers = mergeDCEditReviewers(newReviewers, defaultUsers)
 		}
 		if cmd.Flags().Changed("reviewer") || cmd.Flags().Changed("remove-reviewer") {
-			newReviewers = editDCReviewers(ios.ErrOut, newReviewers, opts.Reviewers, opts.RemoveReviewers)
+			newReviewers = editDCReviewers(ios.ErrOut, newReviewers, opts.Reviewers, opts.RemoveReviewers, preExistingDC)
 		}
 
 		updatedPR, err := client.UpdatePullRequest(ctx, projectKey, repoSlug, opts.ID, pr.Version, bbdc.UpdatePROptions{
@@ -1597,20 +1630,31 @@ func runEdit(cmd *cobra.Command, f *cmdutil.Factory, opts *editOptions) error {
 			}
 
 			currentReviewers := pr.Reviewers
+			var preExistingCloud []bbcloud.User
 			if opts.WithDefaultReviewers {
-				defaultUsers, err := getCloudDefaultReviewers(ctx, client, workspace, repoSlug, bbcloud.User{
+				preExistingCloud = currentReviewers
+				excluded := bbcloud.User{
 					UUID:      pr.Author.UUID,
 					Username:  pr.Author.Username,
 					AccountID: pr.Author.AccountID,
-				})
+				}
+				if len(cloudUserKeys(excluded)) == 0 {
+					fmt.Fprintf(ios.ErrOut, "warning: PR author has no usable identity; falling back to authenticated user for exclusion\n")
+					me, meErr := client.CurrentUser(ctx)
+					if meErr != nil {
+						return fmt.Errorf("PR author has no identity and cannot determine current user: %w", meErr)
+					}
+					excluded = *me
+				}
+				defaultUsers, err := getCloudDefaultReviewers(ctx, client, workspace, repoSlug, excluded)
 				if err != nil {
 					return err
 				}
-				currentReviewers = mergeCloudPRReviewers(currentReviewers, defaultUsers)
+				currentReviewers = mergeCloudEditReviewers(currentReviewers, defaultUsers)
 			}
 
 			if cmd.Flags().Changed("reviewer") || cmd.Flags().Changed("remove-reviewer") {
-				reviewers, err := editCloudReviewers(ios.ErrOut, currentReviewers, opts.Reviewers, opts.RemoveReviewers)
+				reviewers, err := editCloudReviewers(ios.ErrOut, currentReviewers, opts.Reviewers, opts.RemoveReviewers, preExistingCloud)
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -1458,12 +1458,10 @@ func getCloudDefaultReviewers(ctx context.Context, client *bbcloud.Client, works
 }
 
 func runEdit(cmd *cobra.Command, f *cmdutil.Factory, opts *editOptions) error {
-	ios, err := f.Streams()
-	if err != nil {
-		return err
-	}
+	ios, _ := f.Streams()
 
 	override := cmdutil.FlagValue(cmd, "context")
+	var err error
 	_, ctxCfg, host, err := cmdutil.ResolveContext(f, cmd, override)
 	if err != nil {
 		return err

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -1376,21 +1376,17 @@ func mergeCloudPRReviewers(current, defaults []bbcloud.User) []bbcloud.User {
 	result := make([]bbcloud.User, 0, len(current)+len(defaults))
 
 	addUser := func(user bbcloud.User) {
-		uuidKey := ""
-		if user.UUID != "" {
-			uuidKey = bbcloud.NormalizeUUID(user.UUID)
-		}
-		if (user.Username != "" && seen[user.Username]) || (uuidKey != "" && seen[uuidKey]) {
+		keys := cloudUserKeys(user)
+		if len(keys) == 0 {
 			return
 		}
-		if user.Username == "" && uuidKey == "" {
-			return
+		for _, key := range keys {
+			if seen[key] {
+				return
+			}
 		}
-		if user.Username != "" {
-			seen[user.Username] = true
-		}
-		if uuidKey != "" {
-			seen[uuidKey] = true
+		for _, key := range keys {
+			seen[key] = true
 		}
 		result = append(result, user)
 	}
@@ -1406,8 +1402,26 @@ func mergeCloudPRReviewers(current, defaults []bbcloud.User) []bbcloud.User {
 }
 
 func cloudReviewerIDs(reviewers []bbcloud.User) []string {
+	seen := make(map[string]bool, len(reviewers))
 	ids := make([]string, 0, len(reviewers))
 	for _, reviewer := range reviewers {
+		keys := cloudUserKeys(reviewer)
+		if len(keys) == 0 {
+			continue
+		}
+		duplicate := false
+		for _, key := range keys {
+			if seen[key] {
+				duplicate = true
+				break
+			}
+		}
+		if duplicate {
+			continue
+		}
+		for _, key := range keys {
+			seen[key] = true
+		}
 		if reviewer.UUID != "" {
 			ids = append(ids, reviewer.UUID)
 			continue
@@ -1427,15 +1441,35 @@ func getDCDefaultReviewers(ctx context.Context, client *bbdc.Client, projectKey,
 	return defaultUsers, nil
 }
 
+func cloudUserKeys(user bbcloud.User) []string {
+	keys := make([]string, 0, 3)
+	if user.UUID != "" {
+		keys = append(keys, "uuid:"+bbcloud.NormalizeUUID(user.UUID))
+	}
+	if user.AccountID != "" {
+		keys = append(keys, "account_id:"+user.AccountID)
+	}
+	if user.Username != "" {
+		keys = append(keys, "username:"+user.Username)
+	}
+	return keys
+}
+
 func sameCloudUser(a, b bbcloud.User) bool {
-	switch {
-	case a.UUID != "" && b.UUID != "":
-		return bbcloud.NormalizeUUID(a.UUID) == bbcloud.NormalizeUUID(b.UUID)
-	case a.Username != "" && b.Username != "":
-		return a.Username == b.Username
-	default:
+	keys := cloudUserKeys(a)
+	if len(keys) == 0 {
 		return false
 	}
+	seen := make(map[string]bool, len(keys))
+	for _, key := range keys {
+		seen[key] = true
+	}
+	for _, key := range cloudUserKeys(b) {
+		if seen[key] {
+			return true
+		}
+	}
+	return false
 }
 
 func filterCloudUsers(users []bbcloud.User, excluded bbcloud.User) []bbcloud.User {
@@ -1565,8 +1599,9 @@ func runEdit(cmd *cobra.Command, f *cmdutil.Factory, opts *editOptions) error {
 			currentReviewers := pr.Reviewers
 			if opts.WithDefaultReviewers {
 				defaultUsers, err := getCloudDefaultReviewers(ctx, client, workspace, repoSlug, bbcloud.User{
-					UUID:     pr.Author.UUID,
-					Username: pr.Author.Username,
+					UUID:      pr.Author.UUID,
+					Username:  pr.Author.Username,
+					AccountID: pr.Author.AccountID,
 				})
 				if err != nil {
 					return err

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -996,9 +996,9 @@ func runCreate(cmd *cobra.Command, f *cmdutil.Factory, opts *createOptions) erro
 
 		reviewers := opts.Reviewers
 		if opts.WithDefaultReviewers {
-			defaultUsers, err := client.GetDefaultReviewers(ctx, projectKey, repoSlug, opts.Source, opts.Target)
+			defaultUsers, err := getDCDefaultReviewers(ctx, client, projectKey, repoSlug, opts.Source, opts.Target)
 			if err != nil {
-				return fmt.Errorf("fetching default reviewers: %w", err)
+				return err
 			}
 			reviewers = mergeReviewers(reviewers, defaultUsers, func(u bbdc.User) string { return u.Name })
 		}
@@ -1051,20 +1051,11 @@ func runCreate(cmd *cobra.Command, f *cmdutil.Factory, opts *createOptions) erro
 			if err != nil {
 				return fmt.Errorf("resolving current user: %w", err)
 			}
-			defaultUsers, err := client.GetEffectiveDefaultReviewers(ctx, workspace, repoSlug)
+			defaultUsers, err := getCloudDefaultReviewers(ctx, client, workspace, repoSlug, *me)
 			if err != nil {
-				return fmt.Errorf("fetching default reviewers: %w", err)
+				return err
 			}
-			// Filter out the current user — Bitbucket Cloud rejects PRs where
-			// the author is listed as a reviewer. Compare by UUID because
-			// host.Username may be an email and User.Username can be empty.
-			var filtered []bbcloud.User
-			for _, u := range defaultUsers {
-				if u.UUID != me.UUID {
-					filtered = append(filtered, u)
-				}
-			}
-			reviewers = mergeCloudReviewers(reviewers, filtered)
+			reviewers = mergeCloudReviewers(reviewers, defaultUsers)
 		}
 
 		pr, err := client.CreatePullRequest(ctx, workspace, repoSlug, bbcloud.CreatePullRequestInput{
@@ -1271,15 +1262,16 @@ func resolveGitBaseRef(ctx context.Context, targetBranch, remoteName string) (st
 }
 
 type editOptions struct {
-	Project         string
-	Workspace       string
-	Repo            string
-	ID              int
-	Title           string
-	Description     string
-	Body            string
-	Reviewers       []string
-	RemoveReviewers []string
+	Project              string
+	Workspace            string
+	Repo                 string
+	ID                   int
+	Title                string
+	Description          string
+	Body                 string
+	Reviewers            []string
+	RemoveReviewers      []string
+	WithDefaultReviewers bool
 }
 
 func newEditCmd(f *cmdutil.Factory) *cobra.Command {
@@ -1302,6 +1294,9 @@ func newEditCmd(f *cmdutil.Factory) *cobra.Command {
 
   # Remove a reviewer
   bkt pr edit 123 --remove-reviewer alice
+
+  # Add repository default reviewers
+  bkt pr edit 123 --with-default-reviewers
 
   # Add and remove reviewers in one call
   bkt pr edit 123 --reviewer charlie --remove-reviewer alice`,
@@ -1330,9 +1325,9 @@ func newEditCmd(f *cmdutil.Factory) *cobra.Command {
 
 			// Require at least one field to update
 			hasFieldChange := cmd.Flags().Changed("title") || cmd.Flags().Changed("description") || cmd.Flags().Changed("body")
-			hasReviewerChange := cmd.Flags().Changed("reviewer") || cmd.Flags().Changed("remove-reviewer")
+			hasReviewerChange := cmd.Flags().Changed("reviewer") || cmd.Flags().Changed("remove-reviewer") || opts.WithDefaultReviewers
 			if !hasFieldChange && !hasReviewerChange {
-				return fmt.Errorf("at least one of --title, --body, --description, --reviewer, or --remove-reviewer is required")
+				return fmt.Errorf("at least one of --title, --body, --description, --reviewer, --remove-reviewer, or --with-default-reviewers is required")
 			}
 
 			return runEdit(cmd, f, opts)
@@ -1347,8 +1342,119 @@ func newEditCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "Set the new body (alias for --description).")
 	cmd.Flags().StringSliceVar(&opts.Reviewers, "reviewer", nil, "Reviewer username or {UUID} to add (repeatable)")
 	cmd.Flags().StringSliceVar(&opts.RemoveReviewers, "remove-reviewer", nil, "Reviewer username or {UUID} to remove (repeatable)")
+	cmd.Flags().BoolVar(&opts.WithDefaultReviewers, "with-default-reviewers", false, "Add repository default reviewers")
 
 	return cmd
+}
+
+func mergeDCPRReviewers(current []bbdc.PullRequestReviewer, defaults []bbdc.User) []bbdc.PullRequestReviewer {
+	seen := make(map[string]bool, len(current)+len(defaults))
+	result := make([]bbdc.PullRequestReviewer, 0, len(current)+len(defaults))
+
+	for _, reviewer := range current {
+		name := reviewer.User.Name
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		result = append(result, reviewer)
+	}
+
+	for _, user := range defaults {
+		if user.Name == "" || seen[user.Name] {
+			continue
+		}
+		seen[user.Name] = true
+		result = append(result, bbdc.PullRequestReviewer{User: user})
+	}
+
+	return result
+}
+
+func mergeCloudPRReviewers(current, defaults []bbcloud.User) []bbcloud.User {
+	seen := make(map[string]bool, len(current)+len(defaults))
+	result := make([]bbcloud.User, 0, len(current)+len(defaults))
+
+	addUser := func(user bbcloud.User) {
+		uuidKey := ""
+		if user.UUID != "" {
+			uuidKey = bbcloud.NormalizeUUID(user.UUID)
+		}
+		if (user.Username != "" && seen[user.Username]) || (uuidKey != "" && seen[uuidKey]) {
+			return
+		}
+		if user.Username == "" && uuidKey == "" {
+			return
+		}
+		if user.Username != "" {
+			seen[user.Username] = true
+		}
+		if uuidKey != "" {
+			seen[uuidKey] = true
+		}
+		result = append(result, user)
+	}
+
+	for _, user := range current {
+		addUser(user)
+	}
+	for _, user := range defaults {
+		addUser(user)
+	}
+
+	return result
+}
+
+func cloudReviewerIDs(reviewers []bbcloud.User) []string {
+	ids := make([]string, 0, len(reviewers))
+	for _, reviewer := range reviewers {
+		if reviewer.UUID != "" {
+			ids = append(ids, reviewer.UUID)
+			continue
+		}
+		if reviewer.Username != "" {
+			ids = append(ids, reviewer.Username)
+		}
+	}
+	return ids
+}
+
+func getDCDefaultReviewers(ctx context.Context, client *bbdc.Client, projectKey, repoSlug, sourceRef, targetRef string) ([]bbdc.User, error) {
+	defaultUsers, err := client.GetDefaultReviewers(ctx, projectKey, repoSlug, sourceRef, targetRef)
+	if err != nil {
+		return nil, fmt.Errorf("fetching default reviewers: %w", err)
+	}
+	return defaultUsers, nil
+}
+
+func sameCloudUser(a, b bbcloud.User) bool {
+	switch {
+	case a.UUID != "" && b.UUID != "":
+		return bbcloud.NormalizeUUID(a.UUID) == bbcloud.NormalizeUUID(b.UUID)
+	case a.Username != "" && b.Username != "":
+		return a.Username == b.Username
+	default:
+		return false
+	}
+}
+
+func filterCloudUsers(users []bbcloud.User, excluded bbcloud.User) []bbcloud.User {
+	filtered := make([]bbcloud.User, 0, len(users))
+	for _, user := range users {
+		if sameCloudUser(user, excluded) {
+			continue
+		}
+		filtered = append(filtered, user)
+	}
+	return filtered
+}
+
+func getCloudDefaultReviewers(ctx context.Context, client *bbcloud.Client, workspace, repoSlug string, excluded bbcloud.User) ([]bbcloud.User, error) {
+	defaultUsers, err := client.GetEffectiveDefaultReviewers(ctx, workspace, repoSlug)
+	if err != nil {
+		return nil, fmt.Errorf("fetching default reviewers: %w", err)
+	}
+	return filterCloudUsers(defaultUsers, excluded), nil
 }
 
 func runEdit(cmd *cobra.Command, f *cmdutil.Factory, opts *editOptions) error {
@@ -1396,8 +1502,15 @@ func runEdit(cmd *cobra.Command, f *cmdutil.Factory, opts *editOptions) error {
 		}
 
 		newReviewers := pr.Reviewers
+		if opts.WithDefaultReviewers {
+			defaultUsers, err := getDCDefaultReviewers(ctx, client, projectKey, repoSlug, pr.FromRef.ID, pr.ToRef.ID)
+			if err != nil {
+				return err
+			}
+			newReviewers = mergeDCPRReviewers(newReviewers, defaultUsers)
+		}
 		if cmd.Flags().Changed("reviewer") || cmd.Flags().Changed("remove-reviewer") {
-			newReviewers = editDCReviewers(ios.ErrOut, pr.Reviewers, opts.Reviewers, opts.RemoveReviewers)
+			newReviewers = editDCReviewers(ios.ErrOut, newReviewers, opts.Reviewers, opts.RemoveReviewers)
 		}
 
 		updatedPR, err := client.UpdatePullRequest(ctx, projectKey, repoSlug, opts.ID, pr.Version, bbdc.UpdatePROptions{
@@ -1445,16 +1558,33 @@ func runEdit(cmd *cobra.Command, f *cmdutil.Factory, opts *editOptions) error {
 		if cmd.Flags().Changed("description") || cmd.Flags().Changed("body") {
 			input.Description = &opts.Description
 		}
-		if cmd.Flags().Changed("reviewer") || cmd.Flags().Changed("remove-reviewer") {
+		if cmd.Flags().Changed("reviewer") || cmd.Flags().Changed("remove-reviewer") || opts.WithDefaultReviewers {
 			pr, err := client.GetPullRequest(ctx, workspace, repoSlug, opts.ID)
 			if err != nil {
 				return err
 			}
-			reviewers, err := editCloudReviewers(ios.ErrOut, pr.Reviewers, opts.Reviewers, opts.RemoveReviewers)
-			if err != nil {
-				return err
+
+			currentReviewers := pr.Reviewers
+			if opts.WithDefaultReviewers {
+				defaultUsers, err := getCloudDefaultReviewers(ctx, client, workspace, repoSlug, bbcloud.User{
+					UUID:     pr.Author.UUID,
+					Username: pr.Author.Username,
+				})
+				if err != nil {
+					return err
+				}
+				currentReviewers = mergeCloudPRReviewers(currentReviewers, defaultUsers)
 			}
-			input.Reviewers = reviewers
+
+			if cmd.Flags().Changed("reviewer") || cmd.Flags().Changed("remove-reviewer") {
+				reviewers, err := editCloudReviewers(ios.ErrOut, currentReviewers, opts.Reviewers, opts.RemoveReviewers)
+				if err != nil {
+					return err
+				}
+				input.Reviewers = reviewers
+			} else {
+				input.Reviewers = cloudReviewerIDs(currentReviewers)
+			}
 		}
 
 		updatedPR, err := client.UpdatePullRequest(ctx, workspace, repoSlug, opts.ID, input)

--- a/pkg/cmd/pr/pr_test.go
+++ b/pkg/cmd/pr/pr_test.go
@@ -3681,6 +3681,334 @@ func TestRunEditCloudWithDefaultReviewersFalseDoesNotFetchDefaults(t *testing.T)
 	}
 }
 
+func TestRunEditDataCenterErrors(t *testing.T) {
+	tests := []struct {
+		name          string
+		cfg           *config.Config
+		args          []string
+		handler       http.HandlerFunc
+		errorContains string
+	}{
+		{
+			name: "missing project and repo",
+			cfg: &config.Config{
+				ActiveContext: "default",
+				Contexts: map[string]*config.Context{
+					"default": {Host: "main"},
+				},
+				Hosts: map[string]*config.Host{
+					"main": {Kind: "dc", BaseURL: "https://bitbucket.example.com", Token: "test-token"},
+				},
+			},
+			args:          []string{"1", "--title", "Updated"},
+			errorContains: "context must supply project and repo",
+		},
+		{
+			name: "invalid dc client config",
+			cfg: &config.Config{
+				ActiveContext: "default",
+				Contexts: map[string]*config.Context{
+					"default": {Host: "main", ProjectKey: "PROJ", DefaultRepo: "repo"},
+				},
+				Hosts: map[string]*config.Host{
+					"main": {Kind: "dc", BaseURL: "", Token: "test-token"},
+				},
+			},
+			args:          []string{"1", "--title", "Updated"},
+			errorContains: "has no base URL configured",
+		},
+		{
+			name: "get pull request error",
+			cfg: &config.Config{
+				ActiveContext: "default",
+				Contexts: map[string]*config.Context{
+					"default": {Host: "main", ProjectKey: "PROJ", DefaultRepo: "repo"},
+				},
+				Hosts: map[string]*config.Host{
+					"main": {Kind: "dc", BaseURL: "http://placeholder", Token: "test-token"},
+				},
+			},
+			args: []string{"1", "--title", "Updated"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "boom", http.StatusInternalServerError)
+			},
+			errorContains: "500 Internal Server Error",
+		},
+		{
+			name: "default reviewers error",
+			cfg: &config.Config{
+				ActiveContext: "default",
+				Contexts: map[string]*config.Context{
+					"default": {Host: "main", ProjectKey: "PROJ", DefaultRepo: "repo"},
+				},
+				Hosts: map[string]*config.Host{
+					"main": {Kind: "dc", BaseURL: "http://placeholder", Token: "test-token"},
+				},
+			},
+			args: []string{"1", "--with-default-reviewers"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if strings.Contains(r.URL.Path, "/default-reviewers/") {
+					http.Error(w, "boom", http.StatusInternalServerError)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(bbdc.PullRequest{
+					ID: 1, Title: "PR", Version: 1,
+					FromRef: bbdc.Ref{ID: "refs/heads/feature/auth", Repository: bbdc.Repository{Slug: "repo", Project: &bbdc.Project{Key: "PROJ"}}},
+					ToRef:   bbdc.Ref{ID: "refs/heads/main", Repository: bbdc.Repository{Slug: "repo", Project: &bbdc.Project{Key: "PROJ"}}},
+				})
+			},
+			errorContains: "fetching default reviewers",
+		},
+		{
+			name: "update error",
+			cfg: &config.Config{
+				ActiveContext: "default",
+				Contexts: map[string]*config.Context{
+					"default": {Host: "main", ProjectKey: "PROJ", DefaultRepo: "repo"},
+				},
+				Hosts: map[string]*config.Host{
+					"main": {Kind: "dc", BaseURL: "http://placeholder", Token: "test-token"},
+				},
+			},
+			args: []string{"1", "--title", "Updated"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.Method == "GET" {
+					_ = json.NewEncoder(w).Encode(bbdc.PullRequest{
+						ID: 1, Title: "PR", Version: 1,
+						FromRef: bbdc.Ref{ID: "refs/heads/feature/auth", Repository: bbdc.Repository{Slug: "repo", Project: &bbdc.Project{Key: "PROJ"}}},
+						ToRef:   bbdc.Ref{ID: "refs/heads/main", Repository: bbdc.Repository{Slug: "repo", Project: &bbdc.Project{Key: "PROJ"}}},
+					})
+					return
+				}
+				http.Error(w, "boom", http.StatusInternalServerError)
+			},
+			errorContains: "500 Internal Server Error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.handler != nil {
+				server := httptest.NewServer(tt.handler)
+				defer server.Close()
+				tt.cfg.Hosts["main"].BaseURL = server.URL
+			}
+
+			f := &cmdutil.Factory{
+				AppVersion:     "test",
+				ExecutableName: "bkt",
+				IOStreams:      &iostreams.IOStreams{Out: &strings.Builder{}, ErrOut: &strings.Builder{}},
+				Config:         func() (*config.Config, error) { return tt.cfg, nil },
+			}
+
+			cmd := newEditCmd(f)
+			cmd.SilenceErrors = true
+			cmd.SilenceUsage = true
+			cmd.SetArgs(tt.args)
+			cmd.SetContext(context.Background())
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.errorContains)
+			}
+			if !strings.Contains(err.Error(), tt.errorContains) {
+				t.Fatalf("expected error containing %q, got %q", tt.errorContains, err.Error())
+			}
+		})
+	}
+}
+
+func TestRunEditCloudErrors(t *testing.T) {
+	const aliceUUID = "{550e8400-e29b-41d4-a716-446655440000}"
+
+	tests := []struct {
+		name          string
+		cfg           *config.Config
+		args          []string
+		handler       http.HandlerFunc
+		errorContains string
+	}{
+		{
+			name: "missing workspace and repo",
+			cfg: &config.Config{
+				ActiveContext: "default",
+				Contexts: map[string]*config.Context{
+					"default": {Host: "cloud"},
+				},
+				Hosts: map[string]*config.Host{
+					"cloud": {Kind: "cloud", BaseURL: "https://api.bitbucket.org/2.0", Token: "test-token"},
+				},
+			},
+			args:          []string{"1", "--title", "Updated"},
+			errorContains: "context must supply workspace and repo",
+		},
+		{
+			name: "invalid cloud client config",
+			cfg: &config.Config{
+				ActiveContext: "default",
+				Contexts: map[string]*config.Context{
+					"default": {Host: "cloud", Workspace: "ws", DefaultRepo: "repo"},
+				},
+				Hosts: map[string]*config.Host{
+					"cloud": {Kind: "cloud", BaseURL: "://bad", Token: "test-token"},
+				},
+			},
+			args:          []string{"1", "--title", "Updated"},
+			errorContains: "missing protocol scheme",
+		},
+		{
+			name: "get pull request error",
+			cfg: &config.Config{
+				ActiveContext: "default",
+				Contexts: map[string]*config.Context{
+					"default": {Host: "cloud", Workspace: "ws", DefaultRepo: "repo"},
+				},
+				Hosts: map[string]*config.Host{
+					"cloud": {Kind: "cloud", BaseURL: "http://placeholder", Token: "test-token"},
+				},
+			},
+			args: []string{"1", "--reviewer", "bob"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "boom", http.StatusInternalServerError)
+			},
+			errorContains: "500 Internal Server Error",
+		},
+		{
+			name: "default reviewers error",
+			cfg: &config.Config{
+				ActiveContext: "default",
+				Contexts: map[string]*config.Context{
+					"default": {Host: "cloud", Workspace: "ws", DefaultRepo: "repo"},
+				},
+				Hosts: map[string]*config.Host{
+					"cloud": {Kind: "cloud", BaseURL: "http://placeholder", Token: "test-token"},
+				},
+			},
+			args: []string{"1", "--with-default-reviewers"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if strings.Contains(r.URL.Path, "effective-default-reviewers") {
+					http.Error(w, "boom", http.StatusInternalServerError)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(bbcloud.PullRequest{
+					ID:    1,
+					Title: "PR",
+					Author: struct {
+						DisplayName string `json:"display_name"`
+						Username    string `json:"username"`
+						UUID        string `json:"uuid"`
+					}{Username: "alice", UUID: aliceUUID},
+				})
+			},
+			errorContains: "fetching default reviewers",
+		},
+		{
+			name: "edit reviewers error",
+			cfg: &config.Config{
+				ActiveContext: "default",
+				Contexts: map[string]*config.Context{
+					"default": {Host: "cloud", Workspace: "ws", DefaultRepo: "repo"},
+				},
+				Hosts: map[string]*config.Host{
+					"cloud": {Kind: "cloud", BaseURL: "http://placeholder", Token: "test-token"},
+				},
+			},
+			args: []string{"1", "--reviewer", "alice", "--remove-reviewer", aliceUUID},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(bbcloud.PullRequest{
+					ID:    1,
+					Title: "PR",
+					Reviewers: []bbcloud.User{
+						{Username: "alice", UUID: aliceUUID},
+					},
+				})
+			},
+			errorContains: "cannot be in both flags",
+		},
+		{
+			name: "update error",
+			cfg: &config.Config{
+				ActiveContext: "default",
+				Contexts: map[string]*config.Context{
+					"default": {Host: "cloud", Workspace: "ws", DefaultRepo: "repo"},
+				},
+				Hosts: map[string]*config.Host{
+					"cloud": {Kind: "cloud", BaseURL: "http://placeholder", Token: "test-token"},
+				},
+			},
+			args: []string{"1", "--title", "Updated"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == "PUT" {
+					http.Error(w, "boom", http.StatusInternalServerError)
+					return
+				}
+				http.NotFound(w, r)
+			},
+			errorContains: "500 Internal Server Error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.handler != nil {
+				server := httptest.NewServer(tt.handler)
+				defer server.Close()
+				tt.cfg.Hosts["cloud"].BaseURL = server.URL
+			}
+
+			f := &cmdutil.Factory{
+				AppVersion:     "test",
+				ExecutableName: "bkt",
+				IOStreams:      &iostreams.IOStreams{Out: &strings.Builder{}, ErrOut: &strings.Builder{}},
+				Config:         func() (*config.Config, error) { return tt.cfg, nil },
+			}
+
+			cmd := newEditCmd(f)
+			cmd.SilenceErrors = true
+			cmd.SilenceUsage = true
+			cmd.SetArgs(tt.args)
+			cmd.SetContext(context.Background())
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.errorContains)
+			}
+			if !strings.Contains(err.Error(), tt.errorContains) {
+				t.Fatalf("expected error containing %q, got %q", tt.errorContains, err.Error())
+			}
+		})
+	}
+}
+
+func TestRunEditResolveContextError(t *testing.T) {
+	f := &cmdutil.Factory{
+		AppVersion:     "test",
+		ExecutableName: "bkt",
+		IOStreams:      &iostreams.IOStreams{Out: &strings.Builder{}, ErrOut: &strings.Builder{}},
+		Config: func() (*config.Config, error) {
+			return nil, errors.New("config boom")
+		},
+	}
+
+	cmd := newEditCmd(f)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"1", "--title", "Updated"})
+	cmd.SetContext(context.Background())
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "config boom") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestListWorkspaceCloudUsernameFallback(t *testing.T) {
 	// Change to a temp directory without a git repo to prevent
 	// applyRemoteDefaults from overwriting test context values.
@@ -4386,6 +4714,155 @@ func TestMergeReviewers(t *testing.T) {
 				if v != tt.want[i] {
 					t.Errorf("mergeReviewers()[%d] = %q, want %q", i, v, tt.want[i])
 				}
+			}
+		})
+	}
+}
+
+func TestResolveGitBaseRefError(t *testing.T) {
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(origWd)
+	})
+
+	_, err = resolveGitBaseRef(context.Background(), "missing-branch", "origin")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), `could not resolve base branch "missing-branch"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMergeDCPRReviewers(t *testing.T) {
+	got := mergeDCPRReviewers(
+		[]bbdc.PullRequestReviewer{
+			{User: bbdc.User{Name: "alice"}},
+			{User: bbdc.User{Name: ""}},
+			{User: bbdc.User{Name: "alice"}},
+		},
+		[]bbdc.User{
+			{Name: "alice"},
+			{Name: "bob"},
+			{Name: ""},
+		},
+	)
+
+	var names []string
+	for _, reviewer := range got {
+		names = append(names, reviewer.User.Name)
+	}
+	want := []string{"alice", "bob"}
+	if len(names) != len(want) {
+		t.Fatalf("got %v, want %v", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("got %v, want %v", names, want)
+		}
+	}
+}
+
+func TestMergeCloudPRReviewers(t *testing.T) {
+	got := mergeCloudPRReviewers(
+		[]bbcloud.User{
+			{Username: "alice", UUID: "{00000000-0000-0000-0000-000000000001}"},
+			{},
+		},
+		[]bbcloud.User{
+			{Username: "alice", UUID: "{00000000-0000-0000-0000-000000000001}"},
+			{UUID: "{00000000-0000-0000-0000-000000000002}"},
+			{Username: "bob", UUID: "{00000000-0000-0000-0000-000000000002}"},
+			{},
+		},
+	)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 reviewers, got %v", got)
+	}
+	if got[0].Username != "alice" {
+		t.Fatalf("expected alice first, got %v", got[0])
+	}
+	if got[1].UUID != "{00000000-0000-0000-0000-000000000002}" {
+		t.Fatalf("expected second reviewer UUID preserved, got %v", got[1])
+	}
+}
+
+func TestCloudReviewerIDs(t *testing.T) {
+	got := cloudReviewerIDs([]bbcloud.User{
+		{UUID: "{00000000-0000-0000-0000-000000000001}"},
+		{Username: "bob"},
+		{},
+	})
+	want := []string{"{00000000-0000-0000-0000-000000000001}", "bob"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
+func TestGetDCDefaultReviewersError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client, err := bbdc.New(bbdc.Options{BaseURL: server.URL, Username: "u", Token: "t"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_, err = getDCDefaultReviewers(context.Background(), client, "PROJ", "repo", "feature", "main")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "fetching default reviewers") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSameCloudUser(t *testing.T) {
+	tests := []struct {
+		name string
+		a    bbcloud.User
+		b    bbcloud.User
+		want bool
+	}{
+		{
+			name: "same uuid",
+			a:    bbcloud.User{UUID: "{00000000-0000-0000-0000-000000000001}"},
+			b:    bbcloud.User{UUID: "00000000-0000-0000-0000-000000000001"},
+			want: true,
+		},
+		{
+			name: "same username",
+			a:    bbcloud.User{Username: "alice"},
+			b:    bbcloud.User{Username: "alice"},
+			want: true,
+		},
+		{
+			name: "no shared identity",
+			a:    bbcloud.User{},
+			b:    bbcloud.User{Username: "alice"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sameCloudUser(tt.a, tt.b); got != tt.want {
+				t.Fatalf("sameCloudUser() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/cmd/pr/pr_test.go
+++ b/pkg/cmd/pr/pr_test.go
@@ -3463,6 +3463,7 @@ func TestRunEditCloudReviewers(t *testing.T) {
 					DisplayName string "json:\"display_name\""
 					Username    string "json:\"username\""
 					UUID        string "json:\"uuid\""
+					AccountID   string "json:\"account_id\""
 				}{
 					DisplayName: "Alice",
 					Username:    "alice",
@@ -3485,6 +3486,49 @@ func TestRunEditCloudReviewers(t *testing.T) {
 				r1 := reviewers[1].(map[string]any)
 				if r1["uuid"] != carolUUID {
 					t.Fatalf("expected second reviewer to add carol by uuid, got %v", r1)
+				}
+			},
+		},
+		{
+			name:         "add default reviewers dedups and excludes author across account id",
+			withDefaults: true,
+			defaultReviewers: []map[string]any{
+				{"user": map[string]any{"username": "alice", "account_id": "acc-alice"}},
+				{"user": map[string]any{"username": "bob", "account_id": "acc-bob"}},
+				{"user": map[string]any{"username": "carol", "account_id": "acc-carol"}},
+			},
+			prResponse: bbcloud.PullRequest{
+				ID:    1,
+				Title: "PR",
+				Author: struct {
+					DisplayName string "json:\"display_name\""
+					Username    string "json:\"username\""
+					UUID        string "json:\"uuid\""
+					AccountID   string "json:\"account_id\""
+				}{
+					DisplayName: "Alice",
+					UUID:        aliceUUID,
+					AccountID:   "acc-alice",
+				},
+				Reviewers: []bbcloud.User{
+					{UUID: bobUUID, AccountID: "acc-bob"},
+				},
+			},
+			putBodyCheck: func(t *testing.T, body map[string]any) {
+				reviewers, ok := body["reviewers"].([]any)
+				if !ok {
+					t.Fatalf("reviewers not found or wrong type")
+				}
+				if len(reviewers) != 2 {
+					t.Fatalf("expected 2 reviewers after dedup/exclusion, got %d", len(reviewers))
+				}
+				r0 := reviewers[0].(map[string]any)
+				if r0["uuid"] != bobUUID {
+					t.Fatalf("expected existing bob reviewer preserved by uuid, got %v", r0)
+				}
+				r1 := reviewers[1].(map[string]any)
+				if r1["username"] != "carol" {
+					t.Fatalf("expected only carol to be added, got %v", r1)
 				}
 			},
 		},
@@ -3900,6 +3944,7 @@ func TestRunEditCloudErrors(t *testing.T) {
 						DisplayName string `json:"display_name"`
 						Username    string `json:"username"`
 						UUID        string `json:"uuid"`
+						AccountID   string `json:"account_id"`
 					}{Username: "alice", UUID: aliceUUID},
 				})
 			},
@@ -4795,11 +4840,50 @@ func TestMergeCloudPRReviewers(t *testing.T) {
 	}
 }
 
+func TestMergeCloudPRReviewersDedupsAcrossAccountID(t *testing.T) {
+	got := mergeCloudPRReviewers(
+		[]bbcloud.User{
+			{UUID: "{00000000-0000-0000-0000-000000000001}", AccountID: "acc-alice"},
+		},
+		[]bbcloud.User{
+			{Username: "alice", AccountID: "acc-alice"},
+			{Username: "bob", AccountID: "acc-bob"},
+		},
+	)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 reviewers, got %v", got)
+	}
+	if got[0].UUID != "{00000000-0000-0000-0000-000000000001}" {
+		t.Fatalf("expected existing reviewer preserved, got %v", got[0])
+	}
+	if got[1].Username != "bob" {
+		t.Fatalf("expected bob added, got %v", got[1])
+	}
+}
+
 func TestCloudReviewerIDs(t *testing.T) {
 	got := cloudReviewerIDs([]bbcloud.User{
 		{UUID: "{00000000-0000-0000-0000-000000000001}"},
 		{Username: "bob"},
 		{},
+	})
+	want := []string{"{00000000-0000-0000-0000-000000000001}", "bob"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
+func TestCloudReviewerIDsDedupAcrossAccountID(t *testing.T) {
+	got := cloudReviewerIDs([]bbcloud.User{
+		{UUID: "{00000000-0000-0000-0000-000000000001}", AccountID: "acc-alice"},
+		{Username: "alice", AccountID: "acc-alice"},
+		{Username: "bob", AccountID: "acc-bob"},
 	})
 	want := []string{"{00000000-0000-0000-0000-000000000001}", "bob"}
 	if len(got) != len(want) {
@@ -4849,6 +4933,12 @@ func TestSameCloudUser(t *testing.T) {
 			name: "same username",
 			a:    bbcloud.User{Username: "alice"},
 			b:    bbcloud.User{Username: "alice"},
+			want: true,
+		},
+		{
+			name: "same account id bridges mixed identifiers",
+			a:    bbcloud.User{UUID: "{00000000-0000-0000-0000-000000000001}", AccountID: "acc-alice"},
+			b:    bbcloud.User{Username: "alice", AccountID: "acc-alice"},
 			want: true,
 		},
 		{

--- a/pkg/cmd/pr/pr_test.go
+++ b/pkg/cmd/pr/pr_test.go
@@ -3084,6 +3084,12 @@ func TestEditCloudReviewers(t *testing.T) {
 			remove:  []string{aliceUUID},
 			wantErr: "cannot be in both flags",
 		},
+		{
+			name:    "keep username-only reviewer serializes username",
+			current: []bbcloud.User{{Username: "alice"}, {UUID: bobUUID, Username: "bob"}},
+			add:     []string{"charlie"},
+			want:    []string{"alice", bobUUID, "charlie"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -4130,6 +4136,37 @@ func TestRunEditCloudErrors(t *testing.T) {
 			},
 			errorContains: "500 Internal Server Error",
 		},
+		{
+			name: "author no identity and current user fails",
+			cfg: &config.Config{
+				ActiveContext: "default",
+				Contexts: map[string]*config.Context{
+					"default": {Host: "cloud", Workspace: "ws", DefaultRepo: "repo"},
+				},
+				Hosts: map[string]*config.Host{
+					"cloud": {Kind: "cloud", BaseURL: "http://placeholder", Token: "test-token"},
+				},
+			},
+			args: []string{"1", "--with-default-reviewers"},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.URL.Path == "/user" {
+					http.Error(w, "unauthorized", http.StatusUnauthorized)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(bbcloud.PullRequest{
+					ID:    1,
+					Title: "PR",
+					Author: struct {
+						DisplayName string `json:"display_name"`
+						Username    string `json:"username"`
+						UUID        string `json:"uuid"`
+						AccountID   string `json:"account_id"`
+					}{DisplayName: "Ghost"},
+				})
+			},
+			errorContains: "PR author has no identity and cannot determine current user",
+		},
 	}
 
 	for _, tt := range tests {
@@ -4185,6 +4222,39 @@ func TestRunEditResolveContextError(t *testing.T) {
 		t.Fatal("expected error")
 	}
 	if !strings.Contains(err.Error(), "config boom") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunEditUnsupportedHostKind(t *testing.T) {
+	cfg := &config.Config{
+		ActiveContext: "default",
+		Contexts: map[string]*config.Context{
+			"default": {Host: "main", Workspace: "ws", DefaultRepo: "repo"},
+		},
+		Hosts: map[string]*config.Host{
+			"main": {Kind: "unknown", BaseURL: "http://localhost", Token: "test-token"},
+		},
+	}
+
+	f := &cmdutil.Factory{
+		AppVersion:     "test",
+		ExecutableName: "bkt",
+		IOStreams:      &iostreams.IOStreams{Out: &strings.Builder{}, ErrOut: &strings.Builder{}},
+		Config:         func() (*config.Config, error) { return cfg, nil },
+	}
+
+	cmd := newEditCmd(f)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"1", "--title", "Updated"})
+	cmd.SetContext(context.Background())
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for unsupported host kind")
+	}
+	if !strings.Contains(err.Error(), "unsupported host kind") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/pkg/cmd/pr/pr_test.go
+++ b/pkg/cmd/pr/pr_test.go
@@ -2383,7 +2383,7 @@ func TestEditCommandArgumentParsing(t *testing.T) {
 		{
 			name:          "no flags",
 			args:          []string{"123"},
-			errorContains: "at least one of --title, --body, --description, --reviewer, or --remove-reviewer is required",
+			errorContains: "at least one of --title, --body, --description, --reviewer, --remove-reviewer, or --with-default-reviewers is required",
 		},
 		{
 			name:          "both body and description",
@@ -3106,6 +3106,16 @@ func TestEditCommandReviewerArgumentParsing(t *testing.T) {
 			errorContains: "",
 		},
 		{
+			name:          "with-default-reviewers only is valid",
+			args:          []string{"123", "--with-default-reviewers"},
+			errorContains: "",
+		},
+		{
+			name:          "with-default-reviewers false alone is invalid",
+			args:          []string{"123", "--with-default-reviewers=false"},
+			errorContains: "at least one of --title, --body, --description, --reviewer, --remove-reviewer, or --with-default-reviewers is required",
+		},
+		{
 			name:          "overlap errors",
 			args:          []string{"123", "--reviewer", "alice", "--remove-reviewer", "alice"},
 			errorContains: `reviewer "alice" cannot be in both --reviewer and --remove-reviewer`,
@@ -3113,7 +3123,7 @@ func TestEditCommandReviewerArgumentParsing(t *testing.T) {
 		{
 			name:          "no flags at all",
 			args:          []string{"123"},
-			errorContains: "at least one of --title, --body, --description, --reviewer, or --remove-reviewer is required",
+			errorContains: "at least one of --title, --body, --description, --reviewer, --remove-reviewer, or --with-default-reviewers is required",
 		},
 	}
 
@@ -3128,6 +3138,10 @@ func TestEditCommandReviewerArgumentParsing(t *testing.T) {
 						ID: 123, Title: "Title", Version: 1,
 						FromRef: bbdc.Ref{ID: "refs/heads/feature", Repository: bbdc.Repository{Slug: "repo", Project: &bbdc.Project{Key: "PROJ"}}},
 						ToRef:   bbdc.Ref{ID: "refs/heads/main", Repository: bbdc.Repository{Slug: "repo", Project: &bbdc.Project{Key: "PROJ"}}},
+					}
+					if strings.Contains(r.URL.Path, "/default-reviewers/") {
+						_ = json.NewEncoder(w).Encode([]map[string]any{})
+						return
 					}
 					_ = json.NewEncoder(w).Encode(pr)
 				}))
@@ -3182,8 +3196,10 @@ func TestEditCommandReviewerArgumentParsing(t *testing.T) {
 func TestRunEditDataCenterReviewers(t *testing.T) {
 	tests := []struct {
 		name            string
+		withDefaults    bool
 		reviewers       []string
 		removeReviewers []string
+		defaultUsers    []map[string]any
 		prResponse      bbdc.PullRequest
 		putBodyCheck    func(t *testing.T, body map[string]any)
 		stderrContains  string
@@ -3246,6 +3262,29 @@ func TestRunEditDataCenterReviewers(t *testing.T) {
 			},
 			stderrContains: "already on this pull request",
 		},
+		{
+			name:         "add default reviewers",
+			withDefaults: true,
+			defaultUsers: []map[string]any{
+				{"name": "bob"},
+				{"name": "charlie"},
+			},
+			prResponse: bbdc.PullRequest{
+				ID: 1, Title: "PR", Version: 1,
+				Reviewers: []bbdc.PullRequestReviewer{{User: bbdc.User{Name: "alice"}}},
+				FromRef:   bbdc.Ref{ID: "refs/heads/feature/auth", Repository: bbdc.Repository{Slug: "repo", Project: &bbdc.Project{Key: "PROJ"}}},
+				ToRef:     bbdc.Ref{ID: "refs/heads/main", Repository: bbdc.Repository{Slug: "repo", Project: &bbdc.Project{Key: "PROJ"}}},
+			},
+			putBodyCheck: func(t *testing.T, body map[string]any) {
+				reviewers, ok := body["reviewers"].([]any)
+				if !ok {
+					t.Fatalf("reviewers not found or wrong type in PUT body")
+				}
+				if len(reviewers) != 3 {
+					t.Fatalf("expected 3 reviewers, got %d", len(reviewers))
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -3254,6 +3293,22 @@ func TestRunEditDataCenterReviewers(t *testing.T) {
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
+				if r.Method == "GET" && strings.Contains(r.URL.Path, "/default-reviewers/") {
+					if got := r.URL.Query().Get("sourceRefId"); got != "refs/heads/feature/auth" {
+						t.Fatalf("sourceRefId = %q, want refs/heads/feature/auth", got)
+					}
+					if got := r.URL.Query().Get("targetRefId"); got != "refs/heads/main" {
+						t.Fatalf("targetRefId = %q, want refs/heads/main", got)
+					}
+					_ = json.NewEncoder(w).Encode([]map[string]any{
+						{
+							"reviewers": []map[string]any{
+								{"users": tt.defaultUsers},
+							},
+						},
+					})
+					return
+				}
 				if r.Method == "GET" {
 					_ = json.NewEncoder(w).Encode(tt.prResponse)
 					return
@@ -3293,6 +3348,9 @@ func TestRunEditDataCenterReviewers(t *testing.T) {
 			cmd.SilenceUsage = true
 
 			args := []string{"1"}
+			if tt.withDefaults {
+				args = append(args, "--with-default-reviewers")
+			}
 			for _, r := range tt.reviewers {
 				args = append(args, "--reviewer", r)
 			}
@@ -3322,14 +3380,17 @@ func TestRunEditCloudReviewers(t *testing.T) {
 	const (
 		aliceUUID = "{550e8400-e29b-41d4-a716-446655440000}"
 		bobUUID   = "{660e8400-e29b-41d4-a716-446655440000}"
+		carolUUID = "{770e8400-e29b-41d4-a716-446655440000}"
 	)
 	tests := []struct {
-		name            string
-		reviewers       []string
-		removeReviewers []string
-		prResponse      bbcloud.PullRequest
-		putBodyCheck    func(t *testing.T, body map[string]any)
-		stderrContains  string
+		name             string
+		withDefaults     bool
+		reviewers        []string
+		removeReviewers  []string
+		defaultReviewers []map[string]any
+		prResponse       bbcloud.PullRequest
+		putBodyCheck     func(t *testing.T, body map[string]any)
+		stderrContains   string
 	}{
 		{
 			name:      "add reviewer by username",
@@ -3388,6 +3449,45 @@ func TestRunEditCloudReviewers(t *testing.T) {
 			},
 			stderrContains: "already on this pull request",
 		},
+		{
+			name:         "add default reviewers excludes author",
+			withDefaults: true,
+			defaultReviewers: []map[string]any{
+				{"user": map[string]any{"username": "alice", "uuid": aliceUUID}},
+				{"user": map[string]any{"username": "carol", "uuid": carolUUID}},
+			},
+			prResponse: bbcloud.PullRequest{
+				ID:    1,
+				Title: "PR",
+				Author: struct {
+					DisplayName string "json:\"display_name\""
+					Username    string "json:\"username\""
+					UUID        string "json:\"uuid\""
+				}{
+					DisplayName: "Alice",
+					Username:    "alice",
+					UUID:        aliceUUID,
+				},
+				Reviewers: []bbcloud.User{{UUID: bobUUID, Username: "bob"}},
+			},
+			putBodyCheck: func(t *testing.T, body map[string]any) {
+				reviewers, ok := body["reviewers"].([]any)
+				if !ok {
+					t.Fatalf("reviewers not found or wrong type")
+				}
+				if len(reviewers) != 2 {
+					t.Fatalf("expected 2 reviewers, got %d", len(reviewers))
+				}
+				r0 := reviewers[0].(map[string]any)
+				if r0["uuid"] != bobUUID {
+					t.Fatalf("expected first reviewer to preserve bob by uuid, got %v", r0)
+				}
+				r1 := reviewers[1].(map[string]any)
+				if r1["uuid"] != carolUUID {
+					t.Fatalf("expected second reviewer to add carol by uuid, got %v", r1)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -3396,6 +3496,10 @@ func TestRunEditCloudReviewers(t *testing.T) {
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
+				if strings.Contains(r.URL.Path, "effective-default-reviewers") {
+					_ = json.NewEncoder(w).Encode(map[string]any{"values": tt.defaultReviewers})
+					return
+				}
 				if r.Method == "GET" {
 					_ = json.NewEncoder(w).Encode(tt.prResponse)
 					return
@@ -3433,6 +3537,9 @@ func TestRunEditCloudReviewers(t *testing.T) {
 			cmd.SilenceUsage = true
 
 			args := []string{"1"}
+			if tt.withDefaults {
+				args = append(args, "--with-default-reviewers")
+			}
 			for _, r := range tt.reviewers {
 				args = append(args, "--reviewer", r)
 			}
@@ -3455,6 +3562,122 @@ func TestRunEditCloudReviewers(t *testing.T) {
 				t.Errorf("expected stderr containing %q, got %q", tt.stderrContains, stderr.String())
 			}
 		})
+	}
+}
+
+func TestRunEditDataCenterWithDefaultReviewersFalseDoesNotFetchDefaults(t *testing.T) {
+	defaultsCalled := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/default-reviewers/") {
+			defaultsCalled = true
+			t.Fatalf("default reviewers endpoint should not be called when --with-default-reviewers=false")
+		}
+		if r.Method == "GET" {
+			_ = json.NewEncoder(w).Encode(bbdc.PullRequest{
+				ID: 1, Title: "PR", Version: 1,
+				Reviewers: []bbdc.PullRequestReviewer{{User: bbdc.User{Name: "alice"}}},
+				FromRef:   bbdc.Ref{ID: "refs/heads/feature/auth", Repository: bbdc.Repository{Slug: "repo", Project: &bbdc.Project{Key: "PROJ"}}},
+				ToRef:     bbdc.Ref{ID: "refs/heads/main", Repository: bbdc.Repository{Slug: "repo", Project: &bbdc.Project{Key: "PROJ"}}},
+			})
+			return
+		}
+		if r.Method == "PUT" {
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			reviewers := body["reviewers"].([]any)
+			if len(reviewers) != 1 {
+				t.Fatalf("expected reviewers to stay unchanged, got %v", reviewers)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 1, "title": "Updated", "version": 2})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ActiveContext: "default",
+		Contexts: map[string]*config.Context{
+			"default": {Host: "main", ProjectKey: "PROJ", DefaultRepo: "repo"},
+		},
+		Hosts: map[string]*config.Host{
+			"main": {Kind: "dc", BaseURL: server.URL, Username: "testuser", Token: "test-token"},
+		},
+	}
+
+	f := &cmdutil.Factory{
+		AppVersion:     "test",
+		ExecutableName: "bkt",
+		IOStreams:      &iostreams.IOStreams{Out: &strings.Builder{}, ErrOut: &strings.Builder{}},
+		Config:         func() (*config.Config, error) { return cfg, nil },
+	}
+
+	cmd := newEditCmd(f)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"1", "--title", "Updated", "--with-default-reviewers=false"})
+	cmd.SetContext(context.Background())
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if defaultsCalled {
+		t.Fatal("expected default reviewers endpoint not to be called")
+	}
+}
+
+func TestRunEditCloudWithDefaultReviewersFalseDoesNotFetchDefaults(t *testing.T) {
+	defaultsCalled := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "effective-default-reviewers") {
+			defaultsCalled = true
+			t.Fatalf("effective default reviewers endpoint should not be called when --with-default-reviewers=false")
+		}
+		if r.Method == "PUT" {
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if _, ok := body["reviewers"]; ok {
+				t.Fatalf("expected reviewers field to be omitted, got %v", body["reviewers"])
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 1, "title": "Updated"})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ActiveContext: "default",
+		Contexts: map[string]*config.Context{
+			"default": {Host: "cloud", Workspace: "ws", DefaultRepo: "repo"},
+		},
+		Hosts: map[string]*config.Host{
+			"cloud": {Kind: "cloud", BaseURL: server.URL, Username: "testuser", Token: "test-token"},
+		},
+	}
+
+	f := &cmdutil.Factory{
+		AppVersion:     "test",
+		ExecutableName: "bkt",
+		IOStreams:      &iostreams.IOStreams{Out: &strings.Builder{}, ErrOut: &strings.Builder{}},
+		Config:         func() (*config.Config, error) { return cfg, nil },
+	}
+
+	cmd := newEditCmd(f)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"1", "--title", "Updated", "--with-default-reviewers=false"})
+	cmd.SetContext(context.Background())
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if defaultsCalled {
+		t.Fatal("expected effective default reviewers endpoint not to be called")
 	}
 }
 

--- a/pkg/cmd/pr/pr_test.go
+++ b/pkg/cmd/pr/pr_test.go
@@ -3058,10 +3058,10 @@ func TestEditCloudReviewers(t *testing.T) {
 			want:    []string{bobUUID},
 		},
 		{
-			name:    "add reviewer when account-id-only user already present warns",
-			current: []bbcloud.User{{AccountID: "acc-alice"}},
-			add:     []string{"acc-alice"},
-			want:    []string{"acc-alice"},
+			name:        "add reviewer when account-id-only user already present warns",
+			current:     []bbcloud.User{{AccountID: "acc-alice"}},
+			add:         []string{"acc-alice"},
+			want:        []string{"acc-alice"},
 			wantWarning: `warning: reviewer "acc-alice" is already on this pull request`,
 		},
 		{

--- a/pkg/cmd/pr/pr_test.go
+++ b/pkg/cmd/pr/pr_test.go
@@ -2942,7 +2942,7 @@ func TestEditDCReviewers(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var errBuf strings.Builder
-			got := editDCReviewers(&errBuf, tt.current, tt.add, tt.remove)
+			got := editDCReviewers(&errBuf, tt.current, tt.add, tt.remove, nil)
 
 			var gotNames []string
 			for _, r := range got {
@@ -3051,11 +3051,44 @@ func TestEditCloudReviewers(t *testing.T) {
 			remove:  []string{aliceUUID},
 			wantErr: aliceUUID,
 		},
+		{
+			name:    "remove reviewer by account id",
+			current: []bbcloud.User{{AccountID: "acc-alice"}, {UUID: bobUUID, Username: "bob"}},
+			remove:  []string{"acc-alice"},
+			want:    []string{bobUUID},
+		},
+		{
+			name:    "add reviewer when account-id-only user already present warns",
+			current: []bbcloud.User{{AccountID: "acc-alice"}},
+			add:     []string{"acc-alice"},
+			want:    []string{"acc-alice"},
+			wantWarning: `warning: reviewer "acc-alice" is already on this pull request`,
+		},
+		{
+			name:        "remove account-id-only user not present warns",
+			current:     []bbcloud.User{{AccountID: "acc-alice"}},
+			remove:      []string{"acc-bob"},
+			want:        []string{"acc-alice"},
+			wantWarning: `warning: reviewer "acc-bob" is not on this pull request`,
+		},
+		{
+			name:    "keep account-id-only reviewer serializes account id",
+			current: []bbcloud.User{{AccountID: "acc-alice"}, {UUID: bobUUID, Username: "bob"}},
+			add:     []string{"charlie"},
+			want:    []string{"acc-alice", bobUUID, "charlie"},
+		},
+		{
+			name:    "cross-identity overlap by account id errors",
+			current: []bbcloud.User{{UUID: aliceUUID, AccountID: "acc-alice"}},
+			add:     []string{"acc-alice"},
+			remove:  []string{aliceUUID},
+			wantErr: "cannot be in both flags",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var errBuf strings.Builder
-			got, err := editCloudReviewers(&errBuf, tt.current, tt.add, tt.remove)
+			got, err := editCloudReviewers(&errBuf, tt.current, tt.add, tt.remove, nil)
 
 			if tt.wantErr != "" {
 				if err == nil {
@@ -3086,6 +3119,61 @@ func TestEditCloudReviewers(t *testing.T) {
 				t.Errorf("expected no warnings, got %q", errBuf.String())
 			}
 		})
+	}
+}
+
+func TestEditCloudReviewersSuppressesDefaultOverlapWarning(t *testing.T) {
+	const bobUUID = "{660e8400-e29b-41d4-a716-446655440000}"
+
+	// current includes bob (from defaults merge), preExisting is empty
+	// → adding bob should NOT warn
+	var errBuf strings.Builder
+	got, err := editCloudReviewers(&errBuf, []bbcloud.User{{UUID: bobUUID, Username: "bob"}}, []string{"bob"}, nil, []bbcloud.User{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if errBuf.String() != "" {
+		t.Errorf("expected no warning for default-only overlap, got %q", errBuf.String())
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 reviewer, got %v", got)
+	}
+}
+
+func TestEditCloudReviewersWarnsForPreExistingOverlap(t *testing.T) {
+	const bobUUID = "{660e8400-e29b-41d4-a716-446655440000}"
+
+	// bob is in preExisting → adding bob should still warn
+	var errBuf strings.Builder
+	preExisting := []bbcloud.User{{UUID: bobUUID, Username: "bob"}}
+	_, err := editCloudReviewers(&errBuf, preExisting, []string{"bob"}, nil, preExisting)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(errBuf.String(), "already on this pull request") {
+		t.Errorf("expected warning for pre-existing overlap, got %q", errBuf.String())
+	}
+}
+
+func TestEditDCReviewersSuppressesDefaultOverlapWarning(t *testing.T) {
+	// current includes bob (from defaults merge), preExisting is empty
+	var errBuf strings.Builder
+	current := []bbdc.PullRequestReviewer{{User: bbdc.User{Name: "bob"}}}
+	got := editDCReviewers(&errBuf, current, []string{"bob"}, nil, []bbdc.PullRequestReviewer{})
+	if errBuf.String() != "" {
+		t.Errorf("expected no warning for default-only overlap, got %q", errBuf.String())
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 reviewer, got %v", got)
+	}
+}
+
+func TestEditDCReviewersWarnsForPreExistingOverlap(t *testing.T) {
+	var errBuf strings.Builder
+	preExisting := []bbdc.PullRequestReviewer{{User: bbdc.User{Name: "bob"}}}
+	_ = editDCReviewers(&errBuf, preExisting, []string{"bob"}, nil, preExisting)
+	if !strings.Contains(errBuf.String(), "already on this pull request") {
+		t.Errorf("expected warning for pre-existing overlap, got %q", errBuf.String())
 	}
 }
 
@@ -3282,6 +3370,14 @@ func TestRunEditDataCenterReviewers(t *testing.T) {
 				}
 				if len(reviewers) != 3 {
 					t.Fatalf("expected 3 reviewers, got %d", len(reviewers))
+				}
+				wantNames := []string{"alice", "bob", "charlie"}
+				for i, want := range wantNames {
+					r := reviewers[i].(map[string]any)
+					user := r["user"].(map[string]any)
+					if user["name"] != want {
+						t.Errorf("reviewer[%d] name = %q, want %q", i, user["name"], want)
+					}
 				}
 			},
 		},
@@ -3532,6 +3628,37 @@ func TestRunEditCloudReviewers(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:         "author with no identity falls back to current user",
+			withDefaults: true,
+			defaultReviewers: []map[string]any{
+				{"user": map[string]any{"username": "bob", "uuid": bobUUID}},
+			},
+			prResponse: bbcloud.PullRequest{
+				ID:    1,
+				Title: "PR",
+				Author: struct {
+					DisplayName string "json:\"display_name\""
+					Username    string "json:\"username\""
+					UUID        string "json:\"uuid\""
+					AccountID   string "json:\"account_id\""
+				}{
+					DisplayName: "Bob",
+				},
+				Reviewers: []bbcloud.User{},
+			},
+			putBodyCheck: func(t *testing.T, body map[string]any) {
+				reviewers, ok := body["reviewers"].([]any)
+				if !ok {
+					t.Fatalf("reviewers not found or wrong type")
+				}
+				// bob is the current user fallback, should be excluded
+				if len(reviewers) != 0 {
+					t.Fatalf("expected 0 reviewers (bob excluded via current user fallback), got %d: %v", len(reviewers), reviewers)
+				}
+			},
+			stderrContains: "no usable identity",
+		},
 	}
 
 	for _, tt := range tests {
@@ -3540,6 +3667,14 @@ func TestRunEditCloudReviewers(t *testing.T) {
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
+				if r.URL.Path == "/user" && r.Method == "GET" {
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"uuid":       bobUUID,
+						"username":   "bob",
+						"account_id": "acc-bob",
+					})
+					return
+				}
 				if strings.Contains(r.URL.Path, "effective-default-reviewers") {
 					_ = json.NewEncoder(w).Encode(map[string]any{"values": tt.defaultReviewers})
 					return
@@ -4748,16 +4883,16 @@ func TestMergeReviewers(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := mergeReviewers(tt.explicit, tt.defaults, nameFunc)
+			got := mergeCreateReviewers(tt.explicit, tt.defaults, nameFunc)
 			if len(got) == 0 && len(tt.want) == 0 {
 				return
 			}
 			if len(got) != len(tt.want) {
-				t.Fatalf("mergeReviewers() = %v, want %v", got, tt.want)
+				t.Fatalf("mergeCreateReviewers() = %v, want %v", got, tt.want)
 			}
 			for i, v := range got {
 				if v != tt.want[i] {
-					t.Errorf("mergeReviewers()[%d] = %q, want %q", i, v, tt.want[i])
+					t.Errorf("mergeCreateReviewers()[%d] = %q, want %q", i, v, tt.want[i])
 				}
 			}
 		})
@@ -4787,7 +4922,7 @@ func TestResolveGitBaseRefError(t *testing.T) {
 }
 
 func TestMergeDCPRReviewers(t *testing.T) {
-	got := mergeDCPRReviewers(
+	got := mergeDCEditReviewers(
 		[]bbdc.PullRequestReviewer{
 			{User: bbdc.User{Name: "alice"}},
 			{User: bbdc.User{Name: ""}},
@@ -4816,7 +4951,7 @@ func TestMergeDCPRReviewers(t *testing.T) {
 }
 
 func TestMergeCloudPRReviewers(t *testing.T) {
-	got := mergeCloudPRReviewers(
+	got := mergeCloudEditReviewers(
 		[]bbcloud.User{
 			{Username: "alice", UUID: "{00000000-0000-0000-0000-000000000001}"},
 			{},
@@ -4841,7 +4976,7 @@ func TestMergeCloudPRReviewers(t *testing.T) {
 }
 
 func TestMergeCloudPRReviewersDedupsAcrossAccountID(t *testing.T) {
-	got := mergeCloudPRReviewers(
+	got := mergeCloudEditReviewers(
 		[]bbcloud.User{
 			{UUID: "{00000000-0000-0000-0000-000000000001}", AccountID: "acc-alice"},
 		},
@@ -4866,9 +5001,10 @@ func TestCloudReviewerIDs(t *testing.T) {
 	got := cloudReviewerIDs([]bbcloud.User{
 		{UUID: "{00000000-0000-0000-0000-000000000001}"},
 		{Username: "bob"},
+		{AccountID: "acc-charlie"},
 		{},
 	})
-	want := []string{"{00000000-0000-0000-0000-000000000001}", "bob"}
+	want := []string{"{00000000-0000-0000-0000-000000000001}", "bob", "acc-charlie"}
 	if len(got) != len(want) {
 		t.Fatalf("got %v, want %v", got, want)
 	}

--- a/skills/bkt/rules/pr.md
+++ b/skills/bkt/rules/pr.md
@@ -620,6 +620,7 @@ bkt pr edit <id> [flags]
 | `--repo` |  | Repository slug override. |
 | `--reviewer` |  | Reviewer username or {UUID} to add (repeatable) |
 | `--title` | `-t` | Set the new title. |
+| `--with-default-reviewers` |  | Add repository default reviewers |
 | `--workspace` |  | Bitbucket workspace override (Cloud). |
 
 ### Inherited Flags
@@ -649,6 +650,9 @@ bkt pr edit <id> [flags]
 
   # Remove a reviewer
   bkt pr edit 123 --remove-reviewer alice
+
+  # Add repository default reviewers
+  bkt pr edit 123 --with-default-reviewers
 
   # Add and remove reviewers in one call
   bkt pr edit 123 --reviewer charlie --remove-reviewer alice
@@ -1364,4 +1368,3 @@ bkt pr view <id> [flags]
   # View a pull request in a different repository
   bkt pr view 10 --repo my-other-repo
 ```
-


### PR DESCRIPTION
## Summary
This change adds `--with-default-reviewers` support to `bkt pr edit` for both Bitbucket Data Center and Bitbucket Cloud so existing pull requests can be updated to include repository defaults without recreating them. It reuses the existing default-reviewer lookup behavior from `bkt pr create`, preserves current reviewer-edit semantics, and fixes the boolean flag handling so `--with-default-reviewers=false` does not trigger reviewer changes.

## Changes
- CLI behavior:
  - Added `--with-default-reviewers` to `bkt pr edit`.
  - On Data Center, `pr edit` now fetches default reviewers using the PR's current source and target refs and merges them into the existing reviewer set.
  - On Cloud, `pr edit` now fetches effective default reviewers, excludes the PR author, preserves reviewer UUIDs in update payloads, and applies explicit `--reviewer` / `--remove-reviewer` changes on top.
- Shared logic:
  - Refactored default-reviewer fetch and filtering so `pr create` and `pr edit` use the same host-specific helper paths instead of duplicating the behavior.
  - Extended the Cloud pull request model to expose author UUID so author exclusion during edit is reliable.
- Tests and docs:
  - Added regression coverage for Data Center and Cloud edit flows, including the `--with-default-reviewers=false` case so explicit false values do not trigger reviewer mutations.
  - Regenerated the `bkt` skill docs so the `pr edit` reference now includes the new flag and example usage.

## Testing
- `pre-commit run --files pkg/bbcloud/pullrequests.go pkg/cmd/pr/pr.go pkg/cmd/pr/pr_test.go skills/bkt/rules/pr.md`
- `go test ./...`
- No new environment variables were introduced.

## Risks
- Low. The main area worth reviewer attention is reviewer merge behavior on `pr edit`, especially the Cloud path that excludes the PR author and preserves UUID-based reviewers.
- Explicit `--with-default-reviewers=false` handling is covered by regression tests.
