### PR TITLE
chore(release): v0.25.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented here. The format follows
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-04-16
+
 ## [0.24.1] - 2026-04-15
 ### Fixed
 - Release workflow attestation subject collection now avoids Bash-4-only `mapfile`, so macOS runners can finish artifact attestation after GoReleaser publishes a release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented here. The format follows
 ## [Unreleased]
 
 ## [0.25.0] - 2026-04-16
+### Added
+- `bkt pr decline` now accepts `--comment` / `-m`, plus `--text` and `--body` aliases, to send a decline reason on Bitbucket Cloud and Data Center (#161).
+- Nix flake support for running and installing `bkt` via `nix run` / `nix profile install`, with CI validation on Linux and macOS (#165).
 
 ## [0.24.1] - 2026-04-15
 ### Fixed

--- a/skills/bkt/SKILL.md
+++ b/skills/bkt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bkt
-version: 0.24.1
+version: 0.25.0
 description: Bitbucket CLI for Data Center and Cloud. Use when users need to manage repositories, pull requests, branches, issues, webhooks, or pipelines in Bitbucket. Triggers include "bitbucket", "bkt", "pull request", "PR", "repo list", "branch create", "Bitbucket Data Center", "Bitbucket Cloud", "keyring timeout".
 metadata:
   short-description: Bitbucket CLI for repos, PRs, branches


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.25.0`
- aligns skill/plugin metadata to `0.25.0`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.25.0`, publishes the release, and publishes skills in the same workflow run