### PR TITLE
chore(release): v0.24.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ All notable changes to this project will be documented here. The format follows
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-04-15
 ### Added
 - `bkt pr comments --details` now shows file:line context, resolved/complete status, full comment text, and nested reply indentation for Bitbucket Data Center pull request threads (#110).
 
 ### Changed
 - Bitbucket Cloud OAuth login now layers PKCE (RFC 7636, S256) onto the existing authorization-code flow while preserving the client-secret token exchange Bitbucket still requires (#162).
 - Release automation now attests published artifacts and tightens release-commit verification before tags are created (#164).
+
 
 ## [0.23.0] - 2026-04-12
 ### Added

--- a/skills/bkt/SKILL.md
+++ b/skills/bkt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bkt
-version: 0.23.0
+version: 0.24.0
 description: Bitbucket CLI for Data Center and Cloud. Use when users need to manage repositories, pull requests, branches, issues, webhooks, or pipelines in Bitbucket. Triggers include "bitbucket", "bkt", "pull request", "PR", "repo list", "branch create", "Bitbucket Data Center", "Bitbucket Cloud", "keyring timeout".
 metadata:
   short-description: Bitbucket CLI for repos, PRs, branches


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.24.0`
- aligns skill/plugin metadata to `0.24.0`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.24.0`, publishes the release, and publishes skills in the same workflow run