### PR TITLE
docs(changelog): capture unreleased v0.22.0 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented here. The format follows
 ## [Unreleased]
 
 ### Added
+- `bkt auth login --web` browser-based OAuth 2.0 login for Bitbucket Cloud, with keyring-stored short-lived access tokens and automatic refresh on expiry (#152).
+- `BKT_HOST` + `BKT_TOKEN` env-var-driven headless authentication for CI and containers, so commands can run without a prior `bkt auth login` or `bkt context create` (#138).
 - Pull request JSON output now includes creation and update timestamps for Cloud and Data Center listings.
 
 ### Changed


### PR DESCRIPTION
Adds the missing Unreleased notes needed before cutting v0.22.0.

This captures the three user-facing features merged since v0.21.0:
- #138 headless env-var auth
- #151 PR timestamps
- #152 Cloud OAuth login

This is a release-prep prerequisite only; the actual release PR will be created via scripts/release.sh after this lands.