### PR TITLE
chore(release): v0.26.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ All notable changes to this project will be documented here. The format follows
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-04-18
 ### Added
 - `bkt pr close` as an alias for `bkt pr decline`, matching `gh`-style command expectations (#160).
 - `--destination` as a visible alias for `--target` on `bkt pr create`, mutually exclusive with `--target` (#160).
 - Global `--format json|yaml` flag as an alternative to `--json` / `--yaml`; validated before any mutating subcommand runs (#160).
+
 
 ## [0.25.0] - 2026-04-16
 ### Added

--- a/skills/bkt/SKILL.md
+++ b/skills/bkt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bkt
-version: 0.25.0
+version: 0.26.0
 description: Bitbucket CLI for Data Center and Cloud. Use when users need to manage repositories, pull requests, branches, issues, webhooks, or pipelines in Bitbucket. Triggers include "bitbucket", "bkt", "pull request", "PR", "repo list", "branch create", "Bitbucket Data Center", "Bitbucket Cloud", "keyring timeout".
 metadata:
   short-description: Bitbucket CLI for repos, PRs, branches


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.26.0`
- aligns skill/plugin metadata to `0.26.0`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.26.0`, publishes the release, and publishes skills in the same workflow run