### PR TITLE
chore(release): v0.22.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented here. The format follows
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-04-12
 ### Added
 - `bkt auth login --web` browser-based OAuth 2.0 login for Bitbucket Cloud, with keyring-stored short-lived access tokens and automatic refresh on expiry (#152).
 - `BKT_HOST` + `BKT_TOKEN` env-var-driven headless authentication for CI and containers, so commands can run without a prior `bkt auth login` or `bkt context create` (#138).
@@ -13,6 +14,7 @@ All notable changes to this project will be documented here. The format follows
 
 ### Changed
 - `bkt pr list` now appends a local creation timestamp column (`YYYY-MM-DD HH:MM`) to text output for Cloud and Data Center listings.
+
 
 ## [0.21.0] - 2026-04-10
 ### Added

--- a/skills/bkt/SKILL.md
+++ b/skills/bkt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bkt
-version: 0.21.0
+version: 0.22.0
 description: Bitbucket CLI for Data Center and Cloud. Use when users need to manage repositories, pull requests, branches, issues, webhooks, or pipelines in Bitbucket. Triggers include "bitbucket", "bkt", "pull request", "PR", "repo list", "branch create", "Bitbucket Data Center", "Bitbucket Cloud", "keyring timeout".
 metadata:
   short-description: Bitbucket CLI for repos, PRs, branches


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.22.0`
- aligns skill/plugin metadata to `0.22.0`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.22.0`, publishes the release, and publishes skills in the same workflow run