### PR TITLE
chore(release): v0.23.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented here. The format follows
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-04-12
 ### Added
 - `bkt pr edit --with-default-reviewers` now works on Bitbucket Cloud and Data Center, merging effective default reviewers with explicit reviewer edits while preserving mixed Cloud reviewer identities (#150).
 
@@ -14,6 +15,7 @@ All notable changes to this project will be documented here. The format follows
 
 ### Fixed
 - `bkt pr update` is now an alias for `bkt pr edit`, matching `gh`-style command expectations and `--help` output (#149).
+
 
 ## [0.22.0] - 2026-04-12
 ### Added

--- a/skills/bkt/SKILL.md
+++ b/skills/bkt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bkt
-version: 0.22.0
+version: 0.23.0
 description: Bitbucket CLI for Data Center and Cloud. Use when users need to manage repositories, pull requests, branches, issues, webhooks, or pipelines in Bitbucket. Triggers include "bitbucket", "bkt", "pull request", "PR", "repo list", "branch create", "Bitbucket Data Center", "Bitbucket Cloud", "keyring timeout".
 metadata:
   short-description: Bitbucket CLI for repos, PRs, branches


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.23.0`
- aligns skill/plugin metadata to `0.23.0`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.23.0`, publishes the release, and publishes skills in the same workflow run