### PR TITLE
docs(changelog): add v0.24.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+- `bkt pr comments --details` now shows file:line context, resolved/complete status, full comment text, and nested reply indentation for Bitbucket Data Center pull request threads (#110).
+
+### Changed
+- Bitbucket Cloud OAuth login now layers PKCE (RFC 7636, S256) onto the existing authorization-code flow while preserving the client-secret token exchange Bitbucket still requires (#162).
+- Release automation now attests published artifacts and tightens release-commit verification before tags are created (#164).
+
 ## [0.23.0] - 2026-04-12
 ### Added
 - `bkt pr edit --with-default-reviewers` now works on Bitbucket Cloud and Data Center, merging effective default reviewers with explicit reviewer edits while preserving mixed Cloud reviewer identities (#150).


### PR DESCRIPTION
Add the missing Unreleased notes for the notable changes merged after v0.23.0 so the next release can be cut through the supported release PR flow.

This covers the Data Center PR comments details view, PKCE in the Bitbucket Cloud OAuth login flow, and the release-pipeline attestation/gate tightening.

Refs GH-110
Refs GH-162
Refs GH-164