### PR TITLE
test: remove test sleeps and retry backoff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,16 @@ repos:
       - id: gitleaks
         args: ['--config=.gitleaks.toml']
 
+  # Go linting - matches CI tool
+  - repo: local
+    hooks:
+      - id: golangci-lint
+        name: golangci-lint
+        entry: golangci-lint run --timeout 5m
+        language: system
+        pass_filenames: false
+        files: ^(.*\.go|go\.mod|go\.sum)$
+
   # Generated skill rules freshness check
   - repo: local
     hooks:

--- a/pkg/bbcloud/client.go
+++ b/pkg/bbcloud/client.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/avivsinai/bitbucket-cli/pkg/httpx"
 	"github.com/avivsinai/bitbucket-cli/pkg/types"
@@ -13,19 +14,21 @@ import (
 
 // Options configure the Bitbucket Cloud client.
 type Options struct {
-	BaseURL        string
-	Username       string
-	Token          string
-	Workspace      string
-	AuthMethod     string // "basic" (default) or "bearer"
-	EnableCache    bool
-	Retry          httpx.RetryPolicy
-	TokenRefresher func(ctx context.Context) (string, error)
+	BaseURL           string
+	Username          string
+	Token             string
+	Workspace         string
+	AuthMethod        string // "basic" (default) or "bearer"
+	EnableCache       bool
+	Retry             httpx.RetryPolicy
+	MergePollInterval time.Duration
+	TokenRefresher    func(ctx context.Context) (string, error)
 }
 
 // Client wraps Bitbucket Cloud REST endpoints.
 type Client struct {
-	http *httpx.Client
+	http              *httpx.Client
+	mergePollInterval time.Duration
 }
 
 // HTTP exposes the underlying HTTP client for advanced scenarios.
@@ -57,7 +60,15 @@ func New(opts Options) (*Client, error) {
 		return nil, err
 	}
 
-	return &Client{http: httpClient}, nil
+	mergePollInterval := opts.MergePollInterval
+	if mergePollInterval <= 0 {
+		mergePollInterval = 2 * time.Second
+	}
+
+	return &Client{
+		http:              httpClient,
+		mergePollInterval: mergePollInterval,
+	}, nil
 }
 
 // User represents a Bitbucket Cloud user profile.

--- a/pkg/bbcloud/pullrequests.go
+++ b/pkg/bbcloud/pullrequests.go
@@ -533,7 +533,7 @@ func (c *Client) pollMergeTask(ctx context.Context, workspace, repoSlug string, 
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("merge task timed out: %w", ctx.Err())
-		case <-time.After(2 * time.Second):
+		case <-time.After(c.mergePollInterval):
 		}
 
 		req, err := c.http.NewRequest(ctx, "GET", path, nil)

--- a/pkg/bbcloud/pullrequests_test.go
+++ b/pkg/bbcloud/pullrequests_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/avivsinai/bitbucket-cli/pkg/bbcloud"
 )
@@ -18,9 +19,10 @@ func newTestClient(t *testing.T, handler http.Handler) *bbcloud.Client {
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
 	client, err := bbcloud.New(bbcloud.Options{
-		BaseURL:  server.URL,
-		Username: "user",
-		Token:    "token",
+		BaseURL:           server.URL,
+		Username:          "user",
+		Token:             "token",
+		MergePollInterval: time.Millisecond,
 	})
 	if err != nil {
 		t.Fatalf("create client: %v", err)

--- a/pkg/cmd/auth/auth_test.go
+++ b/pkg/cmd/auth/auth_test.go
@@ -386,7 +386,7 @@ func TestRunLoginRejectsUnsupportedKind(t *testing.T) {
 }
 
 func TestRunStatusShowsOAuthMethod(t *testing.T) {
-	t.Setenv(secret.EnvToken, "")
+	t.Setenv(secret.EnvToken, "test-env-token")
 
 	cfg := &config.Config{
 		Hosts: map[string]*config.Host{

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -161,7 +161,7 @@ func runList(cmd *cobra.Command, f *cmdutil.Factory, opts *listOptions) error {
 			return fmt.Errorf("context must supply project; use --project if needed")
 		}
 
-		client, err := cmdutil.NewDCClient(host)
+		client, err := f.DCClient(host)
 		if err != nil {
 			return err
 		}
@@ -233,7 +233,7 @@ func runList(cmd *cobra.Command, f *cmdutil.Factory, opts *listOptions) error {
 			return fmt.Errorf("context must supply workspace; use --workspace if needed")
 		}
 
-		client, err := cmdutil.NewCloudClient(host)
+		client, err := f.CloudClient(host)
 		if err != nil {
 			return err
 		}
@@ -515,7 +515,7 @@ func runView(cmd *cobra.Command, f *cmdutil.Factory, opts *viewOptions) error {
 			return fmt.Errorf("context must supply project and repo; use --project/--repo if needed")
 		}
 
-		client, err := cmdutil.NewDCClient(host)
+		client, err := f.DCClient(host)
 		if err != nil {
 			return err
 		}
@@ -583,7 +583,7 @@ func runView(cmd *cobra.Command, f *cmdutil.Factory, opts *viewOptions) error {
 			return fmt.Errorf("context must supply workspace and repo; use --workspace/--repo if needed")
 		}
 
-		client, err := cmdutil.NewCloudClient(host)
+		client, err := f.CloudClient(host)
 		if err != nil {
 			return err
 		}
@@ -1540,7 +1540,7 @@ func runEdit(cmd *cobra.Command, f *cmdutil.Factory, opts *editOptions) error {
 			return fmt.Errorf("context must supply project and repo; use --project/--repo if needed")
 		}
 
-		client, err := cmdutil.NewDCClient(host)
+		client, err := f.DCClient(host)
 		if err != nil {
 			return err
 		}
@@ -1607,7 +1607,7 @@ func runEdit(cmd *cobra.Command, f *cmdutil.Factory, opts *editOptions) error {
 			return fmt.Errorf("context must supply workspace and repo; use --workspace/--repo if needed")
 		}
 
-		client, err := cmdutil.NewCloudClient(host)
+		client, err := f.CloudClient(host)
 		if err != nil {
 			return err
 		}
@@ -2881,6 +2881,7 @@ type checksOptions struct {
 	Interval    time.Duration
 	MaxInterval time.Duration
 	Timeout     time.Duration
+	waitForPoll func(context.Context, time.Duration) error
 }
 
 func newChecksCmd(f *cmdutil.Factory) *cobra.Command {
@@ -3009,7 +3010,7 @@ func runChecks(cmd *cobra.Command, f *cmdutil.Factory, opts *checksOptions) erro
 			return fmt.Errorf("context must supply project and repo; use --project/--repo if needed")
 		}
 
-		client, err := cmdutil.NewDCClient(host)
+		client, err := f.DCClient(host)
 		if err != nil {
 			return err
 		}
@@ -3056,7 +3057,7 @@ func runChecks(cmd *cobra.Command, f *cmdutil.Factory, opts *checksOptions) erro
 			return fmt.Errorf("context must supply workspace and repo; use --workspace/--repo if needed")
 		}
 
-		client, err := cmdutil.NewCloudClient(host)
+		client, err := f.CloudClient(host)
 		if err != nil {
 			return err
 		}
@@ -3215,12 +3216,10 @@ func pollUntilComplete(
 			_, _ = fmt.Fprintf(ios.ErrOut, "  ⚠ Error fetching status (attempt %d/%d): %v\n", consecutiveErrors, maxConsecutiveErrors, err)
 			// Use iteration + consecutiveErrors to back off faster on errors
 			errorBackoff := calculatePollInterval(opts.Interval, opts.MaxInterval, iteration+consecutiveErrors)
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case <-time.After(errorBackoff):
-				continue
+			if err := waitForPollInterval(ctx, opts, errorBackoff); err != nil {
+				return nil, err
 			}
+			continue
 		}
 		consecutiveErrors = 0 // Reset on success
 
@@ -3271,12 +3270,25 @@ func pollUntilComplete(
 
 		iteration++
 
-		select {
-		case <-ctx.Done():
-			return statuses, ctx.Err()
-		case <-time.After(nextInterval):
-			continue
+		if err := waitForPollInterval(ctx, opts, nextInterval); err != nil {
+			return statuses, err
 		}
+	}
+}
+
+func waitForPollInterval(ctx context.Context, opts *checksOptions, d time.Duration) error {
+	if opts.waitForPoll != nil {
+		return opts.waitForPoll(ctx, d)
+	}
+
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
 	}
 }
 

--- a/pkg/cmd/pr/pr_status_helpers_test.go
+++ b/pkg/cmd/pr/pr_status_helpers_test.go
@@ -1,0 +1,228 @@
+package pr
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/avivsinai/bitbucket-cli/pkg/cmdutil"
+	"github.com/avivsinai/bitbucket-cli/pkg/iostreams"
+	"github.com/avivsinai/bitbucket-cli/pkg/types"
+)
+
+func TestExecuteStatusCheckReturnsErrPendingOnTimeoutWithPendingBuilds(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	ios := &iostreams.IOStreams{Out: &stdout, ErrOut: &stderr}
+	cmd := newStatusCheckTestCommand()
+
+	err := executeStatusCheck(&checksResult{
+		ctx: context.Background(),
+		ios: ios,
+		cmd: cmd,
+		opts: &checksOptions{
+			ID:          42,
+			Wait:        true,
+			Interval:    time.Millisecond,
+			MaxInterval: time.Millisecond,
+			waitForPoll: func(context.Context, time.Duration) error { return context.DeadlineExceeded },
+		},
+		fetchFunc: func() ([]types.CommitStatus, error) {
+			return []types.CommitStatus{{State: "INPROGRESS", Name: "build"}}, nil
+		},
+		commitSHA: "abc123def456",
+		payload:   map[string]any{},
+	})
+	if !errors.Is(err, cmdutil.ErrPending) {
+		t.Fatalf("err = %v, want ErrPending", err)
+	}
+	if got := stderr.String(); got == "" || !bytes.Contains([]byte(got), []byte("Timeout waiting for builds to complete")) {
+		t.Fatalf("stderr = %q", got)
+	}
+	if got := stdout.String(); got == "" || !bytes.Contains([]byte(got), []byte("INPROGRESS")) {
+		t.Fatalf("stdout = %q", got)
+	}
+}
+
+func TestExecuteStatusCheckReturnsErrSilentOnFailedBuilds(t *testing.T) {
+	var stdout bytes.Buffer
+	ios := &iostreams.IOStreams{Out: &stdout, ErrOut: &bytes.Buffer{}}
+	cmd := newStatusCheckTestCommand()
+
+	err := executeStatusCheck(&checksResult{
+		ctx: context.Background(),
+		ios: ios,
+		cmd: cmd,
+		opts: &checksOptions{
+			ID:          99,
+			Wait:        true,
+			Interval:    time.Millisecond,
+			MaxInterval: time.Millisecond,
+			waitForPoll: noWaitPoll,
+		},
+		fetchFunc: func() ([]types.CommitStatus, error) {
+			return []types.CommitStatus{{State: "FAILED", Name: "ci"}}, nil
+		},
+		commitSHA: "abc123def456",
+		payload:   map[string]any{},
+	})
+	if !errors.Is(err, cmdutil.ErrSilent) {
+		t.Fatalf("err = %v, want ErrSilent", err)
+	}
+	if got := stdout.String(); got == "" || !bytes.Contains([]byte(got), []byte("FAILED")) {
+		t.Fatalf("stdout = %q", got)
+	}
+}
+
+func TestExecuteStatusCheckOpensBrowserForFirstStatusURL(t *testing.T) {
+	var opened string
+	cmd := newStatusCheckTestCommand()
+
+	err := executeStatusCheck(&checksResult{
+		ctx: context.Background(),
+		ios: &iostreams.IOStreams{Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{}},
+		cmd: cmd,
+		opts: &checksOptions{
+			ID:   7,
+			Web:  true,
+			Wait: false,
+		},
+		fetchFunc: func() ([]types.CommitStatus, error) {
+			return []types.CommitStatus{{State: "SUCCESSFUL", Name: "build", URL: "https://example.com/build/7"}}, nil
+		},
+		commitSHA: "abc123def456",
+		payload:   map[string]any{},
+		browserOpen: func(url string) error {
+			opened = url
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("executeStatusCheck: %v", err)
+	}
+	if opened != "https://example.com/build/7" {
+		t.Fatalf("opened = %q", opened)
+	}
+}
+
+func TestExecuteStatusCheckReturnsBrowserError(t *testing.T) {
+	cmd := newStatusCheckTestCommand()
+	wantErr := errors.New("browser boom")
+
+	err := executeStatusCheck(&checksResult{
+		ctx: context.Background(),
+		ios: &iostreams.IOStreams{Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{}},
+		cmd: cmd,
+		opts: &checksOptions{
+			ID:   8,
+			Web:  true,
+			Wait: false,
+		},
+		fetchFunc: func() ([]types.CommitStatus, error) {
+			return []types.CommitStatus{{State: "SUCCESSFUL", Name: "build", URL: "https://example.com/build/8"}}, nil
+		},
+		commitSHA: "abc123def456",
+		payload:   map[string]any{},
+		browserOpen: func(string) error {
+			return wantErr
+		},
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want wrapped %v", err, wantErr)
+	}
+}
+
+func TestFindRemoteByURL(t *testing.T) {
+	helperDir := t.TempDir()
+	t.Setenv("PATH", helperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("PR_TEST_GIT_REMOTE_V_OUTPUT", "origin\thttps://bitbucket.org/ws/repo.git (fetch)\norigin\thttps://bitbucket.org/ws/repo.git (push)\nfork\tgit@bitbucket.org:user/repo.git (fetch)\n")
+
+	writePRGitHelper(t, filepath.Join(helperDir, prGitHelperName()))
+
+	if got := findRemoteByURL(context.Background(), "https://bitbucket.org/ws/repo.git"); got != "origin" {
+		t.Fatalf("findRemoteByURL() = %q, want origin", got)
+	}
+	if got := findRemoteByURL(context.Background(), "git@bitbucket.org:user/repo.git"); got != "fork" {
+		t.Fatalf("findRemoteByURL() = %q, want fork", got)
+	}
+	if got := findRemoteByURL(context.Background(), "https://bitbucket.org/missing/repo.git"); got != "" {
+		t.Fatalf("findRemoteByURL() = %q, want empty", got)
+	}
+}
+
+func TestInferProtocol(t *testing.T) {
+	helperDir := t.TempDir()
+	t.Setenv("PATH", helperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("PR_TEST_GIT_REMOTE_GET_URL_OUTPUT", "git@bitbucket.org:ws/repo.git")
+
+	writePRGitHelper(t, filepath.Join(helperDir, prGitHelperName()))
+
+	if got := inferProtocol(context.Background(), "origin"); got != "ssh" {
+		t.Fatalf("inferProtocol() = %q, want ssh", got)
+	}
+
+	t.Setenv("PR_TEST_GIT_REMOTE_GET_URL_OUTPUT", "https://bitbucket.org/ws/repo.git")
+	if got := inferProtocol(context.Background(), "origin"); got != "https" {
+		t.Fatalf("inferProtocol() = %q, want https", got)
+	}
+}
+
+func newStatusCheckTestCommand() *cobra.Command {
+	root := &cobra.Command{Use: "bkt"}
+	root.PersistentFlags().Bool("json", false, "")
+	root.PersistentFlags().Bool("yaml", false, "")
+	root.PersistentFlags().String("jq", "", "")
+	root.PersistentFlags().String("template", "", "")
+
+	cmd := &cobra.Command{Use: "checks"}
+	root.AddCommand(cmd)
+	return cmd
+}
+
+func prGitHelperName() string {
+	if runtime.GOOS == "windows" {
+		return "git.bat"
+	}
+	return "git"
+}
+
+func writePRGitHelper(t *testing.T, target string) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		script := "@echo off\r\n" +
+			"if \"%1\"==\"remote\" if \"%2\"==\"-v\" (\r\n" +
+			"  <nul set /p =%PR_TEST_GIT_REMOTE_V_OUTPUT%\r\n" +
+			"  exit /b 0\r\n" +
+			")\r\n" +
+			"if \"%1\"==\"remote\" if \"%2\"==\"get-url\" (\r\n" +
+			"  <nul set /p =%PR_TEST_GIT_REMOTE_GET_URL_OUTPUT%\r\n" +
+			"  exit /b 0\r\n" +
+			")\r\n" +
+			"exit /b 1\r\n"
+		if err := os.WriteFile(target, []byte(script), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", target, err)
+		}
+		return
+	}
+
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"remote\" ] && [ \"$2\" = \"-v\" ]; then\n" +
+		"  printf '%s' \"$PR_TEST_GIT_REMOTE_V_OUTPUT\"\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"if [ \"$1\" = \"remote\" ] && [ \"$2\" = \"get-url\" ]; then\n" +
+		"  printf '%s' \"$PR_TEST_GIT_REMOTE_GET_URL_OUTPUT\"\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 1\n"
+	if err := os.WriteFile(target, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(%s): %v", target, err)
+	}
+}

--- a/pkg/cmd/pr/pr_test.go
+++ b/pkg/cmd/pr/pr_test.go
@@ -19,9 +19,50 @@ import (
 	"github.com/avivsinai/bitbucket-cli/pkg/bbcloud"
 	"github.com/avivsinai/bitbucket-cli/pkg/bbdc"
 	"github.com/avivsinai/bitbucket-cli/pkg/cmdutil"
+	"github.com/avivsinai/bitbucket-cli/pkg/httpx"
 	"github.com/avivsinai/bitbucket-cli/pkg/iostreams"
 	"github.com/avivsinai/bitbucket-cli/pkg/types"
 )
+
+func noWaitPoll(context.Context, time.Duration) error { return nil }
+
+// newCloudClientNoRetry mirrors cmdutil.NewCloudClient with MaxAttempts:1 to avoid retry delays in tests.
+func newCloudClientNoRetry(host *config.Host) (*bbcloud.Client, error) {
+	if host == nil {
+		return nil, fmt.Errorf("missing host configuration")
+	}
+	if host.BaseURL == "" {
+		host.BaseURL = "https://api.bitbucket.org/2.0"
+	}
+
+	return bbcloud.New(bbcloud.Options{
+		BaseURL:     host.BaseURL,
+		Username:    host.Username,
+		Token:       host.Token,
+		AuthMethod:  host.AuthMethod,
+		EnableCache: true,
+		Retry:       httpx.RetryPolicy{MaxAttempts: 1},
+	})
+}
+
+// newDCClientNoRetry mirrors cmdutil.NewDCClient with MaxAttempts:1 to avoid retry delays in tests.
+func newDCClientNoRetry(host *config.Host) (*bbdc.Client, error) {
+	if host == nil {
+		return nil, fmt.Errorf("missing host configuration")
+	}
+	if host.BaseURL == "" {
+		return nil, fmt.Errorf("host %q has no base URL configured", host.Kind)
+	}
+
+	return bbdc.New(bbdc.Options{
+		BaseURL:     host.BaseURL,
+		Username:    host.Username,
+		Token:       host.Token,
+		AuthMethod:  host.AuthMethod,
+		EnableCache: true,
+		Retry:       httpx.RetryPolicy{MaxAttempts: 1},
+	})
+}
 
 func TestListRequiresMineWithoutRepo(t *testing.T) {
 	// Change to a temp directory without a git repo to prevent
@@ -1943,6 +1984,7 @@ func TestPollUntilComplete_MultipleIterations(t *testing.T) {
 		Wait:        true,
 		Interval:    1 * time.Millisecond, // Very short for testing
 		MaxInterval: 5 * time.Millisecond,
+		waitForPoll: noWaitPoll,
 	}
 
 	fetcher := &mockFetcher{
@@ -2049,6 +2091,7 @@ func TestPollUntilComplete_FetchErrorRetry(t *testing.T) {
 		Wait:        true,
 		Interval:    1 * time.Millisecond,
 		MaxInterval: 5 * time.Millisecond,
+		waitForPoll: noWaitPoll,
 	}
 
 	fetcher := &mockFetcher{
@@ -2082,6 +2125,7 @@ func TestPollUntilComplete_MaxConsecutiveErrors(t *testing.T) {
 		Wait:        true,
 		Interval:    1 * time.Millisecond,
 		MaxInterval: 5 * time.Millisecond,
+		waitForPoll: noWaitPoll,
 	}
 
 	testErr := fmt.Errorf("persistent error")
@@ -2117,6 +2161,7 @@ func TestPollUntilComplete_ErrorResetOnSuccess(t *testing.T) {
 		Wait:        true,
 		Interval:    1 * time.Millisecond,
 		MaxInterval: 5 * time.Millisecond,
+		waitForPoll: noWaitPoll,
 	}
 
 	testErr := fmt.Errorf("temporary error")
@@ -3982,10 +4027,11 @@ func TestRunEditDataCenterErrors(t *testing.T) {
 			}
 
 			f := &cmdutil.Factory{
-				AppVersion:     "test",
-				ExecutableName: "bkt",
-				IOStreams:      &iostreams.IOStreams{Out: &strings.Builder{}, ErrOut: &strings.Builder{}},
-				Config:         func() (*config.Config, error) { return tt.cfg, nil },
+				AppVersion:      "test",
+				ExecutableName:  "bkt",
+				IOStreams:       &iostreams.IOStreams{Out: &strings.Builder{}, ErrOut: &strings.Builder{}},
+				Config:          func() (*config.Config, error) { return tt.cfg, nil },
+				NewDCClientFunc: newDCClientNoRetry,
 			}
 
 			cmd := newEditCmd(f)
@@ -4178,10 +4224,11 @@ func TestRunEditCloudErrors(t *testing.T) {
 			}
 
 			f := &cmdutil.Factory{
-				AppVersion:     "test",
-				ExecutableName: "bkt",
-				IOStreams:      &iostreams.IOStreams{Out: &strings.Builder{}, ErrOut: &strings.Builder{}},
-				Config:         func() (*config.Config, error) { return tt.cfg, nil },
+				AppVersion:         "test",
+				ExecutableName:     "bkt",
+				IOStreams:          &iostreams.IOStreams{Out: &strings.Builder{}, ErrOut: &strings.Builder{}},
+				Config:             func() (*config.Config, error) { return tt.cfg, nil },
+				NewCloudClientFunc: newCloudClientNoRetry,
 			}
 
 			cmd := newEditCmd(f)

--- a/pkg/cmd/pr/pr_view_approve_merge_test.go
+++ b/pkg/cmd/pr/pr_view_approve_merge_test.go
@@ -1,0 +1,365 @@
+package pr_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/bitbucket-cli/internal/config"
+	"github.com/avivsinai/bitbucket-cli/pkg/browser"
+	"github.com/avivsinai/bitbucket-cli/pkg/cmd/root"
+	"github.com/avivsinai/bitbucket-cli/pkg/cmdutil"
+	"github.com/avivsinai/bitbucket-cli/pkg/iostreams"
+)
+
+type recordingBrowser struct {
+	url string
+	err error
+}
+
+func (b *recordingBrowser) Open(url string) error {
+	b.url = url
+	return b.err
+}
+
+func TestPRViewDataCenter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:token"))
+		if r.Header.Get("Authorization") != auth {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		if r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/pull-requests/42") {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":          42,
+				"title":       "Speed up tests",
+				"state":       "OPEN",
+				"description": "Make slow tests fast",
+				"author": map[string]any{
+					"user": map[string]any{
+						"name":        "alice",
+						"displayName": "Alice",
+					},
+				},
+				"fromRef": map[string]any{
+					"displayId": "feature/tests",
+				},
+				"toRef": map[string]any{
+					"displayId": "master",
+				},
+				"reviewers": []map[string]any{
+					{
+						"user": map[string]any{
+							"name":        "bob",
+							"displayName": "Bob",
+						},
+					},
+				},
+				"links": map[string]any{
+					"self": []map[string]any{
+						{"href": "https://bitbucket.example.com/projects/PROJ/repos/my-repo/pull-requests/42"},
+					},
+				},
+			})
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	stdout, stderr, err := runCLI(t, dcConfig(srv.URL), "pr", "view", "42")
+	if err != nil {
+		t.Fatalf("pr view error: %v (stderr=%s)", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("unexpected stderr: %s", stderr)
+	}
+	for _, want := range []string{
+		"Pull Request #42: Speed up tests",
+		"State: OPEN",
+		"Author: Alice",
+		"From: feature/tests",
+		"To:   master",
+		"Make slow tests fast",
+		"Reviewers:",
+		"Bob",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestPRViewCloudWeb(t *testing.T) {
+	b := &recordingBrowser{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:token"))
+		if r.Header.Get("Authorization") != auth {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		if r.Method == "GET" && r.URL.Path == "/repositories/myworkspace/my-repo/pullrequests/7" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":    7,
+				"title": "Cloud PR",
+				"state": "OPEN",
+				"author": map[string]any{
+					"display_name": "Cloud User",
+					"username":     "cloud-user",
+				},
+				"source": map[string]any{
+					"branch": map[string]any{"name": "feature/cloud"},
+				},
+				"destination": map[string]any{
+					"branch": map[string]any{"name": "master"},
+				},
+				"summary": map[string]any{
+					"raw": "Cloud summary",
+				},
+				"links": map[string]any{
+					"html": map[string]any{
+						"href": "https://bitbucket.org/myworkspace/my-repo/pull-requests/7",
+					},
+				},
+			})
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	stdout, stderr, err := runCLIWithBrowser(t, cloudConfig(srv.URL), b, "pr", "view", "7", "--web")
+	if err != nil {
+		t.Fatalf("pr view --web error: %v (stderr=%s)", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("unexpected stderr: %s", stderr)
+	}
+	if b.url != "https://bitbucket.org/myworkspace/my-repo/pull-requests/7" {
+		t.Fatalf("browser opened %q", b.url)
+	}
+	for _, want := range []string{
+		"Pull Request #7: Cloud PR",
+		"Author: Cloud User",
+		"From: feature/cloud",
+		"To:   master",
+		"Cloud summary",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestPRApproveDataCenter(t *testing.T) {
+	var approveCalled bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:token"))
+		if r.Header.Get("Authorization") != auth {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		if r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/pull-requests/42/approve") {
+			approveCalled = true
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	stdout, stderr, err := runCLI(t, dcConfig(srv.URL), "pr", "approve", "42")
+	if err != nil {
+		t.Fatalf("pr approve error: %v (stderr=%s)", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("unexpected stderr: %s", stderr)
+	}
+	if !approveCalled {
+		t.Fatal("approve endpoint not called")
+	}
+	if !strings.Contains(stdout, "Approved pull request #42") {
+		t.Fatalf("unexpected stdout: %s", stdout)
+	}
+}
+
+func TestPRApproveCloud(t *testing.T) {
+	var approveCalled bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:token"))
+		if r.Header.Get("Authorization") != auth {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		if r.Method == "POST" && r.URL.Path == "/repositories/myworkspace/my-repo/pullrequests/42/approve" {
+			approveCalled = true
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	stdout, stderr, err := runCLI(t, cloudConfig(srv.URL), "pr", "approve", "42")
+	if err != nil {
+		t.Fatalf("pr approve error: %v (stderr=%s)", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("unexpected stderr: %s", stderr)
+	}
+	if !approveCalled {
+		t.Fatal("approve endpoint not called")
+	}
+	if !strings.Contains(stdout, "Approved pull request #42") {
+		t.Fatalf("unexpected stdout: %s", stdout)
+	}
+}
+
+func TestPRMergeDataCenter(t *testing.T) {
+	var mergeBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:token"))
+		if r.Header.Get("Authorization") != auth {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		switch {
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/pull-requests/42"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      42,
+				"title":   "Merge me",
+				"state":   "OPEN",
+				"version": 3,
+			})
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/pull-requests/42/merge"):
+			_ = json.NewDecoder(r.Body).Decode(&mergeBody)
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	stdout, stderr, err := runCLI(t, dcConfig(srv.URL), "pr", "merge", "42", "--message", "Ship it", "--strategy", "squash", "--close-source=false")
+	if err != nil {
+		t.Fatalf("pr merge error: %v (stderr=%s)", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("unexpected stderr: %s", stderr)
+	}
+	if got := int(mergeBody["version"].(float64)); got != 3 {
+		t.Fatalf("version = %d", got)
+	}
+	if got := mergeBody["message"]; got != "Ship it" {
+		t.Fatalf("message = %v", got)
+	}
+	if got := mergeBody["mergeStrategyId"]; got != "squash" {
+		t.Fatalf("mergeStrategyId = %v", got)
+	}
+	if got := mergeBody["closeSourceBranch"]; got != false {
+		t.Fatalf("closeSourceBranch = %v", got)
+	}
+	if !strings.Contains(stdout, "Merged pull request #42") {
+		t.Fatalf("unexpected stdout: %s", stdout)
+	}
+}
+
+func TestPRMergeCloud(t *testing.T) {
+	var mergeBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:token"))
+		if r.Header.Get("Authorization") != auth {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		if r.Method == "POST" && r.URL.Path == "/repositories/myworkspace/my-repo/pullrequests/42/merge" {
+			_ = json.NewDecoder(r.Body).Decode(&mergeBody)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{})
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	stdout, stderr, err := runCLI(t, cloudConfig(srv.URL), "pr", "merge", "42", "--message", "Ship it", "--strategy", "squash", "--close-source=false")
+	if err != nil {
+		t.Fatalf("pr merge error: %v (stderr=%s)", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("unexpected stderr: %s", stderr)
+	}
+	if got := mergeBody["message"]; got != "Ship it" {
+		t.Fatalf("message = %v", got)
+	}
+	if got := mergeBody["merge_strategy"]; got != "squash" {
+		t.Fatalf("merge_strategy = %v", got)
+	}
+	if got := mergeBody["close_source_branch"]; got != false {
+		t.Fatalf("close_source_branch = %v", got)
+	}
+	if !strings.Contains(stdout, "Merged pull request #42") {
+		t.Fatalf("unexpected stdout: %s", stdout)
+	}
+}
+
+func runCLIWithBrowser(t *testing.T, cfg *config.Config, b browser.Browser, args ...string) (string, string, error) {
+	t.Helper()
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	ios := &iostreams.IOStreams{
+		In:     io.NopCloser(bytes.NewReader(nil)),
+		Out:    stdout,
+		ErrOut: stderr,
+	}
+
+	factory := &cmdutil.Factory{
+		AppVersion:     "test",
+		ExecutableName: "bkt",
+		IOStreams:      ios,
+		Browser:        b,
+		Config: func() (*config.Config, error) {
+			return cfg, nil
+		},
+	}
+
+	rootCmd, err := root.NewCmdRoot(factory)
+	if err != nil {
+		t.Fatalf("NewCmdRoot: %v", err)
+	}
+	rootCmd.SetArgs(args)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(stderr)
+	rootCmd.SilenceUsage = true
+
+	t.Setenv("BKT_NO_UPDATE_CHECK", "1")
+	t.Setenv("NO_COLOR", "1")
+
+	err = rootCmd.ExecuteContext(context.Background())
+	return stdout.String(), stderr.String(), err
+}

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 
 	"github.com/avivsinai/bitbucket-cli/internal/config"
+	"github.com/avivsinai/bitbucket-cli/pkg/bbcloud"
+	"github.com/avivsinai/bitbucket-cli/pkg/bbdc"
 	"github.com/avivsinai/bitbucket-cli/pkg/browser"
 	"github.com/avivsinai/bitbucket-cli/pkg/iostreams"
 	"github.com/avivsinai/bitbucket-cli/pkg/pager"
@@ -19,6 +21,10 @@ type Factory struct {
 	IOStreams *iostreams.IOStreams
 
 	Config func() (*config.Config, error)
+
+	// Optional client builders for tests that need custom transport/retry behavior.
+	NewCloudClientFunc func(*config.Host) (*bbcloud.Client, error)
+	NewDCClientFunc    func(*config.Host) (*bbdc.Client, error)
 
 	// Lazy-initialised platform helpers.
 	Browser  browser.Browser
@@ -57,6 +63,22 @@ func (f *Factory) Streams() (*iostreams.IOStreams, error) {
 		f.ios = iostreams.System()
 	})
 	return f.ios, nil
+}
+
+// CloudClient returns a Bitbucket Cloud client, using a test override when set.
+func (f *Factory) CloudClient(host *config.Host) (*bbcloud.Client, error) {
+	if f != nil && f.NewCloudClientFunc != nil {
+		return f.NewCloudClientFunc(host)
+	}
+	return NewCloudClient(host)
+}
+
+// DCClient returns a Bitbucket Data Center client, using a test override when set.
+func (f *Factory) DCClient(host *config.Host) (*bbdc.Client, error) {
+	if f != nil && f.NewDCClientFunc != nil {
+		return f.NewDCClientFunc(host)
+	}
+	return NewDCClient(host)
 }
 
 // BrowserOpener returns a Browser, initialising the default system implementation

--- a/pkg/cmdutil/factory_test.go
+++ b/pkg/cmdutil/factory_test.go
@@ -1,0 +1,319 @@
+package cmdutil
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/bitbucket-cli/internal/config"
+	"github.com/avivsinai/bitbucket-cli/pkg/bbcloud"
+	"github.com/avivsinai/bitbucket-cli/pkg/bbdc"
+	"github.com/avivsinai/bitbucket-cli/pkg/browser"
+	"github.com/avivsinai/bitbucket-cli/pkg/iostreams"
+	"github.com/avivsinai/bitbucket-cli/pkg/pager"
+	"github.com/avivsinai/bitbucket-cli/pkg/progress"
+	"github.com/avivsinai/bitbucket-cli/pkg/prompter"
+)
+
+type stubBrowser struct{}
+
+func (stubBrowser) Open(string) error { return nil }
+
+type stubPager struct{}
+
+func (stubPager) Enabled() bool                  { return true }
+func (stubPager) Start() (io.WriteCloser, error) { return nopCloser{Writer: io.Discard}, nil }
+func (stubPager) Stop() error                    { return nil }
+
+type nopCloser struct{ io.Writer }
+
+func (nopCloser) Close() error { return nil }
+
+type stubPrompter struct{}
+
+func (stubPrompter) Input(string, string) (string, error) { return "", nil }
+func (stubPrompter) Password(string) (string, error)      { return "", nil }
+func (stubPrompter) Confirm(string, bool) (bool, error)   { return false, nil }
+
+type stubSpinner struct{}
+
+func (stubSpinner) Start(string) {}
+func (stubSpinner) Stop(string)  {}
+func (stubSpinner) Fail(string)  {}
+
+func testIOStreams() (*iostreams.IOStreams, *bytes.Buffer, *bytes.Buffer) {
+	var out, errOut bytes.Buffer
+	return &iostreams.IOStreams{
+		In:     io.NopCloser(strings.NewReader("")),
+		Out:    &out,
+		ErrOut: &errOut,
+	}, &out, &errOut
+}
+
+func TestFactoryResolveConfigCachesSuccess(t *testing.T) {
+	want := &config.Config{ActiveContext: "dev"}
+	var calls int
+	f := &Factory{
+		Config: func() (*config.Config, error) {
+			calls++
+			return want, nil
+		},
+	}
+
+	got1, err := f.ResolveConfig()
+	if err != nil {
+		t.Fatalf("ResolveConfig first call: %v", err)
+	}
+	got2, err := f.ResolveConfig()
+	if err != nil {
+		t.Fatalf("ResolveConfig second call: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("Config called %d times, want 1", calls)
+	}
+	if got1 != want || got2 != want {
+		t.Fatalf("ResolveConfig did not return cached config pointer")
+	}
+}
+
+func TestFactoryResolveConfigFallsBackToLoad(t *testing.T) {
+	t.Setenv("BKT_CONFIG_DIR", t.TempDir())
+
+	f := &Factory{}
+	got, err := f.ResolveConfig()
+	if err != nil {
+		t.Fatalf("ResolveConfig fallback: %v", err)
+	}
+	if got == nil {
+		t.Fatal("ResolveConfig fallback returned nil config")
+	}
+	if got.Path() == "" {
+		t.Fatal("ResolveConfig fallback did not set config path")
+	}
+}
+
+func TestFactoryResolveConfigCachesError(t *testing.T) {
+	wantErr := errors.New("config boom")
+	var calls int
+	f := &Factory{
+		Config: func() (*config.Config, error) {
+			calls++
+			return nil, wantErr
+		},
+	}
+
+	_, err1 := f.ResolveConfig()
+	_, err2 := f.ResolveConfig()
+	if !errors.Is(err1, wantErr) || !errors.Is(err2, wantErr) {
+		t.Fatalf("ResolveConfig errors = %v / %v, want %v", err1, err2, wantErr)
+	}
+	if calls != 1 {
+		t.Fatalf("Config called %d times, want 1", calls)
+	}
+}
+
+func TestFactoryStreamsCachesProvidedIOStreams(t *testing.T) {
+	ios, _, _ := testIOStreams()
+	f := &Factory{IOStreams: ios}
+
+	got1, err := f.Streams()
+	if err != nil {
+		t.Fatalf("Streams first call: %v", err)
+	}
+	got2, err := f.Streams()
+	if err != nil {
+		t.Fatalf("Streams second call: %v", err)
+	}
+	if got1 != ios || got2 != ios {
+		t.Fatalf("Streams did not return provided IOStreams pointer")
+	}
+}
+
+func TestFactoryStreamsFallsBackToSystem(t *testing.T) {
+	f := &Factory{}
+
+	got1, err := f.Streams()
+	if err != nil {
+		t.Fatalf("Streams first fallback call: %v", err)
+	}
+	got2, err := f.Streams()
+	if err != nil {
+		t.Fatalf("Streams second fallback call: %v", err)
+	}
+	if got1 == nil || got2 == nil {
+		t.Fatal("Streams fallback returned nil")
+	}
+	if got1 != got2 {
+		t.Fatal("Streams fallback did not cache system streams")
+	}
+	if got1.In == nil || got1.Out == nil || got1.ErrOut == nil {
+		t.Fatal("Streams fallback returned incomplete system streams")
+	}
+}
+
+func TestFactoryCloudClientUsesOverride(t *testing.T) {
+	want, err := bbcloud.New(bbcloud.Options{BaseURL: "https://api.bitbucket.org/2.0", Token: "tok"})
+	if err != nil {
+		t.Fatalf("bbcloud.New: %v", err)
+	}
+
+	f := &Factory{
+		NewCloudClientFunc: func(host *config.Host) (*bbcloud.Client, error) {
+			if host == nil || host.BaseURL != "https://api.bitbucket.org/2.0" {
+				t.Fatalf("unexpected host: %#v", host)
+			}
+			return want, nil
+		},
+	}
+
+	got, err := f.CloudClient(&config.Host{BaseURL: "https://api.bitbucket.org/2.0"})
+	if err != nil {
+		t.Fatalf("CloudClient: %v", err)
+	}
+	if got != want {
+		t.Fatal("CloudClient did not return override client")
+	}
+}
+
+func TestFactoryCloudClientFallsBackWithNilReceiver(t *testing.T) {
+	var f *Factory
+	got, err := f.CloudClient(&config.Host{BaseURL: "https://api.bitbucket.org/2.0", Token: "tok"})
+	if err != nil {
+		t.Fatalf("CloudClient fallback: %v", err)
+	}
+	if got == nil {
+		t.Fatal("CloudClient fallback returned nil client")
+	}
+}
+
+func TestFactoryDCClientUsesOverride(t *testing.T) {
+	want, err := bbdc.New(bbdc.Options{BaseURL: "https://bitbucket.example.com", Token: "tok"})
+	if err != nil {
+		t.Fatalf("bbdc.New: %v", err)
+	}
+
+	f := &Factory{
+		NewDCClientFunc: func(host *config.Host) (*bbdc.Client, error) {
+			if host == nil || host.BaseURL != "https://bitbucket.example.com" {
+				t.Fatalf("unexpected host: %#v", host)
+			}
+			return want, nil
+		},
+	}
+
+	got, err := f.DCClient(&config.Host{BaseURL: "https://bitbucket.example.com"})
+	if err != nil {
+		t.Fatalf("DCClient: %v", err)
+	}
+	if got != want {
+		t.Fatal("DCClient did not return override client")
+	}
+}
+
+func TestFactoryDCClientFallsBackWithNilReceiver(t *testing.T) {
+	var f *Factory
+	got, err := f.DCClient(&config.Host{BaseURL: "https://bitbucket.example.com", Token: "tok"})
+	if err != nil {
+		t.Fatalf("DCClient fallback: %v", err)
+	}
+	if got == nil {
+		t.Fatal("DCClient fallback returned nil client")
+	}
+}
+
+func TestFactoryBrowserOpenerCachesDefaultAndHonorsOverride(t *testing.T) {
+	f := &Factory{}
+
+	got1 := f.BrowserOpener()
+	got2 := f.BrowserOpener()
+	if got1 == nil || got2 == nil {
+		t.Fatal("BrowserOpener returned nil")
+	}
+	if got1 != got2 {
+		t.Fatal("BrowserOpener did not cache default browser")
+	}
+
+	override := stubBrowser{}
+	f.Browser = override
+	if got := f.BrowserOpener(); got != override {
+		t.Fatal("BrowserOpener did not return configured browser")
+	}
+}
+
+func TestFactoryPagerManagerCachesDefaultAndHonorsOverride(t *testing.T) {
+	ios, _, _ := testIOStreams()
+	f := &Factory{IOStreams: ios}
+
+	got1 := f.PagerManager()
+	got2 := f.PagerManager()
+	if got1 == nil || got2 == nil {
+		t.Fatal("PagerManager returned nil")
+	}
+	if got1 != got2 {
+		t.Fatal("PagerManager did not cache default pager")
+	}
+	if got1.Enabled() {
+		t.Fatal("PagerManager default should be noop for non-TTY streams")
+	}
+
+	override := stubPager{}
+	f.Pager = override
+	if got := f.PagerManager(); got != override {
+		t.Fatal("PagerManager did not return configured pager")
+	}
+}
+
+func TestFactoryPromptCachesDefaultAndHonorsOverride(t *testing.T) {
+	ios, _, _ := testIOStreams()
+	f := &Factory{IOStreams: ios}
+
+	got1 := f.Prompt()
+	got2 := f.Prompt()
+	if got1 == nil || got2 == nil {
+		t.Fatal("Prompt returned nil")
+	}
+	if got1 != got2 {
+		t.Fatal("Prompt did not cache default prompter")
+	}
+
+	override := stubPrompter{}
+	f.Prompter = override
+	if got := f.Prompt(); got != override {
+		t.Fatal("Prompt did not return configured prompter")
+	}
+}
+
+func TestFactoryProgressSpinnerCachesDefaultAndHonorsOverride(t *testing.T) {
+	ios, _, errOut := testIOStreams()
+	f := &Factory{IOStreams: ios}
+
+	got1 := f.ProgressSpinner()
+	got2 := f.ProgressSpinner()
+	if got1 == nil || got2 == nil {
+		t.Fatal("ProgressSpinner returned nil")
+	}
+	if got1 != got2 {
+		t.Fatal("ProgressSpinner did not cache default spinner")
+	}
+
+	got1.Start("starting")
+	got1.Stop("done")
+	if !strings.Contains(errOut.String(), "starting") || !strings.Contains(errOut.String(), "done") {
+		t.Fatalf("default spinner did not write expected messages, got %q", errOut.String())
+	}
+
+	override := stubSpinner{}
+	f.Spinner = override
+	if got := f.ProgressSpinner(); got != override {
+		t.Fatal("ProgressSpinner did not return configured spinner")
+	}
+}
+
+var (
+	_ browser.Browser    = stubBrowser{}
+	_ pager.Manager      = stubPager{}
+	_ prompter.Interface = stubPrompter{}
+	_ progress.Spinner   = stubSpinner{}
+)


### PR DESCRIPTION
## Summary
This PR makes the test suite much faster by removing real sleep and retry delays from unit tests while keeping production defaults unchanged. It also adds focused coverage for command/factory wiring and a local `golangci-lint` pre-commit hook that matches CI.

## Changes
- Tests/polling:
  - Added a private wait hook for PR check polling so unit tests can bypass real timer waits without changing runtime behavior.
  - Added a configurable merge polling interval for the Bitbucket Cloud client so async merge tests no longer sleep for real 2-second intervals.
- Tests/retries:
  - Added factory-level client seams so targeted negative-path PR edit tests can use retry-free clients.
  - Updated PR edit error tests to disable HTTP retry backoff when retry behavior is not the thing under test.
- Tests/auth:
  - Updated the OAuth auth-status test to avoid an unnecessary keyring/expiry lookup on the hot path while preserving the intent of the assertion.
- Coverage:
  - Added focused `pkg/cmdutil/factory.go` tests covering cache, fallback, lazy-init, and client override paths.
  - Added `pkg/cmd/pr/pr.go` coverage for `view`, `approve`, `merge`, `executeStatusCheck`, `findRemoteByURL`, and `inferProtocol`.
- Dev workflow:
  - Added a local `golangci-lint` pre-commit hook configured to run repo-wide with the same `--timeout 5m` behavior used in CI.

## Testing
- Ran `go test ./... -count=1`
- Verified uncached full-suite wall time dropped from about `30.18s` to about `10.74s`
- Ran `go test ./pkg/cmdutil -coverprofile=/tmp/cmdutil.cover.out -count=1`
- Ran `go test ./pkg/cmd/pr -count=1`
- Ran `golangci-lint run --timeout 5m`
- Ran `pre-commit run golangci-lint --all-files`

## Impact
- `pkg/cmdutil/factory.go` now has full statement/function coverage.
- `pkg/cmd/pr/pr.go` statement coverage increased from about `56.3%` to about `62.9%`.
- The new lint hook should catch CI lint failures earlier in local development.

## Risks
- Low. Production defaults stay unchanged; the new seams are private and primarily used by tests.
- Main review point: confirm the new factory/client hooks remain narrow and do not encourage broader test-only branching in command code.
