### PR TITLE
feat(auth): add OAuth 2.0 login flow for Bitbucket Cloud

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,9 @@ jobs:
         run: make test
       - name: Build CLI
         run: VERSION=${{ needs.prepare.outputs.tag }} make build
+        env:
+          BKT_OAUTH_CLIENT_ID: ${{ secrets.BKT_OAUTH_CLIENT_ID }}
+          BKT_OAUTH_CLIENT_SECRET: ${{ secrets.BKT_OAUTH_CLIENT_SECRET }}
       - name: Check embedded version
         run: ./bin/bkt --version | grep -Fx "bkt version ${{ needs.prepare.outputs.tag }}"
 
@@ -203,6 +206,16 @@ jobs:
           output_path.write_text(match.group(0).strip() + "\n", encoding="utf-8")
           PY
 
+      - name: Validate OAuth secrets
+        env:
+          BKT_OAUTH_CLIENT_ID: ${{ secrets.BKT_OAUTH_CLIENT_ID }}
+          BKT_OAUTH_CLIENT_SECRET: ${{ secrets.BKT_OAUTH_CLIENT_SECRET }}
+        run: |
+          if [ -z "$BKT_OAUTH_CLIENT_ID" ] || [ -z "$BKT_OAUTH_CLIENT_SECRET" ]; then
+            echo "::error::BKT_OAUTH_CLIENT_ID and BKT_OAUTH_CLIENT_SECRET must be set as repository secrets"
+            exit 1
+          fi
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
         with:
@@ -212,6 +225,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          BKT_OAUTH_CLIENT_ID: ${{ secrets.BKT_OAUTH_CLIENT_ID }}
+          BKT_OAUTH_CLIENT_SECRET: ${{ secrets.BKT_OAUTH_CLIENT_SECRET }}
 
   skill-publish:
     name: Publish skills

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,6 +24,8 @@ builds:
       - -X github.com/avivsinai/bitbucket-cli/internal/build.versionFromLdflags={{.Version}}
       - -X github.com/avivsinai/bitbucket-cli/internal/build.commitFromLdflags={{.Commit}}
       - -X github.com/avivsinai/bitbucket-cli/internal/build.dateFromLdflags={{.Date}}
+      - -X github.com/avivsinai/bitbucket-cli/pkg/oauth.cloudClientID={{ .Env.BKT_OAUTH_CLIENT_ID }}
+      - -X github.com/avivsinai/bitbucket-cli/pkg/oauth.cloudClientSecret={{ .Env.BKT_OAUTH_CLIENT_SECRET }}
     mod_timestamp: '{{ .CommitTimestamp }}'
     hooks:
       post:

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,14 @@ VERSION ?= $(shell \
 )
 COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
 BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+BKT_OAUTH_CLIENT_ID ?=
+BKT_OAUTH_CLIENT_SECRET ?=
 LDFLAGS := -s -w \
 	-X github.com/avivsinai/bitbucket-cli/internal/build.versionFromLdflags=$(VERSION) \
 	-X github.com/avivsinai/bitbucket-cli/internal/build.commitFromLdflags=$(COMMIT) \
-	-X github.com/avivsinai/bitbucket-cli/internal/build.dateFromLdflags=$(BUILD_DATE)
+	-X github.com/avivsinai/bitbucket-cli/internal/build.dateFromLdflags=$(BUILD_DATE) \
+	-X github.com/avivsinai/bitbucket-cli/pkg/oauth.cloudClientID=$(BKT_OAUTH_CLIENT_ID) \
+	-X github.com/avivsinai/bitbucket-cli/pkg/oauth.cloudClientSecret=$(BKT_OAUTH_CLIENT_SECRET)
 
 .PHONY: build fmt lint test tidy sbom release snapshot clean check-skills release-local generate-skill
 

--- a/pkg/bbcloud/client.go
+++ b/pkg/bbcloud/client.go
@@ -13,12 +13,14 @@ import (
 
 // Options configure the Bitbucket Cloud client.
 type Options struct {
-	BaseURL     string
-	Username    string
-	Token       string
-	Workspace   string
-	EnableCache bool
-	Retry       httpx.RetryPolicy
+	BaseURL        string
+	Username       string
+	Token          string
+	Workspace      string
+	AuthMethod     string // "basic" (default) or "bearer"
+	EnableCache    bool
+	Retry          httpx.RetryPolicy
+	TokenRefresher func(ctx context.Context) (string, error)
 }
 
 // Client wraps Bitbucket Cloud REST endpoints.
@@ -37,13 +39,19 @@ func New(opts Options) (*Client, error) {
 		opts.BaseURL = "https://api.bitbucket.org/2.0"
 	}
 
+	authMethod := opts.AuthMethod
+	if authMethod == "" && opts.TokenRefresher != nil {
+		authMethod = "bearer"
+	}
 	httpClient, err := httpx.New(httpx.Options{
-		BaseURL:     opts.BaseURL,
-		Username:    opts.Username,
-		Password:    opts.Token,
-		UserAgent:   "bkt-cli",
-		EnableCache: opts.EnableCache,
-		Retry:       opts.Retry,
+		BaseURL:        opts.BaseURL,
+		Username:       opts.Username,
+		Password:       opts.Token,
+		AuthMethod:     authMethod,
+		UserAgent:      "bkt-cli",
+		EnableCache:    opts.EnableCache,
+		Retry:          opts.Retry,
+		TokenRefresher: opts.TokenRefresher,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/bbcloud/client_test.go
+++ b/pkg/bbcloud/client_test.go
@@ -785,6 +785,111 @@ func TestPingPreservesVersionedBasePath(t *testing.T) {
 	}
 }
 
+func TestNewWithExplicitAuthMethod(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if !strings.HasPrefix(auth, "Bearer ") {
+			t.Errorf("Authorization = %q, want Bearer prefix", auth)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client, err := New(Options{
+		BaseURL:    server.URL,
+		Token:      "my-token",
+		AuthMethod: "bearer",
+		Retry:      httpx.RetryPolicy{MaxAttempts: 1},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, _ := client.HTTP().NewRequest(context.Background(), "GET", "/test", nil)
+	_ = client.HTTP().Do(req, nil)
+}
+
+func TestNewWithTokenRefresherImpliesBearer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if !strings.HasPrefix(auth, "Bearer ") {
+			t.Errorf("Authorization = %q, want Bearer prefix", auth)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client, err := New(Options{
+		BaseURL: server.URL,
+		Token:   "oauth-token",
+		Retry:   httpx.RetryPolicy{MaxAttempts: 1},
+		TokenRefresher: func(ctx context.Context) (string, error) {
+			return "refreshed", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, _ := client.HTTP().NewRequest(context.Background(), "GET", "/test", nil)
+	_ = client.HTTP().Do(req, nil)
+}
+
+func TestNewExplicitAuthMethodOverridesRefresherDefault(t *testing.T) {
+	// When AuthMethod is explicitly set, it should be used even if TokenRefresher is set.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if !strings.HasPrefix(auth, "Bearer ") {
+			t.Errorf("Authorization = %q, want Bearer prefix", auth)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client, err := New(Options{
+		BaseURL:    server.URL,
+		Token:      "tok",
+		AuthMethod: "bearer",
+		Retry:      httpx.RetryPolicy{MaxAttempts: 1},
+		TokenRefresher: func(ctx context.Context) (string, error) {
+			return "refreshed", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, _ := client.HTTP().NewRequest(context.Background(), "GET", "/test", nil)
+	_ = client.HTTP().Do(req, nil)
+}
+
+func TestNewWithoutAuthMethodDefaultsToBasic(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		if !ok {
+			t.Error("expected basic auth")
+		}
+		if user != "user@example.com" || pass != "app-password" {
+			t.Errorf("basic auth = (%q, %q)", user, pass)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client, err := New(Options{
+		BaseURL:  server.URL,
+		Username: "user@example.com",
+		Token:    "app-password",
+		Retry:    httpx.RetryPolicy{MaxAttempts: 1},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, _ := client.HTTP().NewRequest(context.Background(), "GET", "/test", nil)
+	_ = client.HTTP().Do(req, nil)
+}
+
 func TestListPipelinesRequiresParams(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	_, err := client.ListPipelines(context.Background(), "", "repo", 0)

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -20,6 +20,7 @@ import (
 	"github.com/avivsinai/bitbucket-cli/pkg/cmdutil"
 	"github.com/avivsinai/bitbucket-cli/pkg/httpx"
 	"github.com/avivsinai/bitbucket-cli/pkg/iostreams"
+	"github.com/avivsinai/bitbucket-cli/pkg/oauth"
 )
 
 // CloudTokenURL is the URL where users create Bitbucket Cloud API tokens.
@@ -62,6 +63,7 @@ type loginOptions struct {
 	AllowInsecureStore bool
 	AllowHTTP          bool
 	Web                bool
+	WebToken           bool
 }
 
 func newLoginCmd(f *cmdutil.Factory) *cobra.Command {
@@ -77,25 +79,32 @@ credentials in the OS keychain.
 
 For Data Center (--kind dc, the default), you authenticate with a Personal
 Access Token (PAT). The token needs Repository Read/Write and Project Read
-permissions. Use --web to open the PAT management page in your browser.
+permissions. Use --web-token to open the PAT management page in your browser.
 
-For Bitbucket Cloud (--kind cloud), you authenticate with an Atlassian API
-token. The token must be created with Bitbucket scopes (Account Read,
-Repositories Read/Write, Pull Requests Read/Write). Use --web to open the
-Atlassian token management page.
+For Bitbucket Cloud (--kind cloud), the recommended method is --web, which
+uses OAuth 2.0 to authenticate in the browser. The CLI receives a short-lived
+access token that is automatically refreshed. Alternatively, use --web-token
+to create an Atlassian API token manually.
+
+OAuth credentials are embedded at build time via ldflags. For source installs
+(go install), set BKT_OAUTH_CLIENT_ID and BKT_OAUTH_CLIENT_SECRET environment
+variables before running --web.
 
 Credentials are verified against the remote host before being stored. If no
 OS keychain is available, pass --allow-insecure-store to use encrypted file
 fallback. In non-interactive environments, provide --username and --token
 on the command line or via stdin.`,
-		Example: `  # Interactive login to a Data Center instance
+		Example: `  # Login to Bitbucket Cloud via OAuth (recommended)
+  bkt auth login https://bitbucket.org --kind cloud --web
+
+  # Login to Bitbucket Cloud with an API token
+  bkt auth login https://bitbucket.org --kind cloud --web-token
+
+  # Interactive login to a Data Center instance
   bkt auth login https://bitbucket.example.com
 
-  # Login to Bitbucket Cloud interactively
-  bkt auth login https://bitbucket.org --kind cloud
-
   # Open browser to create a PAT, then prompt for credentials
-  bkt auth login https://bitbucket.example.com --web
+  bkt auth login https://bitbucket.example.com --web-token
 
   # Non-interactive login with flags (CI pipelines)
   bkt auth login https://bitbucket.example.com --username admin --token "$PAT"`,
@@ -114,7 +123,8 @@ on the command line or via stdin.`,
 	cmd.Flags().StringVar(&opts.AuthMethod, "auth-method", "basic", "Authentication method: basic (username+token) or bearer (token-only)")
 	cmd.Flags().BoolVar(&opts.AllowInsecureStore, "allow-insecure-store", false, "Allow encrypted fallback secret storage when no OS keychain is available")
 	cmd.Flags().BoolVar(&opts.AllowHTTP, "allow-http", false, "Allow http:// URLs for login even though credentials will be sent in plaintext")
-	cmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open browser to create token, then prompt for credentials")
+	cmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Authenticate via OAuth in the browser (Cloud only)")
+	cmd.Flags().BoolVar(&opts.WebToken, "web-token", false, "Open browser to create an API token, then prompt for credentials")
 
 	return cmd
 }
@@ -171,8 +181,15 @@ func runLogin(cmd *cobra.Command, f *cmdutil.Factory, opts *loginOptions) error 
 	if authMethod != "basic" && authMethod != "bearer" {
 		return fmt.Errorf("unsupported auth method %q; use \"basic\" or \"bearer\"", authMethod)
 	}
-	if kind == "cloud" && authMethod != "basic" {
+	if kind == "cloud" && authMethod != "basic" && !opts.Web {
 		return fmt.Errorf("--auth-method is only supported for Data Center hosts")
+	}
+
+	if opts.Web && opts.WebToken {
+		return fmt.Errorf("--web and --web-token are mutually exclusive")
+	}
+	if opts.Web && kind == "dc" {
+		return fmt.Errorf("--web OAuth login is only supported for Bitbucket Cloud; use --web-token to open the PAT page")
 	}
 
 	cfg, err := f.ResolveConfig()
@@ -189,7 +206,7 @@ func runLogin(cmd *cobra.Command, f *cmdutil.Factory, opts *loginOptions) error 
 			return err
 		}
 
-		if opts.Web && isTerminal(ios.In) {
+		if opts.WebToken && isTerminal(ios.In) {
 			tokenURL := strings.TrimSuffix(baseURL, "/") + "/plugins/servlet/access-tokens/manage"
 			if _, err := fmt.Fprintf(ios.Out, "Opening %s to create a Personal Access Token...\n", tokenURL); err != nil {
 				return err
@@ -288,59 +305,6 @@ func runLogin(cmd *cobra.Command, f *cmdutil.Factory, opts *loginOptions) error 
 			return err
 		}
 	case "cloud":
-		if opts.Web && isTerminal(ios.In) {
-			tokenURL := CloudTokenURL
-			if _, err := fmt.Fprintln(ios.Out, "Opening Atlassian to create a Bitbucket API token..."); err != nil {
-				return err
-			}
-			if _, err := fmt.Fprintln(ios.Out, "\nIMPORTANT: Click \"Create API token with scopes\" and select \"Bitbucket\" as the application."); err != nil {
-				return err
-			}
-			if _, err := fmt.Fprintln(ios.Out, "\nRequired scopes:"); err != nil {
-				return err
-			}
-			if _, err := fmt.Fprintln(ios.Out, "  - Account: Read / read:user:bitbucket (required for login)"); err != nil {
-				return err
-			}
-			if _, err := fmt.Fprintln(ios.Out, "  - Repositories: Read, Write"); err != nil {
-				return err
-			}
-			if _, err := fmt.Fprintln(ios.Out, "  - Pull requests: Read, Write"); err != nil {
-				return err
-			}
-			if _, err := fmt.Fprintln(ios.Out, "  - Issues: Read, Write (if using issue commands)"); err != nil {
-				return err
-			}
-			if err := f.BrowserOpener().Open(tokenURL); err != nil {
-				if _, ferr := fmt.Fprintf(ios.Out, "\nFailed to open browser: %v\nPlease open %s manually.\n", err, tokenURL); ferr != nil {
-					return ferr
-				}
-			}
-			if _, err := fmt.Fprintln(ios.Out, ""); err != nil {
-				return err
-			}
-		}
-
-		if opts.Username == "" {
-			if !isTerminal(ios.In) {
-				return fmt.Errorf("username is required when not running in a TTY")
-			}
-			opts.Username, err = promptString(reader, ios.Out, CloudEmailPrompt)
-			if err != nil {
-				return err
-			}
-		}
-
-		if opts.Token == "" {
-			if !isTerminal(ios.In) {
-				return fmt.Errorf("token is required when not running in a TTY")
-			}
-			opts.Token, err = promptSecret(ios, CloudTokenPrompt)
-			if err != nil {
-				return err
-			}
-		}
-
 		apiURL := baseURL
 		if strings.Contains(baseURL, "bitbucket.org") && !strings.Contains(baseURL, "api.bitbucket.org") {
 			apiURL = "https://api.bitbucket.org/2.0"
@@ -351,46 +315,155 @@ func runLogin(cmd *cobra.Command, f *cmdutil.Factory, opts *loginOptions) error 
 			return err
 		}
 
-		client, err := bbcloud.New(bbcloud.Options{
-			BaseURL:     apiURL,
-			Username:    opts.Username,
-			Token:       opts.Token,
-			EnableCache: true,
-			Retry: httpx.RetryPolicy{
-				MaxAttempts:    4,
-				InitialBackoff: 200 * time.Millisecond,
-				MaxBackoff:     2 * time.Second,
-			},
-		})
-		if err != nil {
-			return err
-		}
+		if opts.Web {
+			// OAuth 2.0 browser-based flow.
+			if oauth.CloudClientID() == "" || oauth.CloudClientSecret() == "" {
+				return fmt.Errorf("OAuth credentials were not embedded in this build; rebuild with BKT_OAUTH_CLIENT_ID and BKT_OAUTH_CLIENT_SECRET or use --web-token for API token login")
+			}
+			if _, err := fmt.Fprintln(ios.Out, "Authenticating with Bitbucket Cloud via OAuth..."); err != nil {
+				return err
+			}
 
-		ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
-		defer cancel()
+			ctx, cancel := context.WithTimeout(cmd.Context(), 120*time.Second)
+			defer cancel()
 
-		user, err := client.CurrentUser(ctx)
-		if err != nil {
-			return fmt.Errorf("verify credentials: %w", err)
-		}
+			result, flowErr := oauth.RunFlow(ctx, oauth.FlowOptions{
+				ClientID:     oauth.CloudClientID(),
+				ClientSecret: oauth.CloudClientSecret(),
+				AuthorizeURL: oauth.CloudAuthorizeURL,
+				TokenURL:     oauth.CloudTokenURL,
+				Scopes:       oauth.CloudScopes(),
+				Out:          ios.Out,
+				OpenBrowser:  f.BrowserOpener().Open,
+			})
+			if flowErr != nil {
+				return fmt.Errorf("OAuth login: %w", flowErr)
+			}
 
-		if err := storeHostToken(hostKey, opts.Token, opts.AllowInsecureStore); err != nil {
-			return fmt.Errorf("store token: %w", err)
-		}
+			tokenBlob, marshalErr := result.Token.Marshal()
+			if marshalErr != nil {
+				return fmt.Errorf("encode token: %w", marshalErr)
+			}
 
-		cfg.SetHost(hostKey, &config.Host{
-			Kind:               "cloud",
-			BaseURL:            apiURL,
-			Username:           opts.Username,
-			AllowInsecureStore: opts.AllowInsecureStore,
-		})
+			if err := storeHostToken(hostKey, tokenBlob, opts.AllowInsecureStore); err != nil {
+				return fmt.Errorf("store token: %w", err)
+			}
 
-		if err := cfg.Save(); err != nil {
-			return err
-		}
+			cfg.SetHost(hostKey, &config.Host{
+				Kind:               "cloud",
+				BaseURL:            apiURL,
+				Username:           result.Username,
+				AuthMethod:         "oauth",
+				AllowInsecureStore: opts.AllowInsecureStore,
+			})
 
-		if _, err := fmt.Fprintf(ios.Out, "✓ Logged in to Bitbucket Cloud as %s (%s)\n", user.Display, user.Username); err != nil {
-			return err
+			if err := cfg.Save(); err != nil {
+				return err
+			}
+
+			displayLabel := result.Username
+			if result.DisplayName != "" {
+				displayLabel = fmt.Sprintf("%s (%s)", result.DisplayName, result.Username)
+			}
+			if _, err := fmt.Fprintf(ios.Out, "✓ Logged in to Bitbucket Cloud as %s via OAuth\n", displayLabel); err != nil {
+				return err
+			}
+		} else {
+			// API token flow (existing behavior).
+			if opts.WebToken && isTerminal(ios.In) {
+				tokenURL := CloudTokenURL
+				if _, err := fmt.Fprintln(ios.Out, "Opening Atlassian to create a Bitbucket API token..."); err != nil {
+					return err
+				}
+				if _, err := fmt.Fprintln(ios.Out, "\nIMPORTANT: Click \"Create API token with scopes\" and select \"Bitbucket\" as the application."); err != nil {
+					return err
+				}
+				if _, err := fmt.Fprintln(ios.Out, "\nRequired scopes:"); err != nil {
+					return err
+				}
+				if _, err := fmt.Fprintln(ios.Out, "  - Account: Read / read:user:bitbucket (required for login)"); err != nil {
+					return err
+				}
+				if _, err := fmt.Fprintln(ios.Out, "  - Repositories: Read, Write"); err != nil {
+					return err
+				}
+				if _, err := fmt.Fprintln(ios.Out, "  - Pull requests: Read, Write"); err != nil {
+					return err
+				}
+				if _, err := fmt.Fprintln(ios.Out, "  - Issues: Read, Write (if using issue commands)"); err != nil {
+					return err
+				}
+				if err := f.BrowserOpener().Open(tokenURL); err != nil {
+					if _, ferr := fmt.Fprintf(ios.Out, "\nFailed to open browser: %v\nPlease open %s manually.\n", err, tokenURL); ferr != nil {
+						return ferr
+					}
+				}
+				if _, err := fmt.Fprintln(ios.Out, ""); err != nil {
+					return err
+				}
+			}
+
+			if opts.Username == "" {
+				if !isTerminal(ios.In) {
+					return fmt.Errorf("username is required when not running in a TTY")
+				}
+				opts.Username, err = promptString(reader, ios.Out, CloudEmailPrompt)
+				if err != nil {
+					return err
+				}
+			}
+
+			if opts.Token == "" {
+				if !isTerminal(ios.In) {
+					return fmt.Errorf("token is required when not running in a TTY")
+				}
+				opts.Token, err = promptSecret(ios, CloudTokenPrompt)
+				if err != nil {
+					return err
+				}
+			}
+
+			client, err := bbcloud.New(bbcloud.Options{
+				BaseURL:     apiURL,
+				Username:    opts.Username,
+				Token:       opts.Token,
+				EnableCache: true,
+				Retry: httpx.RetryPolicy{
+					MaxAttempts:    4,
+					InitialBackoff: 200 * time.Millisecond,
+					MaxBackoff:     2 * time.Second,
+				},
+			})
+			if err != nil {
+				return err
+			}
+
+			ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
+			defer cancel()
+
+			user, err := client.CurrentUser(ctx)
+			if err != nil {
+				return fmt.Errorf("verify credentials: %w", err)
+			}
+
+			if err := storeHostToken(hostKey, opts.Token, opts.AllowInsecureStore); err != nil {
+				return fmt.Errorf("store token: %w", err)
+			}
+
+			cfg.SetHost(hostKey, &config.Host{
+				Kind:               "cloud",
+				BaseURL:            apiURL,
+				Username:           opts.Username,
+				AllowInsecureStore: opts.AllowInsecureStore,
+			})
+
+			if err := cfg.Save(); err != nil {
+				return err
+			}
+
+			if _, err := fmt.Fprintf(ios.Out, "✓ Logged in to Bitbucket Cloud as %s (%s)\n", user.Display, user.Username); err != nil {
+				return err
+			}
 		}
 	default:
 		return fmt.Errorf("unsupported deployment kind %q", opts.Kind)
@@ -442,6 +515,7 @@ func runStatus(cmd *cobra.Command, f *cmdutil.Factory) error {
 		Username    string `json:"username,omitempty"`
 		AuthMethod  string `json:"auth_method"`
 		TokenSource string `json:"token_source"`
+		Expires     string `json:"expires,omitempty"`
 	}
 
 	type contextSummary struct {
@@ -468,14 +542,18 @@ func runStatus(cmd *cobra.Command, f *cmdutil.Factory) error {
 		if am == "" {
 			am = "basic"
 		}
-		hosts = append(hosts, hostSummary{
+		hs := hostSummary{
 			Key:         key,
 			Kind:        h.Kind,
 			BaseURL:     h.BaseURL,
 			Username:    h.Username,
 			AuthMethod:  am,
 			TokenSource: tokenSource,
-		})
+		}
+		if am == "oauth" && tokenSource != secret.EnvToken {
+			hs.Expires = oauthExpiryLabel(key, h)
+		}
+		hosts = append(hosts, hs)
 	}
 
 	var contextNames []string
@@ -532,6 +610,11 @@ func runStatus(cmd *cobra.Command, f *cmdutil.Factory) error {
 			}
 			if _, err := fmt.Fprintf(ios.Out, "    token source: %s\n", h.TokenSource); err != nil {
 				return err
+			}
+			if h.Expires != "" {
+				if _, err := fmt.Fprintf(ios.Out, "    expires: %s\n", h.Expires); err != nil {
+					return err
+				}
 			}
 		}
 
@@ -750,4 +833,33 @@ func resolvedTokenSource() string {
 		return secret.EnvToken
 	}
 	return "keyring"
+}
+
+// oauthExpiryLabel reads the OAuth JSON blob from the keyring and returns a
+// human-readable expiry string. Returns "" on any error (best-effort).
+func oauthExpiryLabel(hostKey string, host *config.Host) string {
+	opts := []secret.Option{}
+	if host.AllowInsecureStore {
+		opts = append(opts, secret.WithAllowFileFallback(true))
+	}
+	store, err := secret.Open(opts...)
+	if err != nil {
+		return ""
+	}
+	raw, err := store.Get(secret.TokenKey(hostKey))
+	if err != nil {
+		return ""
+	}
+	if !oauth.IsTokenBlob(raw) {
+		return ""
+	}
+	tok, err := oauth.Unmarshal(raw)
+	if err != nil {
+		return ""
+	}
+	if tok.IsExpired() {
+		return "expired"
+	}
+	remaining := time.Until(tok.ExpiresAt).Truncate(time.Minute)
+	return fmt.Sprintf("%s (in %s)", tok.ExpiresAt.Format(time.RFC3339), remaining)
 }

--- a/pkg/cmd/auth/auth_test.go
+++ b/pkg/cmd/auth/auth_test.go
@@ -1,7 +1,11 @@
 package auth
 
 import (
+	"context"
+	"encoding/json"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -254,6 +258,677 @@ func TestRunStatusShowsKeyringTokenSource(t *testing.T) {
 	if !strings.Contains(output, "token source: keyring") {
 		t.Fatalf("expected keyring token source in output, got:\n%s", output)
 	}
+}
+
+func TestRunLoginRejectsWebOnDC(t *testing.T) {
+	cfg := &config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	}
+	f, _, _ := newAuthTestFactory(cfg)
+
+	err := runLogin(&cobra.Command{}, f, &loginOptions{
+		Host: "https://bitbucket.example.com",
+		Kind: "dc",
+		Web:  true,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "only supported for Bitbucket Cloud") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+func TestRunLoginRejectsWebAndWebToken(t *testing.T) {
+	cfg := &config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	}
+	f, _, _ := newAuthTestFactory(cfg)
+
+	err := runLogin(&cobra.Command{}, f, &loginOptions{
+		Host:     "https://bitbucket.org",
+		Kind:     "cloud",
+		Web:      true,
+		WebToken: true,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+func TestRunLoginRejectsWebWithoutOAuthCreds(t *testing.T) {
+	t.Setenv("BKT_OAUTH_CLIENT_ID", "")
+	t.Setenv("BKT_OAUTH_CLIENT_SECRET", "")
+
+	cfg := &config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	}
+	f, _, _ := newAuthTestFactory(cfg)
+
+	err := runLogin(&cobra.Command{}, f, &loginOptions{
+		Host: "https://bitbucket.org",
+		Kind: "cloud",
+		Web:  true,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "OAuth credentials were not embedded") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+func TestRunLoginRejectsAuthMethodOnCloudNonWeb(t *testing.T) {
+	cfg := &config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	}
+	f, _, _ := newAuthTestFactory(cfg)
+
+	err := runLogin(&cobra.Command{}, f, &loginOptions{
+		Host:       "https://bitbucket.org",
+		Kind:       "cloud",
+		AuthMethod: "bearer",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "auth-method is only supported for Data Center") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+func TestRunLoginRejectsUnsupportedAuthMethod(t *testing.T) {
+	cfg := &config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	}
+	f, _, _ := newAuthTestFactory(cfg)
+
+	err := runLogin(&cobra.Command{}, f, &loginOptions{
+		Host:       "https://bitbucket.example.com",
+		Kind:       "dc",
+		AuthMethod: "digest",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "unsupported auth method") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+func TestRunLoginRejectsUnsupportedKind(t *testing.T) {
+	cfg := &config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	}
+	f, _, _ := newAuthTestFactory(cfg)
+
+	err := runLogin(&cobra.Command{}, f, &loginOptions{
+		Host:     "https://bitbucket.example.com",
+		Kind:     "server",
+		Username: "admin",
+		Token:    "tok",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "unsupported deployment kind") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+func TestRunStatusShowsOAuthMethod(t *testing.T) {
+	t.Setenv(secret.EnvToken, "")
+
+	cfg := &config.Config{
+		Hosts: map[string]*config.Host{
+			"api.bitbucket.org": {
+				Kind:       "cloud",
+				BaseURL:    "https://api.bitbucket.org/2.0",
+				Username:   "erank_ai21",
+				AuthMethod: "oauth",
+			},
+		},
+		Contexts: make(map[string]*config.Context),
+	}
+	f, stdout, _ := newAuthTestFactory(cfg)
+
+	if err := runStatus(&cobra.Command{}, f); err != nil {
+		t.Fatalf("runStatus error: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "auth: oauth") {
+		t.Errorf("expected 'auth: oauth' in output, got:\n%s", output)
+	}
+}
+
+func TestRunStatusHidesOAuthExpiryWithBKTToken(t *testing.T) {
+	t.Setenv(secret.EnvToken, "override-token")
+
+	cfg := &config.Config{
+		Hosts: map[string]*config.Host{
+			"api.bitbucket.org": {
+				Kind:       "cloud",
+				BaseURL:    "https://api.bitbucket.org/2.0",
+				Username:   "erank_ai21",
+				AuthMethod: "oauth",
+			},
+		},
+		Contexts: make(map[string]*config.Context),
+	}
+	f, stdout, _ := newAuthTestFactory(cfg)
+
+	if err := runStatus(&cobra.Command{}, f); err != nil {
+		t.Fatalf("runStatus error: %v", err)
+	}
+
+	output := stdout.String()
+	if strings.Contains(output, "expires:") {
+		t.Errorf("should not show expires when BKT_TOKEN is set, got:\n%s", output)
+	}
+	if !strings.Contains(output, "token source: BKT_TOKEN") {
+		t.Errorf("expected BKT_TOKEN source, got:\n%s", output)
+	}
+}
+
+func TestRunStatusShowsNoHostsMessage(t *testing.T) {
+	t.Setenv(secret.EnvToken, "")
+
+	cfg := &config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	}
+	f, stdout, _ := newAuthTestFactory(cfg)
+
+	if err := runStatus(&cobra.Command{}, f); err != nil {
+		t.Fatalf("runStatus error: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "No hosts configured") {
+		t.Errorf("expected no-hosts message, got:\n%s", output)
+	}
+}
+
+func TestRunLogoutRequiresHost(t *testing.T) {
+	cfg := &config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	}
+	f, _, _ := newAuthTestFactory(cfg)
+
+	err := runLogout(&cobra.Command{}, f, &logoutOptions{Host: ""})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "host is required") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+func TestRunLogoutUnknownHost(t *testing.T) {
+	cfg := &config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	}
+	f, _, _ := newAuthTestFactory(cfg)
+
+	err := runLogout(&cobra.Command{}, f, &logoutOptions{Host: "unknown.example.com"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+func TestNewCmdAuthHasSubcommands(t *testing.T) {
+	f, _, _ := newAuthTestFactory(&config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	})
+
+	cmd := NewCmdAuth(f)
+	names := make(map[string]bool)
+	for _, sub := range cmd.Commands() {
+		names[sub.Name()] = true
+	}
+	for _, want := range []string{"login", "status", "logout"} {
+		if !names[want] {
+			t.Errorf("missing subcommand %q", want)
+		}
+	}
+}
+
+func TestRunLoginCloudNonWebRequiresUsername(t *testing.T) {
+	cfg := &config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	}
+	f, _, _ := newAuthTestFactory(cfg)
+
+	err := runLogin(&cobra.Command{}, f, &loginOptions{
+		Host: "https://bitbucket.org",
+		Kind: "cloud",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "username is required") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+func TestRunLoginCloudNonWebRequiresToken(t *testing.T) {
+	cfg := &config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	}
+	f, _, _ := newAuthTestFactory(cfg)
+
+	err := runLogin(&cobra.Command{}, f, &loginOptions{
+		Host:     "https://bitbucket.org",
+		Kind:     "cloud",
+		Username: "user@example.com",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "token is required") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+func TestRunLoginCloudWebTokenNonTTYSkipsBrowserPrompt(t *testing.T) {
+	// --web-token in non-TTY: browser scope output is skipped, falls through
+	// to username prompt which errors in non-TTY.
+	cfg := &config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	}
+	f, stdout, _ := newAuthTestFactory(cfg)
+
+	err := runLogin(&cobra.Command{}, f, &loginOptions{
+		Host:     "https://bitbucket.org",
+		Kind:     "cloud",
+		WebToken: true,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "username is required") {
+		t.Errorf("error = %q", err)
+	}
+	// In non-TTY, the browser scope output should NOT be printed.
+	if strings.Contains(stdout.String(), "Opening Atlassian") {
+		t.Error("should not print browser prompt in non-TTY")
+	}
+}
+
+func TestRunLoginDCWebTokenNonTTY(t *testing.T) {
+	// --web-token on DC in non-TTY: browser output skipped, falls to username prompt.
+	cfg := &config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	}
+	f, stdout, _ := newAuthTestFactory(cfg)
+
+	err := runLogin(&cobra.Command{}, f, &loginOptions{
+		Host:     "https://bitbucket.example.com",
+		Kind:     "dc",
+		WebToken: true,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "username is required") {
+		t.Errorf("error = %q", err)
+	}
+	if strings.Contains(stdout.String(), "Opening") {
+		t.Error("should not print browser prompt in non-TTY")
+	}
+}
+
+func TestRunLoginDCBearerSkipsUsernamePrompt(t *testing.T) {
+	// DC with bearer auth skips username prompt, goes straight to token prompt.
+	cfg := &config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	}
+	f, _, _ := newAuthTestFactory(cfg)
+
+	err := runLogin(&cobra.Command{}, f, &loginOptions{
+		Host:       "https://bitbucket.example.com",
+		Kind:       "dc",
+		AuthMethod: "bearer",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// Should ask for token, not username.
+	if !strings.Contains(err.Error(), "token is required") {
+		t.Errorf("error = %q, want 'token is required'", err)
+	}
+}
+
+func TestRunStatusShowsContexts(t *testing.T) {
+	t.Setenv(secret.EnvToken, "")
+
+	cfg := &config.Config{
+		ActiveContext: "dev",
+		Hosts: map[string]*config.Host{
+			"bitbucket.example.com": {
+				Kind:    "dc",
+				BaseURL: "https://bitbucket.example.com",
+			},
+		},
+		Contexts: map[string]*config.Context{
+			"dev": {
+				Host:       "bitbucket.example.com",
+				ProjectKey: "PROJ",
+				Workspace:  "ws",
+			},
+		},
+	}
+	f, stdout, _ := newAuthTestFactory(cfg)
+
+	if err := runStatus(&cobra.Command{}, f); err != nil {
+		t.Fatalf("runStatus error: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "* dev") {
+		t.Errorf("expected active context marker, got:\n%s", output)
+	}
+	if !strings.Contains(output, "project: PROJ") {
+		t.Errorf("expected project in output, got:\n%s", output)
+	}
+}
+
+func TestLoginCmdHasWebAndWebTokenFlags(t *testing.T) {
+	f, _, _ := newAuthTestFactory(&config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	})
+
+	cmd := newLoginCmd(f)
+	if cmd.Flag("web") == nil {
+		t.Error("missing --web flag")
+	}
+	if cmd.Flag("web-token") == nil {
+		t.Error("missing --web-token flag")
+	}
+}
+
+// setupFileKeyring configures env vars for file-backed keyring in a temp dir.
+func setupFileKeyring(t *testing.T) {
+	t.Helper()
+	t.Setenv("BKT_ALLOW_INSECURE_STORE", "1")
+	t.Setenv("BKT_KEYRING_PASSPHRASE", "test-pass")
+	t.Setenv("KEYRING_BACKEND", "file")
+	t.Setenv("KEYRING_FILE_DIR", t.TempDir())
+}
+
+func TestRunLoginDCFullFlow(t *testing.T) {
+	// Mock DC server: /rest/api/1.0/users/admin returns user info.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/rest/api/1.0/users/admin") {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"name":        "admin",
+				"displayName": "Admin User",
+				"slug":        "admin",
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	setupFileKeyring(t)
+	t.Setenv(secret.EnvToken, "")
+
+	tmpDir := t.TempDir()
+	t.Setenv("BKT_CONFIG_DIR", tmpDir)
+
+	cfg := &config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	}
+	f, stdout, _ := newAuthTestFactory(cfg)
+
+	err := runLogin(newTestCmd(), f, &loginOptions{
+		Host:               srv.URL,
+		Kind:               "dc",
+		Username:           "admin",
+		Token:              "test-pat",
+		AllowHTTP:          true,
+		AllowInsecureStore: true,
+	})
+	if err != nil {
+		t.Fatalf("runLogin: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Logged in") {
+		t.Errorf("expected success message, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Admin User") {
+		t.Errorf("expected display name in output, got:\n%s", output)
+	}
+}
+
+func TestRunLoginDCBearerFullFlow(t *testing.T) {
+	// Mock DC server: /rest/api/1.0/users?limit=1 returns user list.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/rest/api/1.0/users") {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values": []map[string]any{
+					{"name": "admin", "displayName": "Admin User"},
+				},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	setupFileKeyring(t)
+	t.Setenv(secret.EnvToken, "")
+
+	tmpDir := t.TempDir()
+	t.Setenv("BKT_CONFIG_DIR", tmpDir)
+
+	cfg := &config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	}
+	f, stdout, _ := newAuthTestFactory(cfg)
+
+	err := runLogin(newTestCmd(), f, &loginOptions{
+		Host:               srv.URL,
+		Kind:               "dc",
+		AuthMethod:         "bearer",
+		Token:              "test-pat",
+		AllowHTTP:          true,
+		AllowInsecureStore: true,
+	})
+	if err != nil {
+		t.Fatalf("runLogin: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Logged in") {
+		t.Errorf("expected success message, got:\n%s", output)
+	}
+	if !strings.Contains(output, "bearer token") {
+		t.Errorf("expected 'bearer token' display name, got:\n%s", output)
+	}
+}
+
+func TestRunLoginCloudAPITokenFullFlow(t *testing.T) {
+	// Mock Cloud server: /user returns user info.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/user" || strings.HasSuffix(r.URL.Path, "/user") {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"username":     "erank",
+				"display_name": "Eran K",
+				"account_id":   "123:abc",
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	setupFileKeyring(t)
+	t.Setenv(secret.EnvToken, "")
+
+	tmpDir := t.TempDir()
+	t.Setenv("BKT_CONFIG_DIR", tmpDir)
+
+	cfg := &config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	}
+	f, stdout, _ := newAuthTestFactory(cfg)
+
+	err := runLogin(newTestCmd(), f, &loginOptions{
+		Host:               srv.URL,
+		Kind:               "cloud",
+		Username:           "erank@example.com",
+		Token:              "api-token",
+		AllowHTTP:          true,
+		AllowInsecureStore: true,
+	})
+	if err != nil {
+		t.Fatalf("runLogin: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Logged in to Bitbucket Cloud") {
+		t.Errorf("expected success message, got:\n%s", output)
+	}
+	if !strings.Contains(output, "erank") {
+		t.Errorf("expected username in output, got:\n%s", output)
+	}
+}
+
+func TestRunLoginDCVerifyFails(t *testing.T) {
+	// Mock DC server that returns 401.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	}
+	f, _, _ := newAuthTestFactory(cfg)
+
+	err := runLogin(newTestCmd(), f, &loginOptions{
+		Host:      srv.URL,
+		Kind:      "dc",
+		Username:  "admin",
+		Token:     "bad-token",
+		AllowHTTP: true,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "verify credentials") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+func TestRunLoginCloudVerifyFails(t *testing.T) {
+	// Mock Cloud server that returns 401.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	}
+	f, _, _ := newAuthTestFactory(cfg)
+
+	err := runLogin(newTestCmd(), f, &loginOptions{
+		Host:      srv.URL,
+		Kind:      "cloud",
+		Username:  "user@example.com",
+		Token:     "bad-token",
+		AllowHTTP: true,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "verify credentials") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+func TestRunLogoutFullFlow(t *testing.T) {
+	setupFileKeyring(t)
+	t.Setenv(secret.EnvToken, "")
+
+	tmpDir := t.TempDir()
+	t.Setenv("BKT_CONFIG_DIR", tmpDir)
+
+	// Pre-store a token so delete succeeds.
+	store, storeErr := secret.Open(secret.WithAllowFileFallback(true))
+	if storeErr != nil {
+		t.Fatalf("open store: %v", storeErr)
+	}
+	hostKey := "bitbucket.example.com"
+	if err := store.Set(secret.TokenKey(hostKey), "test-token"); err != nil {
+		t.Fatalf("store token: %v", err)
+	}
+
+	cfg := &config.Config{
+		Hosts: map[string]*config.Host{
+			hostKey: {
+				Kind:               "dc",
+				BaseURL:            "https://bitbucket.example.com",
+				Username:           "admin",
+				AllowInsecureStore: true,
+			},
+		},
+		Contexts: map[string]*config.Context{
+			"dev": {Host: hostKey},
+		},
+		ActiveContext: "dev",
+	}
+	f, stdout, _ := newAuthTestFactory(cfg)
+
+	err := runLogout(&cobra.Command{}, f, &logoutOptions{Host: hostKey})
+	if err != nil {
+		t.Fatalf("runLogout: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Removed credentials") {
+		t.Errorf("expected removal message, got:\n%s", output)
+	}
+}
+
+func newTestCmd() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	return cmd
 }
 
 func newAuthTestFactory(cfg *config.Config) (*cmdutil.Factory, *strings.Builder, *strings.Builder) {

--- a/pkg/cmdutil/client.go
+++ b/pkg/cmdutil/client.go
@@ -1,13 +1,16 @@
 package cmdutil
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/avivsinai/bitbucket-cli/internal/config"
+	"github.com/avivsinai/bitbucket-cli/internal/secret"
 	"github.com/avivsinai/bitbucket-cli/pkg/bbcloud"
 	"github.com/avivsinai/bitbucket-cli/pkg/bbdc"
 	"github.com/avivsinai/bitbucket-cli/pkg/httpx"
+	"github.com/avivsinai/bitbucket-cli/pkg/oauth"
 )
 
 // NewDCClient constructs a Bitbucket Data Center client using the supplied host.
@@ -34,6 +37,8 @@ func NewDCClient(host *config.Host) (*bbdc.Client, error) {
 }
 
 // NewCloudClient constructs a Bitbucket Cloud client using the supplied host.
+// When the host uses OAuth authentication, a TokenRefresher is wired to
+// transparently refresh expired tokens on 401.
 func NewCloudClient(host *config.Host) (*bbcloud.Client, error) {
 	if host == nil {
 		return nil, fmt.Errorf("missing host configuration")
@@ -52,7 +57,74 @@ func NewCloudClient(host *config.Host) (*bbcloud.Client, error) {
 			MaxBackoff:     2 * time.Second,
 		},
 	}
+
+	if host.AuthMethod == "oauth" && secret.TokenFromEnv() == "" {
+		// Keyring-stored OAuth tokens use Bearer auth + auto-refresh.
+		// When BKT_TOKEN overrides, the caller controls the token type
+		// and auth method defaults to basic (matching API-token behavior).
+		opts.AuthMethod = "bearer"
+		hostKey, err := HostKeyFromURL(host.BaseURL)
+		if err != nil {
+			return nil, fmt.Errorf("resolve host key: %w", err)
+		}
+		opts.TokenRefresher = oauthTokenRefresher(hostKey, host)
+	}
+
 	return bbcloud.New(opts)
+}
+
+// oauthTokenRefresher returns a function that refreshes the OAuth token and
+// updates the keyring. Captured values are the host key and host config so the
+// closure can persist the new token.
+func oauthTokenRefresher(hostKey string, host *config.Host) func(ctx context.Context) (string, error) {
+	return func(ctx context.Context) (string, error) {
+		if oauth.CloudClientID() == "" || oauth.CloudClientSecret() == "" {
+			return "", fmt.Errorf("token expired and OAuth client credentials are missing; rebuild with BKT_OAUTH_CLIENT_ID/BKT_OAUTH_CLIENT_SECRET or re-login with `bkt auth login --web-token`")
+		}
+
+		store, err := secret.Open(secretOpts(host)...)
+		if err != nil {
+			return "", fmt.Errorf("open secret store: %w", err)
+		}
+
+		raw, err := store.Get(secret.TokenKey(hostKey))
+		if err != nil {
+			return "", fmt.Errorf("read token: %w", err)
+		}
+
+		tok, err := oauth.Unmarshal(raw)
+		if err != nil {
+			return "", fmt.Errorf("parse stored token: %w", err)
+		}
+
+		newTok, err := oauth.RefreshToken(ctx,
+			tok.RefreshToken,
+			oauth.CloudClientID(),
+			oauth.CloudClientSecret(),
+			oauth.CloudTokenURL,
+		)
+		if err != nil {
+			return "", fmt.Errorf("refresh failed (re-login with `bkt auth login --web`): %w", err)
+		}
+
+		blob, err := newTok.Marshal()
+		if err != nil {
+			return "", fmt.Errorf("encode refreshed token: %w", err)
+		}
+		if err := store.Set(secret.TokenKey(hostKey), blob); err != nil {
+			return "", fmt.Errorf("store refreshed token: %w", err)
+		}
+
+		host.Token = newTok.AccessToken
+		return newTok.AccessToken, nil
+	}
+}
+
+func secretOpts(host *config.Host) []secret.Option {
+	if host != nil && host.AllowInsecureStore {
+		return []secret.Option{secret.WithAllowFileFallback(true)}
+	}
+	return nil
 }
 
 // NewHTTPClient constructs a raw HTTP client for the configured host.

--- a/pkg/cmdutil/client_test.go
+++ b/pkg/cmdutil/client_test.go
@@ -1,0 +1,313 @@
+package cmdutil
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/bitbucket-cli/internal/config"
+	"github.com/avivsinai/bitbucket-cli/internal/secret"
+	"github.com/avivsinai/bitbucket-cli/pkg/oauth"
+)
+
+func TestNewCloudClientBasicAuth(t *testing.T) {
+	host := &config.Host{
+		Kind:     "cloud",
+		BaseURL:  "https://api.bitbucket.org/2.0",
+		Username: "user@example.com",
+		Token:    "app-password",
+	}
+
+	client, err := NewCloudClient(host)
+	if err != nil {
+		t.Fatalf("NewCloudClient error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected client, got nil")
+	}
+}
+
+func TestNewCloudClientOAuthWiresRefresher(t *testing.T) {
+	host := &config.Host{
+		Kind:       "cloud",
+		BaseURL:    "https://api.bitbucket.org/2.0",
+		Username:   "erank_ai21",
+		AuthMethod: "oauth",
+		Token:      "access-token",
+	}
+
+	// Ensure BKT_TOKEN is not set so the OAuth path is taken.
+	t.Setenv(secret.EnvToken, "")
+
+	client, err := NewCloudClient(host)
+	if err != nil {
+		t.Fatalf("NewCloudClient error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected client, got nil")
+	}
+}
+
+func TestNewCloudClientOAuthSkipsRefresherWithBKTToken(t *testing.T) {
+	host := &config.Host{
+		Kind:       "cloud",
+		BaseURL:    "https://api.bitbucket.org/2.0",
+		Username:   "erank_ai21",
+		AuthMethod: "oauth",
+		Token:      "env-override",
+	}
+
+	t.Setenv(secret.EnvToken, "env-override")
+
+	client, err := NewCloudClient(host)
+	if err != nil {
+		t.Fatalf("NewCloudClient error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected client, got nil")
+	}
+}
+
+func TestNewCloudClientNilHostError(t *testing.T) {
+	_, err := NewCloudClient(nil)
+	if err == nil {
+		t.Fatal("expected error for nil host")
+	}
+}
+
+func TestNewDCClientBasic(t *testing.T) {
+	host := &config.Host{
+		Kind:    "dc",
+		BaseURL: "https://bitbucket.example.com",
+		Token:   "pat",
+	}
+
+	client, err := NewDCClient(host)
+	if err != nil {
+		t.Fatalf("NewDCClient error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected client, got nil")
+	}
+}
+
+func TestSecretOptsInsecure(t *testing.T) {
+	host := &config.Host{AllowInsecureStore: true}
+	opts := secretOpts(host)
+	if len(opts) != 1 {
+		t.Errorf("secretOpts = %d options, want 1", len(opts))
+	}
+}
+
+func TestSecretOptsSecure(t *testing.T) {
+	host := &config.Host{AllowInsecureStore: false}
+	opts := secretOpts(host)
+	if len(opts) != 0 {
+		t.Errorf("secretOpts = %d options, want 0", len(opts))
+	}
+}
+
+func TestSecretOptsNilHost(t *testing.T) {
+	opts := secretOpts(nil)
+	if opts != nil {
+		t.Errorf("secretOpts(nil) = %v, want nil", opts)
+	}
+}
+
+func TestOAuthTokenRefresherMissingCreds(t *testing.T) {
+	t.Setenv("BKT_OAUTH_CLIENT_ID", "")
+	t.Setenv("BKT_OAUTH_CLIENT_SECRET", "")
+
+	host := &config.Host{
+		Kind:               "cloud",
+		BaseURL:            "https://api.bitbucket.org/2.0",
+		AuthMethod:         "oauth",
+		AllowInsecureStore: true,
+	}
+
+	refresher := oauthTokenRefresher("api.bitbucket.org", host)
+	_, err := refresher(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "OAuth client credentials are missing") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+func TestOAuthTokenRefresherKeyNotFound(t *testing.T) {
+	t.Setenv("BKT_OAUTH_CLIENT_ID", "cid")         // gitleaks:allow
+	t.Setenv("BKT_OAUTH_CLIENT_SECRET", "csecret") // gitleaks:allow
+	t.Setenv("BKT_ALLOW_INSECURE_STORE", "1")
+	t.Setenv("BKT_KEYRING_PASSPHRASE", "test-pass")
+	t.Setenv("KEYRING_BACKEND", "file")
+	t.Setenv("KEYRING_FILE_DIR", t.TempDir())
+
+	host := &config.Host{
+		Kind:               "cloud",
+		BaseURL:            "https://api.bitbucket.org/2.0",
+		AuthMethod:         "oauth",
+		AllowInsecureStore: true,
+	}
+
+	refresher := oauthTokenRefresher("api.bitbucket.org", host)
+	_, err := refresher(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "read token") {
+		t.Errorf("error = %q, want 'read token'", err)
+	}
+}
+
+func TestOAuthTokenRefresherInvalidBlob(t *testing.T) {
+	t.Setenv("BKT_OAUTH_CLIENT_ID", "cid")         // gitleaks:allow
+	t.Setenv("BKT_OAUTH_CLIENT_SECRET", "csecret") // gitleaks:allow
+	t.Setenv("BKT_ALLOW_INSECURE_STORE", "1")
+	t.Setenv("BKT_KEYRING_PASSPHRASE", "test-pass")
+	t.Setenv("KEYRING_BACKEND", "file")
+	fileDir := t.TempDir()
+	t.Setenv("KEYRING_FILE_DIR", fileDir)
+
+	// Store invalid JSON blob in keyring.
+	store, err := secret.Open(secret.WithAllowFileFallback(true), secret.WithPassphrase("test-pass"), secret.WithFileDir(fileDir))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := store.Set(secret.TokenKey("api.bitbucket.org"), "not-json"); err != nil {
+		t.Fatalf("store.Set: %v", err)
+	}
+
+	host := &config.Host{
+		Kind:               "cloud",
+		BaseURL:            "https://api.bitbucket.org/2.0",
+		AuthMethod:         "oauth",
+		AllowInsecureStore: true,
+	}
+
+	refresher := oauthTokenRefresher("api.bitbucket.org", host)
+	_, err = refresher(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "parse stored token") {
+		t.Errorf("error = %q, want 'parse stored token'", err)
+	}
+}
+
+func TestOAuthTokenRefresherSuccess(t *testing.T) {
+	// Mock token endpoint that returns a new token.
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{ // gitleaks:allow
+			"access_token":  "new-access",
+			"refresh_token": "new-refresh",
+			"expires_in":    7200,
+		})
+	}))
+	defer tokenSrv.Close()
+
+	t.Setenv("BKT_OAUTH_CLIENT_ID", "cid")         // gitleaks:allow
+	t.Setenv("BKT_OAUTH_CLIENT_SECRET", "csecret") // gitleaks:allow
+	t.Setenv("BKT_ALLOW_INSECURE_STORE", "1")
+	t.Setenv("BKT_KEYRING_PASSPHRASE", "test-pass")
+	t.Setenv("KEYRING_BACKEND", "file")
+	fileDir := t.TempDir()
+	t.Setenv("KEYRING_FILE_DIR", fileDir)
+
+	// Store a valid OAuth token blob in the keyring.
+	tok := oauth.FromResponse("old-access", "old-refresh", 7200)
+	blob, err := tok.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	store, err := secret.Open(secret.WithAllowFileFallback(true), secret.WithPassphrase("test-pass"), secret.WithFileDir(fileDir))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := store.Set(secret.TokenKey("api.bitbucket.org"), blob); err != nil {
+		t.Fatalf("store.Set: %v", err)
+	}
+
+	host := &config.Host{
+		Kind:               "cloud",
+		BaseURL:            "https://api.bitbucket.org/2.0",
+		AuthMethod:         "oauth",
+		AllowInsecureStore: true,
+	}
+
+	// Build a refresher that uses our mock token endpoint.
+	// We can't easily override oauth.CloudTokenURL, so we test the
+	// sub-components instead. Here we directly call oauthTokenRefresher
+	// which uses the real CloudTokenURL. Instead, test the creds check
+	// and store interaction — the actual HTTP refresh is covered in
+	// pkg/oauth/flow_test.go (TestRefreshToken).
+	//
+	// For this test, verify the refresher reads the stored blob,
+	// then fails at the refresh step (since CloudTokenURL is real and
+	// our creds are fake), confirming the store-read path is covered.
+	refresher := oauthTokenRefresher("api.bitbucket.org", host)
+	_, err = refresher(context.Background())
+	// Expected: refresh fails because our fake creds can't auth against
+	// real Bitbucket, but the error should be "refresh failed" (not
+	// "read token" or "parse stored token"), proving we got past those.
+	if err == nil {
+		t.Fatal("expected error from refresh with fake creds")
+	}
+	if !strings.Contains(err.Error(), "refresh failed") {
+		t.Errorf("error = %q, want 'refresh failed'", err)
+	}
+	// Verify host.Token was NOT updated (refresh failed).
+	if host.Token == "new-access" {
+		t.Error("host.Token should not be updated on refresh failure")
+	}
+}
+
+func TestNewHTTPClientDC(t *testing.T) {
+	host := &config.Host{
+		Kind:    "dc",
+		BaseURL: "https://bitbucket.example.com",
+		Token:   "pat",
+	}
+	client, err := NewHTTPClient(host)
+	if err != nil {
+		t.Fatalf("NewHTTPClient error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected client")
+	}
+}
+
+func TestNewHTTPClientCloud(t *testing.T) {
+	host := &config.Host{
+		Kind:    "cloud",
+		BaseURL: "https://api.bitbucket.org/2.0",
+		Token:   "tok",
+	}
+	t.Setenv(secret.EnvToken, "")
+	client, err := NewHTTPClient(host)
+	if err != nil {
+		t.Fatalf("NewHTTPClient error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected client")
+	}
+}
+
+func TestNewHTTPClientUnsupportedKind(t *testing.T) {
+	host := &config.Host{Kind: "unknown"}
+	_, err := NewHTTPClient(host)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestNewHTTPClientNil(t *testing.T) {
+	_, err := NewHTTPClient(nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/pkg/cmdutil/context.go
+++ b/pkg/cmdutil/context.go
@@ -14,6 +14,7 @@ import (
 	"github.com/avivsinai/bitbucket-cli/internal/config"
 	"github.com/avivsinai/bitbucket-cli/internal/remote"
 	"github.com/avivsinai/bitbucket-cli/internal/secret"
+	"github.com/avivsinai/bitbucket-cli/pkg/oauth"
 )
 
 // ResolveContext fetches the context and host configuration given an optional
@@ -249,6 +250,17 @@ func loadHostToken(executable, hostKey string, host *config.Host) error {
 	// host needs a different token, use the keyring instead.
 	if envToken := secret.TokenFromEnv(); envToken != "" {
 		host.Token = envToken
+		// Apply BKT_USERNAME and BKT_AUTH_METHOD so that OAuth-saved hosts
+		// (where Username is a Bitbucket ID, not an email) work correctly
+		// when overridden with a Cloud API token.
+		if u := strings.TrimSpace(os.Getenv(secret.EnvUsername)); u != "" {
+			host.Username = u
+		} else if host.AuthMethod == "oauth" && host.Kind == "cloud" {
+			return fmt.Errorf("BKT_USERNAME is required when overriding an OAuth-authenticated Cloud host with BKT_TOKEN; set BKT_USERNAME to your Atlassian account email")
+		}
+		if m := strings.TrimSpace(os.Getenv(secret.EnvAuthMethod)); m != "" {
+			host.AuthMethod = m
+		}
 		return nil
 	}
 
@@ -279,6 +291,18 @@ func loadHostToken(executable, hostKey string, host *config.Host) error {
 			return fmt.Errorf("credentials for host %q not found; run `%s auth login %s`", hostKey, executable, target)
 		}
 		return err
+	}
+
+	if oauth.IsTokenBlob(token) {
+		tok, parseErr := oauth.Unmarshal(token)
+		if parseErr != nil {
+			return fmt.Errorf("parse OAuth token for host %q: %w", hostKey, parseErr)
+		}
+		host.Token = tok.AccessToken
+		if host.AuthMethod == "" {
+			host.AuthMethod = "oauth"
+		}
+		return nil
 	}
 
 	host.Token = token

--- a/pkg/cmdutil/context_test.go
+++ b/pkg/cmdutil/context_test.go
@@ -868,6 +868,187 @@ func TestResolveHostEnvFallbackWithSingleHostOverride(t *testing.T) {
 	}
 }
 
+func TestLoadHostTokenEnvOverridesUsernameAndAuthMethod(t *testing.T) {
+	t.Setenv(secret.EnvToken, "env-token")
+	t.Setenv(secret.EnvUsername, "ci@example.com")
+	t.Setenv(secret.EnvAuthMethod, "basic")
+
+	host := &config.Host{
+		Kind:       "cloud",
+		BaseURL:    "https://api.bitbucket.org/2.0",
+		Username:   "old-user",
+		AuthMethod: "oauth",
+	}
+
+	if err := loadHostToken("bkt", "api.bitbucket.org", host); err != nil {
+		t.Fatalf("loadHostToken error: %v", err)
+	}
+	if host.Token != "env-token" {
+		t.Errorf("Token = %q, want env-token", host.Token)
+	}
+	if host.Username != "ci@example.com" {
+		t.Errorf("Username = %q, want ci@example.com", host.Username)
+	}
+	if host.AuthMethod != "basic" {
+		t.Errorf("AuthMethod = %q, want basic", host.AuthMethod)
+	}
+}
+
+func TestLoadHostTokenOAuthRequiresBKTUsername(t *testing.T) {
+	t.Setenv(secret.EnvToken, "env-token")
+	t.Setenv(secret.EnvUsername, "")
+	t.Setenv(secret.EnvAuthMethod, "")
+
+	host := &config.Host{
+		Kind:       "cloud",
+		BaseURL:    "https://api.bitbucket.org/2.0",
+		Username:   "erank_ai21",
+		AuthMethod: "oauth",
+	}
+
+	err := loadHostToken("bkt", "api.bitbucket.org", host)
+	if err == nil {
+		t.Fatal("expected error for OAuth host without BKT_USERNAME")
+	}
+	if !strings.Contains(err.Error(), "BKT_USERNAME") {
+		t.Errorf("error = %v, want BKT_USERNAME mention", err)
+	}
+}
+
+// setupFileKeyring configures env vars for a file-backed keyring in a temp dir
+// and returns the opened store.
+func setupFileKeyring(t *testing.T) *secret.Store {
+	t.Helper()
+	fileDir := t.TempDir()
+	t.Setenv("BKT_ALLOW_INSECURE_STORE", "1")
+	t.Setenv("BKT_KEYRING_PASSPHRASE", "test-pass")
+	t.Setenv("KEYRING_BACKEND", "file")
+	t.Setenv("KEYRING_FILE_DIR", fileDir)
+	t.Setenv(secret.EnvToken, "")
+
+	store, err := secret.Open(
+		secret.WithAllowFileFallback(true),
+		secret.WithPassphrase("test-pass"),
+		secret.WithFileDir(fileDir),
+	)
+	if err != nil {
+		t.Fatalf("open file keyring: %v", err)
+	}
+	return store
+}
+
+func TestLoadHostTokenDetectsOAuthBlobFromKeyring(t *testing.T) {
+	store := setupFileKeyring(t)
+
+	blob := `{"access_token":"at-from-keyring","refresh_token":"rt-456","expires_at":"2099-01-01T00:00:00Z"}`
+	if err := store.Set(secret.TokenKey("api.bitbucket.org"), blob); err != nil {
+		t.Fatalf("store.Set: %v", err)
+	}
+
+	host := &config.Host{
+		Kind:               "cloud",
+		BaseURL:            "https://api.bitbucket.org/2.0",
+		AllowInsecureStore: true,
+	}
+
+	if err := loadHostToken("bkt", "api.bitbucket.org", host); err != nil {
+		t.Fatalf("loadHostToken: %v", err)
+	}
+	if host.Token != "at-from-keyring" {
+		t.Errorf("Token = %q, want at-from-keyring", host.Token)
+	}
+	if host.AuthMethod != "oauth" {
+		t.Errorf("AuthMethod = %q, want oauth", host.AuthMethod)
+	}
+}
+
+func TestLoadHostTokenPreservesExistingAuthMethodOnBlob(t *testing.T) {
+	store := setupFileKeyring(t)
+
+	blob := `{"access_token":"at-123","refresh_token":"rt-456","expires_at":"2099-01-01T00:00:00Z"}`
+	if err := store.Set(secret.TokenKey("api.bitbucket.org"), blob); err != nil {
+		t.Fatalf("store.Set: %v", err)
+	}
+
+	host := &config.Host{
+		Kind:               "cloud",
+		BaseURL:            "https://api.bitbucket.org/2.0",
+		AuthMethod:         "oauth",
+		AllowInsecureStore: true,
+	}
+
+	if err := loadHostToken("bkt", "api.bitbucket.org", host); err != nil {
+		t.Fatalf("loadHostToken: %v", err)
+	}
+	if host.AuthMethod != "oauth" {
+		t.Errorf("AuthMethod = %q, want oauth (preserved)", host.AuthMethod)
+	}
+}
+
+func TestLoadHostTokenInvalidBlobFromKeyring(t *testing.T) {
+	store := setupFileKeyring(t)
+
+	if err := store.Set(secret.TokenKey("api.bitbucket.org"), "{invalid-json"); err != nil {
+		t.Fatalf("store.Set: %v", err)
+	}
+
+	host := &config.Host{
+		Kind:               "cloud",
+		BaseURL:            "https://api.bitbucket.org/2.0",
+		AllowInsecureStore: true,
+	}
+
+	err := loadHostToken("bkt", "api.bitbucket.org", host)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON blob")
+	}
+	if !strings.Contains(err.Error(), "parse OAuth token") {
+		t.Errorf("error = %q, want 'parse OAuth token'", err)
+	}
+}
+
+func TestLoadHostTokenPlainStringFromKeyring(t *testing.T) {
+	store := setupFileKeyring(t)
+
+	if err := store.Set(secret.TokenKey("bitbucket.example.com"), "plain-pat-token"); err != nil {
+		t.Fatalf("store.Set: %v", err)
+	}
+
+	host := &config.Host{
+		Kind:               "dc",
+		BaseURL:            "https://bitbucket.example.com",
+		AllowInsecureStore: true,
+	}
+
+	if err := loadHostToken("bkt", "bitbucket.example.com", host); err != nil {
+		t.Fatalf("loadHostToken: %v", err)
+	}
+	if host.Token != "plain-pat-token" {
+		t.Errorf("Token = %q, want plain-pat-token", host.Token)
+	}
+	if host.AuthMethod != "" {
+		t.Errorf("AuthMethod = %q, want empty", host.AuthMethod)
+	}
+}
+
+func TestLoadHostTokenKeyNotFoundError(t *testing.T) {
+	_ = setupFileKeyring(t)
+
+	host := &config.Host{
+		Kind:               "dc",
+		BaseURL:            "https://bitbucket.example.com",
+		AllowInsecureStore: true,
+	}
+
+	err := loadHostToken("bkt", "bitbucket.example.com", host)
+	if err == nil {
+		t.Fatal("expected error for missing key")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error = %q, want 'not found'", err)
+	}
+}
+
 func TestResolveHostMultipleHostsErrorWhenNoEnvHost(t *testing.T) {
 	t.Setenv(secret.EnvToken, "")
 	t.Setenv(secret.EnvHost, "")

--- a/pkg/oauth/cloud.go
+++ b/pkg/oauth/cloud.go
@@ -1,27 +1,45 @@
 package oauth
 
+import "os"
+
 // Cloud OAuth 2.0 configuration for Bitbucket Cloud.
 //
 // Bitbucket Cloud does not support PKCE for OAuth consumers, so the
-// client_secret is embedded in the binary. This is the same trade-off made
-// by tools like gh (GitHub CLI). The OAuth consumer must be registered in a
-// bkt-owned Bitbucket Cloud workspace with the scopes listed in CloudScopes.
+// client_secret is embedded in the binary at build time via ldflags.
+// This is the same trade-off made by tools like gh (GitHub CLI).
 const (
 	// CloudAuthorizeURL is the Bitbucket Cloud authorization endpoint.
 	CloudAuthorizeURL = "https://bitbucket.org/site/oauth2/authorize"
 
 	// CloudTokenURL is the Bitbucket Cloud token exchange endpoint.
 	CloudTokenURL = "https://bitbucket.org/site/oauth2/access_token"
-
-	// CloudClientID is the OAuth consumer key registered in the bkt workspace.
-	// Replace with the actual client_id after registering the OAuth consumer.
-	CloudClientID = "REPLACE_WITH_CLIENT_ID" // gitleaks:allow
-
-	// CloudClientSecret is the OAuth consumer secret. Bitbucket Cloud does not
-	// support PKCE so this ships in the binary (same trade-off as gh).
-	// Replace with the actual client_secret after registering the OAuth consumer.
-	CloudClientSecret = "REPLACE_WITH_CLIENT_SECRET" // gitleaks:allow
 )
+
+// CloudClientID and CloudClientSecret are injected at build time via ldflags.
+// For source installs (go install) that lack ldflags, they fall back to the
+// BKT_OAUTH_CLIENT_ID / BKT_OAUTH_CLIENT_SECRET environment variables.
+var (
+	cloudClientID     string // set via -ldflags -X
+	cloudClientSecret string // set via -ldflags -X
+)
+
+// CloudClientID returns the OAuth consumer key.
+// Prefers the build-time value; falls back to BKT_OAUTH_CLIENT_ID env var.
+func CloudClientID() string {
+	if cloudClientID != "" {
+		return cloudClientID
+	}
+	return os.Getenv("BKT_OAUTH_CLIENT_ID")
+}
+
+// CloudClientSecret returns the OAuth consumer secret.
+// Prefers the build-time value; falls back to BKT_OAUTH_CLIENT_SECRET env var.
+func CloudClientSecret() string {
+	if cloudClientSecret != "" {
+		return cloudClientSecret
+	}
+	return os.Getenv("BKT_OAUTH_CLIENT_SECRET")
+}
 
 // CloudScopes returns the OAuth scopes requested during authorization.
 // Scopes cover the full Cloud command set: repos, PRs, issues, pipelines,

--- a/pkg/oauth/cloud_test.go
+++ b/pkg/oauth/cloud_test.go
@@ -1,0 +1,82 @@
+package oauth
+
+import (
+	"testing"
+)
+
+func TestCloudClientIDFromLdflags(t *testing.T) {
+	orig := cloudClientID
+	defer func() { cloudClientID = orig }()
+
+	cloudClientID = "build-id"                // gitleaks:allow
+	t.Setenv("BKT_OAUTH_CLIENT_ID", "env-id") // gitleaks:allow
+
+	if got := CloudClientID(); got != "build-id" {
+		t.Errorf("CloudClientID() = %q, want build-time value %q", got, "build-id")
+	}
+}
+
+func TestCloudClientIDFromEnv(t *testing.T) {
+	orig := cloudClientID
+	defer func() { cloudClientID = orig }()
+
+	cloudClientID = ""                        // gitleaks:allow
+	t.Setenv("BKT_OAUTH_CLIENT_ID", "env-id") // gitleaks:allow
+
+	if got := CloudClientID(); got != "env-id" {
+		t.Errorf("CloudClientID() = %q, want env fallback %q", got, "env-id")
+	}
+}
+
+func TestCloudClientIDEmpty(t *testing.T) {
+	orig := cloudClientID
+	defer func() { cloudClientID = orig }()
+
+	cloudClientID = ""                  // gitleaks:allow
+	t.Setenv("BKT_OAUTH_CLIENT_ID", "") // gitleaks:allow
+
+	if got := CloudClientID(); got != "" {
+		t.Errorf("CloudClientID() = %q, want empty", got)
+	}
+}
+
+func TestCloudClientSecretFromLdflags(t *testing.T) {
+	orig := cloudClientSecret
+	defer func() { cloudClientSecret = orig }()
+
+	cloudClientSecret = "build-secret"                // gitleaks:allow
+	t.Setenv("BKT_OAUTH_CLIENT_SECRET", "env-secret") // gitleaks:allow
+
+	if got := CloudClientSecret(); got != "build-secret" {
+		t.Errorf("CloudClientSecret() = %q, want build-time value %q", got, "build-secret")
+	}
+}
+
+func TestCloudClientSecretFromEnv(t *testing.T) {
+	orig := cloudClientSecret
+	defer func() { cloudClientSecret = orig }()
+
+	cloudClientSecret = ""                            // gitleaks:allow
+	t.Setenv("BKT_OAUTH_CLIENT_SECRET", "env-secret") // gitleaks:allow
+
+	if got := CloudClientSecret(); got != "env-secret" {
+		t.Errorf("CloudClientSecret() = %q, want env fallback %q", got, "env-secret")
+	}
+}
+
+func TestCloudScopes(t *testing.T) {
+	scopes := CloudScopes()
+	if len(scopes) == 0 {
+		t.Fatal("CloudScopes() returned empty")
+	}
+	want := map[string]bool{"account": true, "repository": true, "pullrequest": true, "issue": true, "pipeline": true, "webhook": true}
+	for _, s := range scopes {
+		if !want[s] {
+			t.Errorf("unexpected scope %q", s)
+		}
+		delete(want, s)
+	}
+	for s := range want {
+		t.Errorf("missing scope %q", s)
+	}
+}

--- a/pkg/oauth/flow.go
+++ b/pkg/oauth/flow.go
@@ -1,0 +1,239 @@
+package oauth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+)
+
+// FlowOptions configures the OAuth authorization code flow.
+type FlowOptions struct {
+	// ClientID is the OAuth consumer key.
+	ClientID string
+	// ClientSecret is the OAuth consumer secret.
+	ClientSecret string
+	// AuthorizeURL is the authorization endpoint.
+	AuthorizeURL string
+	// TokenURL is the token exchange endpoint.
+	TokenURL string
+	// UserInfoURL is the endpoint used to fetch the authenticated username.
+	// Defaults to https://api.bitbucket.org/2.0/user when empty.
+	UserInfoURL string
+	// Scopes to request.
+	Scopes []string
+	// Out is the writer for user-facing messages. Defaults to os.Stdout.
+	Out io.Writer
+	// OpenBrowser opens the given URL in the user's browser.
+	// When nil the URL is printed but not opened.
+	OpenBrowser func(string) error
+}
+
+// FlowResult contains the outcome of a successful OAuth flow.
+type FlowResult struct {
+	Token       *Token
+	Username    string
+	DisplayName string
+}
+
+// RunFlow executes the full OAuth authorization code flow:
+//  1. Start localhost callback server
+//  2. Build authorize URL with state
+//  3. Open browser (or print URL)
+//  4. Wait for callback with auth code
+//  5. Exchange code for tokens
+//  6. Fetch authenticated username via /2.0/user
+func RunFlow(ctx context.Context, opts FlowOptions) (*FlowResult, error) {
+	out := opts.Out
+	if out == nil {
+		out = os.Stdout
+	}
+
+	srv, err := NewCallbackServer()
+	if err != nil {
+		return nil, err
+	}
+	defer srv.Close()
+
+	state, err := randomState()
+	if err != nil {
+		return nil, fmt.Errorf("generate state: %w", err)
+	}
+
+	authURL := buildAuthorizeURL(opts, srv.RedirectURI(), state)
+
+	if opts.OpenBrowser != nil {
+		if err := opts.OpenBrowser(authURL); err != nil {
+			fmt.Fprintf(out, "Failed to open browser: %v\n", err)
+			fmt.Fprintf(out, "Open this URL manually:\n  %s\n", authURL)
+		}
+	} else {
+		fmt.Fprintf(out, "Open this URL in your browser:\n  %s\n", authURL)
+	}
+
+	code, callbackState, err := srv.Wait(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("authorization: %w", err)
+	}
+
+	if callbackState != state {
+		return nil, fmt.Errorf("state mismatch: possible CSRF attack")
+	}
+
+	tok, err := exchangeCode(ctx, opts, code, srv.RedirectURI())
+	if err != nil {
+		return nil, err
+	}
+
+	userInfoURL := opts.UserInfoURL
+	if userInfoURL == "" {
+		userInfoURL = "https://api.bitbucket.org/2.0/user"
+	}
+	username, displayName, err := fetchUsername(ctx, tok.AccessToken, userInfoURL)
+	if err != nil {
+		return nil, fmt.Errorf("verify token: %w", err)
+	}
+
+	return &FlowResult{Token: tok, Username: username, DisplayName: displayName}, nil
+}
+
+// RefreshToken exchanges a refresh token for a new access token.
+func RefreshToken(ctx context.Context, refreshToken, clientID, clientSecret, tokenURL string) (*Token, error) {
+	data := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refreshToken},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", tokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("build refresh request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(clientID, clientSecret)
+
+	return doTokenRequest(req)
+}
+
+func buildAuthorizeURL(opts FlowOptions, redirectURI, state string) string {
+	v := url.Values{
+		"client_id":     {opts.ClientID},
+		"response_type": {"code"},
+		"redirect_uri":  {redirectURI},
+		"state":         {state},
+	}
+	if len(opts.Scopes) > 0 {
+		v.Set("scope", strings.Join(opts.Scopes, " "))
+	}
+	return opts.AuthorizeURL + "?" + v.Encode()
+}
+
+func exchangeCode(ctx context.Context, opts FlowOptions, code, redirectURI string) (*Token, error) {
+	// Bitbucket requires redirect_uri at both authorize and token exchange
+	// when it was included at authorize. Must be the exact same value.
+	data := url.Values{
+		"grant_type":   {"authorization_code"},
+		"code":         {code},
+		"redirect_uri": {redirectURI},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", opts.TokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(opts.ClientID, opts.ClientSecret)
+
+	return doTokenRequest(req)
+}
+
+func doTokenRequest(req *http.Request) (*Token, error) {
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("token request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp struct {
+			Error       string `json:"error"`
+			Description string `json:"error_description"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&errResp)
+		msg := errResp.Description
+		if msg == "" {
+			msg = errResp.Error
+		}
+		if msg == "" {
+			msg = resp.Status
+		}
+		return nil, fmt.Errorf("token exchange: %s", msg)
+	}
+
+	var tokenResp struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int    `json:"expires_in"`
+		TokenType    string `json:"token_type"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return nil, fmt.Errorf("decode token response: %w", err)
+	}
+
+	if tokenResp.AccessToken == "" {
+		return nil, fmt.Errorf("token exchange: empty access_token in response")
+	}
+
+	return FromResponse(tokenResp.AccessToken, tokenResp.RefreshToken, tokenResp.ExpiresIn), nil
+}
+
+// fetchUsername returns (username, displayName, error). Username is the
+// API-safe identifier (username or account_id); displayName is for UX only.
+func fetchUsername(ctx context.Context, accessToken, userInfoURL string) (string, string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", userInfoURL, nil)
+	if err != nil {
+		return "", "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("GET %s: %s", userInfoURL, resp.Status)
+	}
+
+	var user struct {
+		Username    string `json:"username"`
+		AccountID   string `json:"account_id"`
+		DisplayName string `json:"display_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
+		return "", "", fmt.Errorf("decode user: %w", err)
+	}
+
+	username := user.Username
+	if username == "" {
+		username = user.AccountID
+	}
+	if username == "" {
+		return "", "", fmt.Errorf("user response missing both username and account_id")
+	}
+	return username, user.DisplayName, nil
+}
+
+func randomState() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/pkg/oauth/flow_test.go
+++ b/pkg/oauth/flow_test.go
@@ -1,0 +1,473 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildAuthorizeURL(t *testing.T) {
+	opts := FlowOptions{
+		ClientID:     "test-id",
+		AuthorizeURL: "https://bitbucket.org/site/oauth2/authorize",
+		Scopes:       []string{"account", "repository"},
+	}
+	got := buildAuthorizeURL(opts, "http://127.0.0.1:12345/callback", "test-state")
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("parse URL: %v", err)
+	}
+	if u.Host != "bitbucket.org" {
+		t.Errorf("host = %q, want bitbucket.org", u.Host)
+	}
+	q := u.Query()
+	if q.Get("client_id") != "test-id" {
+		t.Errorf("client_id = %q", q.Get("client_id"))
+	}
+	if q.Get("response_type") != "code" {
+		t.Errorf("response_type = %q", q.Get("response_type"))
+	}
+	if q.Get("redirect_uri") != "http://127.0.0.1:12345/callback" {
+		t.Errorf("redirect_uri = %q", q.Get("redirect_uri"))
+	}
+	if q.Get("state") != "test-state" {
+		t.Errorf("state = %q", q.Get("state"))
+	}
+	if q.Get("scope") != "account repository" {
+		t.Errorf("scope = %q", q.Get("scope"))
+	}
+}
+
+func TestExchangeCode(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		if r.Form.Get("grant_type") != "authorization_code" {
+			t.Errorf("grant_type = %q", r.Form.Get("grant_type"))
+		}
+		if r.Form.Get("code") != "test-code" {
+			t.Errorf("code = %q", r.Form.Get("code"))
+		}
+		// redirect_uri must be present and match what was sent at authorize.
+		if r.Form.Get("redirect_uri") == "" {
+			t.Error("redirect_uri must be sent at token exchange")
+		}
+		// Verify Basic auth.
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "cid" || pass != "csecret" {
+			t.Errorf("basic auth = (%q, %q, %v)", user, pass, ok)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "at-123",
+			"refresh_token": "rt-456",
+			"expires_in":    7200,
+			"token_type":    "bearer",
+			"scopes":        "account repository",
+		})
+	}))
+	defer tokenSrv.Close()
+
+	opts := FlowOptions{
+		ClientID:     "cid",
+		ClientSecret: "csecret",
+		TokenURL:     tokenSrv.URL,
+	}
+	tok, err := exchangeCode(context.Background(), opts, "test-code", "http://127.0.0.1:12345/callback")
+	if err != nil {
+		t.Fatalf("exchangeCode: %v", err)
+	}
+	if tok.AccessToken != "at-123" {
+		t.Errorf("access_token = %q", tok.AccessToken)
+	}
+	if tok.RefreshToken != "rt-456" {
+		t.Errorf("refresh_token = %q", tok.RefreshToken)
+	}
+	if tok.IsExpired() {
+		t.Error("token should not be expired")
+	}
+}
+
+func TestExchangeCodeError(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":             "invalid_grant",
+			"error_description": "code already used",
+		})
+	}))
+	defer tokenSrv.Close()
+
+	opts := FlowOptions{
+		ClientID:     "cid",
+		ClientSecret: "csecret",
+		TokenURL:     tokenSrv.URL,
+	}
+	_, err := exchangeCode(context.Background(), opts, "used-code", "http://127.0.0.1:12345/callback")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "code already used") {
+		t.Errorf("error = %q, want to contain 'code already used'", err)
+	}
+}
+
+func TestRefreshToken(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		if r.Form.Get("grant_type") != "refresh_token" {
+			t.Errorf("grant_type = %q", r.Form.Get("grant_type"))
+		}
+		if r.Form.Get("refresh_token") != "rt-old" {
+			t.Errorf("refresh_token = %q", r.Form.Get("refresh_token"))
+		}
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "cid" || pass != "csecret" {
+			t.Errorf("basic auth = (%q, %q, %v)", user, pass, ok)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "at-new",
+			"refresh_token": "rt-new",
+			"expires_in":    7200,
+		})
+	}))
+	defer tokenSrv.Close()
+
+	tok, err := RefreshToken(context.Background(), "rt-old", "cid", "csecret", tokenSrv.URL)
+	if err != nil {
+		t.Fatalf("RefreshToken: %v", err)
+	}
+	if tok.AccessToken != "at-new" {
+		t.Errorf("access_token = %q", tok.AccessToken)
+	}
+	if tok.RefreshToken != "rt-new" {
+		t.Errorf("refresh_token = %q", tok.RefreshToken)
+	}
+}
+
+func TestRunFlowStateMismatch(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("token endpoint should not be called on state mismatch")
+	}))
+	defer tokenSrv.Close()
+
+	opts := FlowOptions{
+		ClientID:     "cid",
+		ClientSecret: "csecret",
+		AuthorizeURL: "https://bitbucket.org/site/oauth2/authorize",
+		TokenURL:     tokenSrv.URL,
+		OpenBrowser: func(authURL string) error {
+			// Parse the state from the authorize URL.
+			u, _ := url.Parse(authURL)
+			// Simulate callback with wrong state.
+			callbackURL := u.Query().Get("redirect_uri") + "?code=test-code&state=wrong-state"
+			resp, err := http.Get(callbackURL)
+			if err != nil {
+				return err
+			}
+			_ = resp.Body.Close()
+			return nil
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := RunFlow(ctx, opts)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "state mismatch") {
+		t.Errorf("error = %q, want state mismatch", err)
+	}
+}
+
+func TestRunFlowSuccess(t *testing.T) {
+	// Mock token endpoint.
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "at-flow",
+			"refresh_token": "rt-flow",
+			"expires_in":    7200,
+		})
+	}))
+	defer tokenSrv.Close()
+
+	// Mock user endpoint.
+	userSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer at-flow" {
+			t.Errorf("Authorization = %q, want Bearer at-flow", auth)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"username":     "testuser",
+			"display_name": "Test User",
+		})
+	}))
+	defer userSrv.Close()
+
+	var buf strings.Builder
+	opts := FlowOptions{
+		ClientID:     "cid",
+		ClientSecret: "csecret",
+		AuthorizeURL: "https://bitbucket.org/site/oauth2/authorize",
+		TokenURL:     tokenSrv.URL,
+		UserInfoURL:  userSrv.URL,
+		Out:          &buf,
+		OpenBrowser: func(authURL string) error {
+			u, _ := url.Parse(authURL)
+			state := u.Query().Get("state")
+			redirectURI := u.Query().Get("redirect_uri")
+			callbackURL := fmt.Sprintf("%s?code=auth-code&state=%s", redirectURI, state)
+			resp, err := http.Get(callbackURL)
+			if err != nil {
+				return err
+			}
+			_ = resp.Body.Close()
+			return nil
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := RunFlow(ctx, opts)
+	if err != nil {
+		t.Fatalf("RunFlow: %v", err)
+	}
+	if result.Token.AccessToken != "at-flow" {
+		t.Errorf("access_token = %q", result.Token.AccessToken)
+	}
+	if result.Username != "testuser" {
+		t.Errorf("username = %q", result.Username)
+	}
+	if result.DisplayName != "Test User" {
+		t.Errorf("display_name = %q, want %q", result.DisplayName, "Test User")
+	}
+}
+
+func TestFetchUsernameSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"username":     "erank",
+			"account_id":   "123:abc",
+			"display_name": "Eran K",
+		})
+	}))
+	defer srv.Close()
+
+	username, display, err := fetchUsername(context.Background(), "tok", srv.URL)
+	if err != nil {
+		t.Fatalf("fetchUsername: %v", err)
+	}
+	if username != "erank" {
+		t.Errorf("username = %q, want erank", username)
+	}
+	if display != "Eran K" {
+		t.Errorf("display = %q, want Eran K", display)
+	}
+}
+
+func TestFetchUsernameFallsBackToAccountID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"account_id":   "123:abc",
+			"display_name": "Eran K",
+		})
+	}))
+	defer srv.Close()
+
+	username, _, err := fetchUsername(context.Background(), "tok", srv.URL)
+	if err != nil {
+		t.Fatalf("fetchUsername: %v", err)
+	}
+	if username != "123:abc" {
+		t.Errorf("username = %q, want 123:abc", username)
+	}
+}
+
+func TestFetchUsernameMissingBothFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"display_name": "Eran K",
+		})
+	}))
+	defer srv.Close()
+
+	_, _, err := fetchUsername(context.Background(), "tok", srv.URL)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "missing both username and account_id") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+func TestFetchUsernameNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	_, _, err := fetchUsername(context.Background(), "tok", srv.URL)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("error = %q, want 403", err)
+	}
+}
+
+func TestDoTokenRequestEmptyAccessToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"refresh_token": "rt",
+			"expires_in":    7200,
+		})
+	}))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("POST", srv.URL, nil)
+	_, err := doTokenRequest(req)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "empty access_token") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+func TestDoTokenRequestErrorNoDescription(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error": "invalid_grant",
+		})
+	}))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("POST", srv.URL, nil)
+	_, err := doTokenRequest(req)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "invalid_grant") {
+		t.Errorf("error = %q, want invalid_grant", err)
+	}
+}
+
+func TestDoTokenRequestErrorPlainStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("POST", srv.URL, nil)
+	_, err := doTokenRequest(req)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error = %q, want 500", err)
+	}
+}
+
+func TestRunFlowNoBrowserPrintsURL(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "at-nobrowser",
+			"refresh_token": "rt-nobrowser",
+			"expires_in":    7200,
+		})
+	}))
+	defer tokenSrv.Close()
+
+	userSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"username": "testuser",
+		})
+	}))
+	defer userSrv.Close()
+
+	var buf strings.Builder
+	// OpenBrowser is nil → should print URL to Out.
+	// But we need to simulate the callback, so we use OpenBrowser to do it.
+	// Instead, test the browser-failure fallback path.
+	opts := FlowOptions{
+		ClientID:     "cid",
+		ClientSecret: "csecret",
+		AuthorizeURL: "https://bitbucket.org/site/oauth2/authorize",
+		TokenURL:     tokenSrv.URL,
+		UserInfoURL:  userSrv.URL,
+		Out:          &buf,
+		OpenBrowser: func(authURL string) error {
+			// Simulate browser failure → fallback prints URL.
+			u, _ := url.Parse(authURL)
+			state := u.Query().Get("state")
+			redirectURI := u.Query().Get("redirect_uri")
+			// Still send the callback so the flow completes.
+			callbackURL := fmt.Sprintf("%s?code=code&state=%s", redirectURI, state)
+			resp, err := http.Get(callbackURL) //nolint:gosec
+			if err != nil {
+				return err
+			}
+			_ = resp.Body.Close()
+			return fmt.Errorf("browser unavailable")
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := RunFlow(ctx, opts)
+	if err != nil {
+		t.Fatalf("RunFlow: %v", err)
+	}
+	if result.Token.AccessToken != "at-nobrowser" {
+		t.Errorf("access_token = %q", result.Token.AccessToken)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "Failed to open browser") {
+		t.Errorf("output missing browser failure message: %q", output)
+	}
+	if !strings.Contains(output, "Open this URL manually") {
+		t.Errorf("output missing manual URL fallback: %q", output)
+	}
+}
+
+func TestRandomState(t *testing.T) {
+	s1, err := randomState()
+	if err != nil {
+		t.Fatalf("randomState: %v", err)
+	}
+	s2, _ := randomState()
+	if s1 == s2 {
+		t.Error("two calls returned same state")
+	}
+	if len(s1) != 32 {
+		t.Errorf("state length = %d, want 32", len(s1))
+	}
+}

--- a/skills/bkt/SKILL.md
+++ b/skills/bkt/SKILL.md
@@ -48,11 +48,14 @@ If not authenticated, log in:
 # Data Center (PAT-based)
 bkt auth login https://bitbucket.example.com --username alice --token <PAT>
 
-# Bitbucket Cloud (API token; --web opens Atlassian's token creation page)
+# Bitbucket Cloud — OAuth (recommended; opens browser)
 bkt auth login https://bitbucket.org --kind cloud --web
+
+# Bitbucket Cloud — API token (--web-token opens Atlassian's token creation page)
+bkt auth login https://bitbucket.org --kind cloud --web-token
 ```
 
-**Cloud token requirements:** Create an "API token with scopes" (not a general API token). Select **Bitbucket** as the application. Required: **Account: Read** (`read:user:bitbucket`). Add repository, PR, and issue scopes as needed.
+For `go install` builds, set `BKT_OAUTH_CLIENT_ID` and `BKT_OAUTH_CLIENT_SECRET` env vars before running `--web`.
 
 **3. Set up a context** — contexts bind a host to a project/workspace and optional default repo, so you don't repeat flags on every command:
 

--- a/skills/bkt/rules/auth.md
+++ b/skills/bkt/rules/auth.md
@@ -30,12 +30,16 @@ credentials in the OS keychain.
 
 For Data Center (--kind dc, the default), you authenticate with a Personal
 Access Token (PAT). The token needs Repository Read/Write and Project Read
-permissions. Use --web to open the PAT management page in your browser.
+permissions. Use --web-token to open the PAT management page in your browser.
 
-For Bitbucket Cloud (--kind cloud), you authenticate with an Atlassian API
-token. The token must be created with Bitbucket scopes (Account Read,
-Repositories Read/Write, Pull Requests Read/Write). Use --web to open the
-Atlassian token management page.
+For Bitbucket Cloud (--kind cloud), the recommended method is --web, which
+uses OAuth 2.0 to authenticate in the browser. The CLI receives a short-lived
+access token that is automatically refreshed. Alternatively, use --web-token
+to create an Atlassian API token manually.
+
+OAuth credentials are embedded at build time via ldflags. For source installs
+(go install), set BKT_OAUTH_CLIENT_ID and BKT_OAUTH_CLIENT_SECRET environment
+variables before running --web.
 
 Credentials are verified against the remote host before being stored. If no
 OS keychain is available, pass --allow-insecure-store to use encrypted file
@@ -58,7 +62,8 @@ bkt auth login [host] [flags]
 | `--kind` |  | Bitbucket deployment kind (dc or cloud) |
 | `--token` |  | Authentication token (DC: PAT, Cloud: API token). WARNING: visible in process list and shell history; prefer the interactive prompt |
 | `--username` |  | Username (DC: PAT owner, Cloud: Atlassian email for API tokens) |
-| `--web` | `-w` | Open browser to create token, then prompt for credentials |
+| `--web` | `-w` | Authenticate via OAuth in the browser (Cloud only) |
+| `--web-token` |  | Open browser to create an API token, then prompt for credentials |
 
 ### Inherited Flags
 
@@ -73,14 +78,17 @@ bkt auth login [host] [flags]
 ### Examples
 
 ```bash
-# Interactive login to a Data Center instance
+# Login to Bitbucket Cloud via OAuth (recommended)
+  bkt auth login https://bitbucket.org --kind cloud --web
+
+  # Login to Bitbucket Cloud with an API token
+  bkt auth login https://bitbucket.org --kind cloud --web-token
+
+  # Interactive login to a Data Center instance
   bkt auth login https://bitbucket.example.com
 
-  # Login to Bitbucket Cloud interactively
-  bkt auth login https://bitbucket.org --kind cloud
-
   # Open browser to create a PAT, then prompt for credentials
-  bkt auth login https://bitbucket.example.com --web
+  bkt auth login https://bitbucket.example.com --web-token
 
   # Non-interactive login with flags (CI pipelines)
   bkt auth login https://bitbucket.example.com --username admin --token "$PAT"
@@ -170,4 +178,3 @@ bkt auth status [flags]
   # Get status as JSON
   bkt auth status --output json
 ```
-

--- a/skills/bkt/rules/headless.md
+++ b/skills/bkt/rules/headless.md
@@ -45,6 +45,8 @@ bkt pr list
 | `BKT_CONFIG_DIR` | Config directory override. |
 | `BKT_ALLOW_INSECURE_STORE` | Allow file-based credential storage. |
 | `BKT_KEYRING_TIMEOUT` | Keyring operation timeout (e.g. `2m`). |
+| `BKT_OAUTH_CLIENT_ID` | OAuth consumer key. Used at runtime when not embedded via ldflags (e.g. `go install` builds). |
+| `BKT_OAUTH_CLIENT_SECRET` | OAuth consumer secret. Same fallback logic as `BKT_OAUTH_CLIENT_ID`. |
 
 ## Saved-host behaviour
 


### PR DESCRIPTION
## Summary
Adds browser-based OAuth 2.0 login for Bitbucket Cloud via `bkt auth login --web`.
Short-lived access tokens are stored as JSON blobs in the keyring and transparently
refreshed on 401. The existing API-token flow is preserved under `--web-token`.

Closes #136 (Phase 2).

## Changes

**OAuth flow (`pkg/oauth/flow.go`)**
- Full authorization code flow: localhost callback server → browser → code exchange → `/2.0/user` verification
- `RefreshToken()` for transparent 401-triggered refresh
- Output routed through `io.Writer` (not stdout) for testability
- User identity: prefers `username` > `account_id`, never stores `display_name` as the API username

**Auth command (`pkg/cmd/auth/auth.go`)**
- `--web` on Cloud runs OAuth flow; `--web` on DC errors with guidance to use `--web-token`
- `--web-token` replaces old `--web` behavior (opens token management page)
- `--web` and `--web-token` are mutually exclusive
- `auth status` shows OAuth token expiry (hidden when `BKT_TOKEN` overrides)
- Guard: `--web` fails fast if OAuth client credentials are missing from the build

**Token refresh wiring (`pkg/cmdutil/client.go`)**
- `NewCloudClient` wires `TokenRefresher` for OAuth hosts using keyring tokens
- Bearer auth + refresher only when using keyring; `BKT_TOKEN` overrides default to basic
- Missing client credentials checked at refresh time, not construction — local builds work until token expires

**Token detection (`pkg/cmdutil/context.go`)**
- `loadHostToken` detects JSON blob in keyring → extracts `access_token`, sets `auth_method=oauth`
- `BKT_TOKEN` path now applies `BKT_USERNAME` and `BKT_AUTH_METHOD` overrides (fixes OAuth host + env token)
- Requires `BKT_USERNAME` when overriding an OAuth Cloud host (prevents silent 401 from wrong username)

**Credentials injection (`pkg/oauth/cloud.go`, `Makefile`, `.goreleaser.yaml`, `release.yml`)**
- OAuth `client_id`/`client_secret` injected at build time via `-ldflags -X`
- Runtime fallback to `BKT_OAUTH_CLIENT_ID`/`BKT_OAUTH_CLIENT_SECRET` env vars for `go install` builds
- Release workflow validates secrets are non-empty before goreleaser publishes

**Cloud client (`pkg/bbcloud/client.go`)**
- Added `AuthMethod` and `TokenRefresher` to `Options`
- Auth method selection: explicit > refresher-implied-bearer > default-basic

**Skill docs**
- Updated `SKILL.md`, `auth.md` (regenerated), `headless.md` with OAuth env vars and examples

## Testing
- `go test ./...` — 1013 tests pass
- Pre-commit hooks pass
- Manual end-to-end: `bkt auth login --web` → browser consent → token stored → `auth status` shows expiry
- Manual: `--web` without build creds → clear error; `--web` on DC → error with `--web-token` guidance
- New tests in `pkg/oauth/flow_test.go`: authorize URL, code exchange, refresh, state mismatch, full flow, error paths, randomState

## Risks
- `BKT_OAUTH_CLIENT_ID`/`BKT_OAUTH_CLIENT_SECRET` GitHub secrets must be added by repo admin before the next release (comment posted on #136)
- Repo admin should rotate the OAuth consumer credentials since the original values were exposed in issue comments