### PR TITLE
ci(release): attest artifacts and tighten release gates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,4 +17,3 @@ updates:
       - avivsinai
     cooldown:
       default-days: 7
-      semver-major-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: read
+
 concurrency:
   group: release-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.sha }}
   cancel-in-progress: false
@@ -129,6 +132,19 @@ jobs:
           go-version: '1.25'
       - name: Verify release metadata
         run: ./scripts/check-release-version.sh "${{ needs.prepare.outputs.version }}"
+      - name: Check skill sync
+        run: make check-skills
+      - name: Verify gofmt
+        shell: bash
+        run: |
+          files="$(gofmt -l .)"
+          if [[ -n "$files" ]]; then
+            echo "The following files need gofmt:" >&2
+            echo "$files" >&2
+            exit 1
+          fi
+      - name: Go vet
+        run: go vet ./...
       - name: Run tests
         run: make test
       - name: Build CLI
@@ -143,6 +159,8 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: write
+      attestations: write
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -212,6 +230,27 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+      - name: Collect attestation subjects
+        id: attestation_subjects
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t subjects < <(find dist -maxdepth 1 -type f | sort)
+          if ((${#subjects[@]} == 0)); then
+            echo "::error::No release artifacts found to attest."
+            exit 1
+          fi
+          {
+            echo "subjects<<EOF"
+            printf '%s\n' "${subjects[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate artifact attestation
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-path: ${{ steps.attestation_subjects.outputs.subjects }}
 
   skill-publish:
     name: Publish skills

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -9,7 +9,7 @@
      - It creates `release/vX.Y.Z`.
      - It turns `Unreleased` into `## [X.Y.Z] - YYYY-MM-DD`.
      - It bumps `skills/*/SKILL.md`, `.claude-plugin/plugin.json`, and `.codex-plugin/plugin.json`.
-     - It runs `./scripts/check-release-version.sh`, `make fmt`, `make test`, and `make build`.
+     - It runs `./scripts/check-release-version.sh`, `make check-skills`, `gofmt`, `go vet`, `make test`, and `make build`.
      - It commits `chore(release): vX.Y.Z`, pushes the release branch, opens a PR, and enables squash auto-merge by default.
 
 2. **Merge**
@@ -24,6 +24,7 @@
      - Checksums (`bkt_${VERSION}_checksums.txt`)
      - SBOMs (`sbom-${VERSION}.cyclonedx.json` via Syft)
    - Artifacts are uploaded to the GitHub Release page.
+   - The workflow emits GitHub build provenance attestations for the released files.
    - The `bkt` skill publish workflow runs from the CI-created tag.
 
 4. **Post-release**

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -12,13 +12,13 @@ Prepares a release PR from master by:
 - moving CHANGELOG.md's Unreleased section into a versioned release entry
 - bumping skill/plugin metadata versions
 - validating the release metadata
-- optionally running fmt/test/build
+- optionally running check-skills/gofmt/vet/test/build
 - creating and pushing the release commit
 - opening a GitHub PR and enabling squash auto-merge
 
 Options:
   --date YYYY-MM-DD  Override release date (default: today in UTC)
-  --skip-verify      Skip make fmt/test/build
+  --skip-verify      Skip local verification gates
   --allow-empty      Allow releasing with an empty Unreleased section
   --no-auto-merge    Create the PR but do not enable auto-merge
   -h, --help         Show this help text
@@ -210,7 +210,14 @@ PY
 ./scripts/check-release-version.sh "$tag"
 
 if [ "$skip_verify" -eq 0 ]; then
-  make fmt
+  make check-skills
+  files="$(gofmt -l .)"
+  if [[ -n "$files" ]]; then
+    echo "error: gofmt wants changes:" >&2
+    echo "$files" >&2
+    exit 1
+  fi
+  go vet ./...
   make test
   make build
 fi


### PR DESCRIPTION
## Summary
- add stronger release-commit verification gates
- attest published artifacts in the release job
- tighten local release script/docs to match CI