### PR TITLE
fix(auth): clarify Bitbucket Cloud token auth failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+- Bitbucket Cloud 401 auth failures now explain the most common API-token misconfigurations, including the required Atlassian-account email username and `read:user:bitbucket` scope.
+
 ## [0.26.0] - 2026-04-18
 ### Added
 - `bkt pr close` as an alias for `bkt pr decline`, matching `gh`-style command expectations (#160).

--- a/pkg/httpx/client.go
+++ b/pkg/httpx/client.go
@@ -401,12 +401,20 @@ func decodeError(resp *http.Response) error {
 	type apiErr struct {
 		Errors []apiErrEntry `json:"errors"`
 	}
+	type cloudAPIError struct {
+		Type  string `json:"type"`
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
 
 	var payload apiErr
+	var cloudPayload cloudAPIError
 	data, err := io.ReadAll(resp.Body)
 	if err == nil && len(data) > 0 {
 		// Attempt to parse structured error; intentionally ignore unmarshal errors and fall back to raw text
 		_ = json.Unmarshal(data, &payload)
+		_ = json.Unmarshal(data, &cloudPayload)
 	}
 
 	if len(payload.Errors) > 0 {
@@ -424,7 +432,12 @@ func decodeError(resp *http.Response) error {
 		if isCaptchaException(bestErr.ExceptionName) && !strings.Contains(strings.ToLower(msg), "captcha") {
 			msg = "CAPTCHA verification required: " + msg
 		}
+		msg = withBitbucketCloudAuthHint(msg)
 		return fmt.Errorf("%s: %s", resp.Status, msg)
+	}
+
+	if msg := strings.TrimSpace(cloudPayload.Error.Message); msg != "" {
+		return fmt.Errorf("%s: %s", resp.Status, withBitbucketCloudAuthHint(msg))
 	}
 
 	if err == nil && len(data) > 0 {
@@ -437,6 +450,18 @@ func decodeError(resp *http.Response) error {
 // isCaptchaException checks if the exception name indicates a CAPTCHA-locked account.
 func isCaptchaException(exceptionName string) bool {
 	return strings.Contains(strings.ToLower(exceptionName), "captcharequired")
+}
+
+func withBitbucketCloudAuthHint(msg string) string {
+	lower := strings.ToLower(msg)
+	if !strings.Contains(lower, "token is invalid, expired, or not supported for this endpoint") &&
+		!strings.Contains(lower, "this api is not accessible by this authentication mechanism") {
+		return msg
+	}
+	if strings.Contains(lower, "read:user:bitbucket") || strings.Contains(lower, "atlassian account email") {
+		return msg
+	}
+	return msg + " Hint: for Bitbucket Cloud API tokens, set BKT_USERNAME to your Atlassian account email and include the read:user:bitbucket scope."
 }
 
 func cloneRequest(req *http.Request) (*http.Request, error) {

--- a/pkg/httpx/client_test.go
+++ b/pkg/httpx/client_test.go
@@ -445,6 +445,41 @@ func TestDecodeErrorStructuredMessage(t *testing.T) {
 	}
 }
 
+func TestDecodeErrorBitbucketCloudTokenHint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"type": "error",
+			"error": map[string]any{
+				"message": "Token is invalid, expired, or not supported for this endpoint.",
+			},
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{BaseURL: server.URL, Retry: RetryPolicy{MaxAttempts: 1}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "/api", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	err = client.Do(req, nil)
+	if err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+	if !strings.Contains(err.Error(), "read:user:bitbucket") {
+		t.Fatalf("expected Bitbucket Cloud auth hint, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "Atlassian account email") {
+		t.Fatalf("expected username hint, got %v", err)
+	}
+}
+
 func TestDecodeErrorPlainText(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")


### PR DESCRIPTION
## Summary
- decode Bitbucket Cloud's nested auth error payloads
- add an actionable hint for the common scoped API token misconfigurations
- cover the 401 case with a regression test
- record the fix in the changelog

## Testing
- go test ./pkg/httpx ./pkg/cmdutil ./pkg/bbcloud ./pkg/cmd/auth ./pkg/cmd/pr

Refs #174

Review pending via peer check.