### PR TITLE
ci(release): avoid mapfile in attestation step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,14 +251,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          mapfile -t subjects < <(find dist -maxdepth 1 -type f | sort)
-          if ((${#subjects[@]} == 0)); then
+          subjects="$(find dist -maxdepth 1 -type f | sort)"
+          if [[ -z "$subjects" ]]; then
             echo "::error::No release artifacts found to attest."
             exit 1
           fi
           {
             echo "subjects<<EOF"
-            printf '%s\n' "${subjects[@]}"
+            printf '%s\n' "$subjects"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+- Release workflow attestation subject collection now avoids Bash-4-only `mapfile`, so macOS runners can finish artifact attestation after GoReleaser publishes a release.
+
 ## [0.24.0] - 2026-04-15
 ### Added
 - `bkt pr comments --details` now shows file:line context, resolved/complete status, full comment text, and nested reply indentation for Bitbucket Data Center pull request threads (#110).


### PR DESCRIPTION
Fix the late-stage release failure we hit on v0.24.0.

The attestation-subject collection step used \, but the macOS runner image still ships Bash 3.2, so the workflow failed after GoReleaser had already published the release artifacts. Switch that step to a Bash-3-compatible newline-preserving capture and add the matching changelog note for the fix-forward patch release.

This is the prerequisite for cutting a clean v0.24.1 release.