### PR TITLE
feat(pr): add creation timestamp to pr list output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+- Pull request JSON output now includes creation and update timestamps for Cloud and Data Center listings.
+
+### Changed
+- `bkt pr list` now appends a local creation timestamp column (`YYYY-MM-DD HH:MM`) to text output for Cloud and Data Center listings.
+
 ## [0.21.0] - 2026-04-10
 ### Added
 - OAuth 2.0 infrastructure for Cloud login in the new `pkg/oauth` package, plus a `TokenRefresher` hook on `httpx.Client` for transparent 401-driven token refresh. Phase 1 only; login-command wiring is not included yet (#137).
@@ -58,7 +64,6 @@ All notable changes to this project will be documented here. The format follows
 - Added missing `timeout-minutes` and `concurrency` blocks to all workflows.
 - Standalone publish-skill workflow now accepts `workflow_dispatch` with an explicit `tag` input.
 - Bitbucket Pipelines Go image updated from 1.24 to 1.25 to match `go.mod`.
-
 
 ## [0.16.4] - 2026-04-02
 ### Fixed

--- a/pkg/bbcloud/pullrequests.go
+++ b/pkg/bbcloud/pullrequests.go
@@ -28,11 +28,13 @@ type RepositoryRef struct {
 
 // PullRequest models a Bitbucket Cloud pull request.
 type PullRequest struct {
-	ID     int    `json:"id"`
-	Title  string `json:"title"`
-	State  string `json:"state"`
-	Draft  bool   `json:"draft"`
-	Author struct {
+	ID        int    `json:"id"`
+	Title     string `json:"title"`
+	State     string `json:"state"`
+	Draft     bool   `json:"draft"`
+	CreatedOn string `json:"created_on"`
+	UpdatedOn string `json:"updated_on"`
+	Author    struct {
 		DisplayName string `json:"display_name"`
 		Username    string `json:"username"`
 	} `json:"author"`

--- a/pkg/bbdc/client.go
+++ b/pkg/bbdc/client.go
@@ -102,6 +102,8 @@ type PullRequest struct {
 	State       string `json:"state"`
 	Version     int    `json:"version"`
 	Draft       bool   `json:"draft"`
+	CreatedDate int64  `json:"createdDate"`
+	UpdatedDate int64  `json:"updatedDate"`
 	Author      struct {
 		User User `json:"user"`
 	} `json:"author"`

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -29,8 +29,9 @@ import (
 
 const (
 	// Standard timeouts for API calls.
-	timeoutRead  = 15 * time.Second
-	timeoutWrite = 10 * time.Second
+	timeoutRead      = 15 * time.Second
+	timeoutWrite     = 10 * time.Second
+	prListTimeLayout = "2006-01-02 15:04"
 )
 
 // Sentinel errors for checks command
@@ -202,7 +203,8 @@ func runList(cmd *cobra.Command, f *cmdutil.Factory, opts *listOptions) error {
 
 			for _, pr := range prs {
 				author := cmdutil.FirstNonEmpty(pr.Author.User.FullName, pr.Author.User.Name)
-				if _, err := fmt.Fprintf(ios.Out, "#%d\t%-8s\t%s\n", pr.ID, pr.State, pr.Title); err != nil {
+				created := formatPRListUnixMilli(pr.CreatedDate)
+				if _, err := fmt.Fprintf(ios.Out, "#%d\t%-8s\t%s\t%s\n", pr.ID, pr.State, pr.Title, created); err != nil {
 					return err
 				}
 				if _, err := fmt.Fprintf(ios.Out, "    %s -> %s\tby %s\n", pr.FromRef.DisplayID, pr.ToRef.DisplayID, author); err != nil {
@@ -267,7 +269,8 @@ func runList(cmd *cobra.Command, f *cmdutil.Factory, opts *listOptions) error {
 
 			for _, pr := range prs {
 				author := cmdutil.FirstNonEmpty(pr.Author.DisplayName, pr.Author.Username)
-				if _, err := fmt.Fprintf(ios.Out, "#%d\t%-8s\t%s\n", pr.ID, pr.State, pr.Title); err != nil {
+				created := formatPRListRFC3339(pr.CreatedOn)
+				if _, err := fmt.Fprintf(ios.Out, "#%d\t%-8s\t%s\t%s\n", pr.ID, pr.State, pr.Title, created); err != nil {
 					return err
 				}
 				if _, err := fmt.Fprintf(ios.Out, "    %s -> %s\tby %s\n", pr.Source.Branch.Name, pr.Destination.Branch.Name, author); err != nil {
@@ -313,6 +316,7 @@ func runListDashboardDC(cmd *cobra.Command, f *cmdutil.Factory, ios *iostreams.I
 
 		for _, pr := range prs {
 			author := cmdutil.FirstNonEmpty(pr.Author.User.FullName, pr.Author.User.Name)
+			created := formatPRListUnixMilli(pr.CreatedDate)
 			// Use ToRef.Repository (destination) to show where the PR merges into,
 			// which is more useful for fork-based PRs than the source repo
 			repoInfo := ""
@@ -322,7 +326,7 @@ func runListDashboardDC(cmd *cobra.Command, f *cmdutil.Factory, ios *iostreams.I
 					repoInfo = pr.ToRef.Repository.Project.Key + "/" + repoInfo
 				}
 			}
-			if _, err := fmt.Fprintf(ios.Out, "#%d\t%-8s\t%s\n", pr.ID, pr.State, pr.Title); err != nil {
+			if _, err := fmt.Fprintf(ios.Out, "#%d\t%-8s\t%s\t%s\n", pr.ID, pr.State, pr.Title, created); err != nil {
 				return err
 			}
 			if repoInfo != "" {
@@ -389,13 +393,14 @@ func runListWorkspaceCloud(cmd *cobra.Command, f *cmdutil.Factory, ios *iostream
 
 		for _, pr := range prs {
 			author := cmdutil.FirstNonEmpty(pr.Author.DisplayName, pr.Author.Username)
+			created := formatPRListRFC3339(pr.CreatedOn)
 			// Use Destination.Repository.Slug (where PR merges into) as primary source,
 			// fall back to URL parsing for backwards compatibility
 			repoInfo := pr.Destination.Repository.Slug
 			if repoInfo == "" {
 				repoInfo = extractRepoFromCloudPRLink(pr.Links.HTML.Href)
 			}
-			if _, err := fmt.Fprintf(ios.Out, "#%d\t%-8s\t%s\n", pr.ID, pr.State, pr.Title); err != nil {
+			if _, err := fmt.Fprintf(ios.Out, "#%d\t%-8s\t%s\t%s\n", pr.ID, pr.State, pr.Title, created); err != nil {
 				return err
 			}
 			if repoInfo != "" {
@@ -410,6 +415,27 @@ func runListWorkspaceCloud(cmd *cobra.Command, f *cmdutil.Factory, ios *iostream
 		}
 		return nil
 	})
+}
+
+func formatPRListUnixMilli(unixMilli int64) string {
+	if unixMilli == 0 {
+		return ""
+	}
+
+	return time.UnixMilli(unixMilli).Local().Format(prListTimeLayout)
+}
+
+func formatPRListRFC3339(value string) string {
+	if value == "" {
+		return ""
+	}
+
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return ""
+	}
+
+	return parsed.Local().Format(prListTimeLayout)
 }
 
 // extractRepoFromCloudPRLink extracts the repository slug from a Bitbucket Cloud PR URL.

--- a/pkg/cmd/pr/pr_test.go
+++ b/pkg/cmd/pr/pr_test.go
@@ -133,12 +133,27 @@ func TestListRequiresMineWithoutRepo(t *testing.T) {
 	}
 }
 
+func findOutputLine(t *testing.T, output, needle string) string {
+	t.Helper()
+
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(line, needle) {
+			return line
+		}
+	}
+
+	t.Fatalf("expected output line containing %q, got:\n%s", needle, output)
+	return ""
+}
+
 func TestListDashboardDC(t *testing.T) {
+	formattedCreated := time.Date(2026, time.April, 10, 11, 30, 0, 0, time.FixedZone("UTC+2", 2*60*60)).UnixMilli()
 	prs := []bbdc.PullRequest{
 		{
-			ID:    1,
-			Title: "First PR",
-			State: "OPEN",
+			ID:          1,
+			Title:       "First PR",
+			State:       "OPEN",
+			CreatedDate: formattedCreated,
 			FromRef: bbdc.Ref{
 				DisplayID:  "feature-1",
 				Repository: bbdc.Repository{Slug: "fork-repo1", Project: &bbdc.Project{Key: "~USER"}},
@@ -239,6 +254,27 @@ func TestListDashboardDC(t *testing.T) {
 	if !strings.Contains(output, "PROJ/repo1") {
 		t.Errorf("expected output to contain repo info 'PROJ/repo1', got:\n%s", output)
 	}
+
+	firstLine := findOutputLine(t, output, "First PR")
+	firstFields := strings.Split(firstLine, "\t")
+	if len(firstFields) != 4 {
+		t.Fatalf("expected 4 tab-separated fields for First PR, got %d: %q", len(firstFields), firstLine)
+	}
+	if got, want := firstFields[3], time.UnixMilli(formattedCreated).Local().Format(prListTimeLayout); got != want {
+		t.Fatalf("expected formatted timestamp %q, got %q", want, got)
+	}
+
+	secondLine := findOutputLine(t, output, "Second PR")
+	secondFields := strings.Split(secondLine, "\t")
+	if len(secondFields) != 4 {
+		t.Fatalf("expected 4 tab-separated fields for Second PR, got %d: %q", len(secondFields), secondLine)
+	}
+	if got := secondFields[3]; got != "" {
+		t.Fatalf("expected empty timestamp for zero CreatedDate, got %q", got)
+	}
+	if strings.Contains(output, "1970-01-01 00:00") {
+		t.Fatalf("expected zero CreatedDate to render empty string, got:\n%s", output)
+	}
 }
 
 func TestListWorkspaceCloud(t *testing.T) {
@@ -258,14 +294,16 @@ func TestListWorkspaceCloud(t *testing.T) {
 
 	prs := []bbcloud.PullRequest{
 		{
-			ID:    1,
-			Title: "First PR",
-			State: "OPEN",
+			ID:        1,
+			Title:     "First PR",
+			State:     "OPEN",
+			CreatedOn: "2026-04-10T11:30:45.123456+02:00",
 		},
 		{
-			ID:    2,
-			Title: "Second PR",
-			State: "OPEN",
+			ID:        2,
+			Title:     "Second PR",
+			State:     "OPEN",
+			CreatedOn: "not-a-timestamp",
 		},
 	}
 	// Set nested fields - use Destination.Repository.Slug as primary source
@@ -363,6 +401,213 @@ func TestListWorkspaceCloud(t *testing.T) {
 	}
 	if !strings.Contains(output, "repo1") {
 		t.Errorf("expected output to contain repo info 'repo1', got:\n%s", output)
+	}
+
+	firstLine := findOutputLine(t, output, "First PR")
+	firstFields := strings.Split(firstLine, "\t")
+	if len(firstFields) != 4 {
+		t.Fatalf("expected 4 tab-separated fields for First PR, got %d: %q", len(firstFields), firstLine)
+	}
+	expectedFirst, err := time.Parse(time.RFC3339Nano, prs[0].CreatedOn)
+	if err != nil {
+		t.Fatalf("failed to parse test timestamp: %v", err)
+	}
+	if got, want := firstFields[3], expectedFirst.Local().Format(prListTimeLayout); got != want {
+		t.Fatalf("expected formatted timestamp %q, got %q", want, got)
+	}
+
+	secondLine := findOutputLine(t, output, "Second PR")
+	secondFields := strings.Split(secondLine, "\t")
+	if len(secondFields) != 4 {
+		t.Fatalf("expected 4 tab-separated fields for Second PR, got %d: %q", len(secondFields), secondLine)
+	}
+	if got := secondFields[3]; got != "" {
+		t.Fatalf("expected empty timestamp for invalid CreatedOn, got %q", got)
+	}
+	if strings.Contains(output, "0001-01-01 00:00") {
+		t.Fatalf("expected invalid CreatedOn to render empty string, got:\n%s", output)
+	}
+}
+
+func TestListRepositoryDCIncludesCreationTimestamp(t *testing.T) {
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(origWd)
+	})
+
+	createdDate := time.Date(2026, time.April, 10, 9, 15, 0, 0, time.UTC).UnixMilli()
+	prs := []bbdc.PullRequest{
+		{
+			ID:          7,
+			Title:       "Repo PR",
+			State:       "OPEN",
+			CreatedDate: createdDate,
+			FromRef: bbdc.Ref{
+				DisplayID: "feature/repo",
+			},
+			ToRef: bbdc.Ref{
+				DisplayID: "main",
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if strings.Contains(r.URL.Path, "/pull-requests") {
+			resp := struct {
+				Values     []bbdc.PullRequest `json:"values"`
+				IsLastPage bool               `json:"isLastPage"`
+			}{
+				Values:     prs,
+				IsLastPage: true,
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ActiveContext: "default",
+		Contexts: map[string]*config.Context{
+			"default": {
+				Host:        "main",
+				ProjectKey:  "PROJ",
+				DefaultRepo: "repo1",
+			},
+		},
+		Hosts: map[string]*config.Host{
+			"main": {
+				Kind:     "dc",
+				BaseURL:  server.URL,
+				Username: "testuser",
+				Token:    "test-token",
+			},
+		},
+	}
+
+	stdout := &strings.Builder{}
+	stderr := &strings.Builder{}
+	f := &cmdutil.Factory{
+		AppVersion:     "test",
+		ExecutableName: "bkt",
+		IOStreams:      &iostreams.IOStreams{Out: stdout, ErrOut: stderr},
+		Config:         func() (*config.Config, error) { return cfg, nil },
+	}
+
+	cmd := newListCmd(f)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	line := findOutputLine(t, stdout.String(), "Repo PR")
+	fields := strings.Split(line, "\t")
+	if len(fields) != 4 {
+		t.Fatalf("expected 4 tab-separated fields, got %d: %q", len(fields), line)
+	}
+	if got, want := fields[3], time.UnixMilli(createdDate).Local().Format(prListTimeLayout); got != want {
+		t.Fatalf("expected formatted timestamp %q, got %q", want, got)
+	}
+}
+
+func TestListRepositoryCloudIncludesCreationTimestamp(t *testing.T) {
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(origWd)
+	})
+
+	prs := []bbcloud.PullRequest{
+		{
+			ID:        8,
+			Title:     "Cloud Repo PR",
+			State:     "OPEN",
+			CreatedOn: "",
+		},
+	}
+	prs[0].Source.Branch.Name = "feature/cloud"
+	prs[0].Destination.Branch.Name = "main"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if strings.Contains(r.URL.Path, "/repositories/") && strings.Contains(r.URL.Path, "/pullrequests") {
+			resp := struct {
+				Values []bbcloud.PullRequest `json:"values"`
+				Next   string                `json:"next"`
+			}{
+				Values: prs,
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ActiveContext: "default",
+		Contexts: map[string]*config.Context{
+			"default": {
+				Host:        "cloud",
+				Workspace:   "workspace",
+				DefaultRepo: "repo1",
+			},
+		},
+		Hosts: map[string]*config.Host{
+			"cloud": {
+				Kind:     "cloud",
+				BaseURL:  server.URL,
+				Username: "testuser",
+				Token:    "test-token",
+			},
+		},
+	}
+
+	stdout := &strings.Builder{}
+	stderr := &strings.Builder{}
+	f := &cmdutil.Factory{
+		AppVersion:     "test",
+		ExecutableName: "bkt",
+		IOStreams:      &iostreams.IOStreams{Out: stdout, ErrOut: stderr},
+		Config:         func() (*config.Config, error) { return cfg, nil },
+	}
+
+	cmd := newListCmd(f)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	line := findOutputLine(t, stdout.String(), "Cloud Repo PR")
+	fields := strings.Split(line, "\t")
+	if len(fields) != 4 {
+		t.Fatalf("expected 4 tab-separated fields, got %d: %q", len(fields), line)
+	}
+	if got := fields[3]; got != "" {
+		t.Fatalf("expected empty timestamp for empty CreatedOn, got %q", got)
 	}
 }
 

--- a/pkg/cmd/pr/pr_test.go
+++ b/pkg/cmd/pr/pr_test.go
@@ -611,6 +611,138 @@ func TestListRepositoryCloudIncludesCreationTimestamp(t *testing.T) {
 	}
 }
 
+// failingWriter returns an error on every Write. It exercises the error-return
+// branches after the per-PR Fprintf calls in the list rendering paths.
+type failingWriter struct{}
+
+func (failingWriter) Write(_ []byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func TestListWriteErrorPropagation(t *testing.T) {
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(origWd)
+	})
+
+	dcPRs := []bbdc.PullRequest{{
+		ID:    1,
+		Title: "DC PR",
+		State: "OPEN",
+		FromRef: bbdc.Ref{
+			DisplayID:  "feature",
+			Repository: bbdc.Repository{Slug: "repo1", Project: &bbdc.Project{Key: "PROJ"}},
+		},
+		ToRef: bbdc.Ref{
+			DisplayID:  "main",
+			Repository: bbdc.Repository{Slug: "repo1", Project: &bbdc.Project{Key: "PROJ"}},
+		},
+	}}
+	dcHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := struct {
+			Values     []bbdc.PullRequest `json:"values"`
+			IsLastPage bool               `json:"isLastPage"`
+		}{Values: dcPRs, IsLastPage: true}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	cloudPRs := []bbcloud.PullRequest{{
+		ID:    1,
+		Title: "Cloud PR",
+		State: "OPEN",
+	}}
+	cloudPRs[0].Source.Branch.Name = "feature"
+	cloudPRs[0].Destination.Branch.Name = "main"
+	cloudPRs[0].Destination.Repository.Slug = "repo1"
+	cloudHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/user" {
+			_ = json.NewEncoder(w).Encode(bbcloud.User{UUID: "{1}", Username: "testuser", Display: "Test"})
+			return
+		}
+		resp := struct {
+			Values []bbcloud.PullRequest `json:"values"`
+			Next   string                `json:"next"`
+		}{Values: cloudPRs}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	cases := []struct {
+		name        string
+		handler     http.HandlerFunc
+		kind        string
+		workspace   string
+		projectKey  string
+		defaultRepo string
+		args        []string
+	}{
+		{"repository DC", dcHandler, "dc", "", "PROJ", "repo1", nil},
+		{"repository Cloud", cloudHandler, "cloud", "workspace", "", "repo1", nil},
+		{"dashboard DC", dcHandler, "dc", "", "PROJ", "", []string{"--mine"}},
+		{"workspace Cloud", cloudHandler, "cloud", "workspace", "", "", []string{"--mine"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			cfg := &config.Config{
+				ActiveContext: "default",
+				Contexts: map[string]*config.Context{
+					"default": {
+						Host:        "h",
+						Workspace:   tc.workspace,
+						ProjectKey:  tc.projectKey,
+						DefaultRepo: tc.defaultRepo,
+					},
+				},
+				Hosts: map[string]*config.Host{
+					"h": {
+						Kind:     tc.kind,
+						BaseURL:  server.URL,
+						Username: "testuser",
+						Token:    "test-token",
+					},
+				},
+			}
+
+			f := &cmdutil.Factory{
+				AppVersion:     "test",
+				ExecutableName: "bkt",
+				IOStreams: &iostreams.IOStreams{
+					Out:    failingWriter{},
+					ErrOut: &strings.Builder{},
+				},
+				Config: func() (*config.Config, error) { return cfg, nil },
+			}
+
+			cmd := newListCmd(f)
+			cmd.SilenceErrors = true
+			cmd.SilenceUsage = true
+			if len(tc.args) > 0 {
+				cmd.SetArgs(tc.args)
+			}
+
+			execErr := cmd.Execute()
+			if execErr == nil {
+				t.Fatal("expected error from failing writer, got nil")
+			}
+			if !strings.Contains(execErr.Error(), "write failed") {
+				t.Fatalf("expected error to contain %q, got %v", "write failed", execErr)
+			}
+		})
+	}
+}
+
 func TestStateIcon(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
## Summary
Adds a creation timestamp column to `bkt pr list` for both Data Center and Cloud backends, and exposes `created_on` / `updated_on` in `--json` output. The text column is appended to the end of the tab-separated row rather than inserted before `title`, so existing parsers keep working.

Only the creation timestamp is shown in text output; `updated_on` is available in `--json` only.

Picks up #92 after 5 days of no contributor activity. Cherry-picked Luke's commit with `-x` and kept his `Co-authored-by` trailer so authorship is preserved.

## What changed vs #92
Three blocking issues from the original review are fixed:
1. `time.RFC3339Nano` (was `RFC3339`) — Bitbucket Cloud returns fractional seconds, so the old format silently failed to parse and rendered `0001-01-01 00:00`.
2. Parse errors and zero values no longer fall through to wrong output — empty string instead of `0001-01-01 00:00` (Cloud) or `1970-01-01 00:00` (DC).
3. `.Local()` applied on all paths so DC and Cloud render in the same timezone.

Reference pattern: `pkg/cmd/pipeline/pipeline.go:212-218`.

## Test plan
- [x] `make fmt`
- [x] `make test` — new cases in `pkg/cmd/pr/pr_test.go`:
  - DC normal / DC zero-value → empty
  - Cloud with fractional seconds / Cloud empty / Cloud invalid → empty
  - Repo-specific + dashboard/workspace list paths
- [x] `make build`
- [ ] Manual smoke: `bkt pr list` against DC + Cloud

Supersedes #92.

Co-authored-by: Luke Johnstone <luke@touchfoundry.co.za>