### PR TITLE
chore(nix): add vendorHash refresh helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ LDFLAGS := -s -w \
 	-X github.com/avivsinai/bitbucket-cli/pkg/oauth.cloudClientID=$(BKT_OAUTH_CLIENT_ID) \
 	-X github.com/avivsinai/bitbucket-cli/pkg/oauth.cloudClientSecret=$(BKT_OAUTH_CLIENT_SECRET)
 
-.PHONY: build fmt lint test tidy sbom release snapshot clean check-skills check-generated-skill release-local generate-skill
+.PHONY: build fmt lint test tidy sbom release snapshot clean check-skills check-generated-skill release-local generate-skill nix-update-vendor-hash
 
 build: $(BIN_DIR)/bkt
 
@@ -80,6 +80,9 @@ generate-skill:
 
 check-generated-skill:
 	@GO="$(GO)" ./scripts/check-generated-skill.sh
+
+nix-update-vendor-hash:
+	./scripts/update-nix-vendor-hash.sh
 
 release:
 	@test -n "$(RELEASE_VERSION)" || (echo "usage: make release RELEASE_VERSION=X.Y.Z [RELEASE_DATE=YYYY-MM-DD] [RELEASE_SKIP_VERIFY=1] [RELEASE_ALLOW_EMPTY=1] [RELEASE_NO_AUTO_MERGE=1]" && exit 1)

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -35,6 +35,7 @@
 ## Guardrails
 
 - Treat `scripts/release.sh` as the only supported release entrypoint.
+- Refresh `flake.nix`'s `vendorHash` whenever `go.mod` or `go.sum` changes; do not wait until release time because Nix CI runs on pull requests. Use `make nix-update-vendor-hash` after dependency bumps.
 - `scripts/check-release-version.sh vX.Y.Z` now validates both metadata versions and the matching `CHANGELOG.md` heading.
 - If a release PR merges but the tag publish fails verification, fix forward with the next patch version instead of rewriting the failed tag.
 

--- a/scripts/update-nix-vendor-hash.sh
+++ b/scripts/update-nix-vendor-hash.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/update-nix-vendor-hash.sh [flake-file] [build-target]
+
+Refreshes buildGoModule's vendorHash by temporarily using pkgs.lib.fakeHash,
+running a Nix build, and replacing the hash with the value reported by Nix.
+
+Examples:
+  ./scripts/update-nix-vendor-hash.sh
+  ./scripts/update-nix-vendor-hash.sh flake.nix .#default
+EOF
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+flake_file="${1:-flake.nix}"
+build_target="${2:-.#default}"
+
+case "${flake_file}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+esac
+
+require_command nix
+require_command python3
+
+[ -f "$flake_file" ] || {
+  echo "error: flake file not found: $flake_file" >&2
+  exit 1
+}
+
+backup_file="$(mktemp)"
+log_file="$(mktemp)"
+keep_changes=0
+
+cleanup() {
+  if [ "$keep_changes" -eq 0 ] && [ -f "$backup_file" ]; then
+    cp "$backup_file" "$flake_file"
+  fi
+  rm -f "$backup_file" "$log_file"
+}
+
+trap cleanup EXIT
+
+cp "$flake_file" "$backup_file"
+
+python3 - "$flake_file" <<'PY'
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+pattern = re.compile(r'vendorHash\s*=\s*(?:"[^"]*"|pkgs\.lib\.fakeHash|lib\.fakeHash|null);')
+replacement = "vendorHash = pkgs.lib.fakeHash;"
+updated, count = pattern.subn(replacement, text, count=1)
+if count != 1:
+    raise SystemExit(f"error: expected exactly one vendorHash assignment in {path}")
+path.write_text(updated, encoding="utf-8")
+PY
+
+if nix build "$build_target" --no-link --print-build-logs >"$log_file" 2>&1; then
+  echo "error: nix build unexpectedly succeeded; vendorHash was not refreshed" >&2
+  exit 1
+fi
+
+new_hash="$(
+  sed -n 's/.*got:[[:space:]]*\(sha256-[A-Za-z0-9+/=]*\).*/\1/p' "$log_file" | tail -n 1
+)"
+
+[ -n "$new_hash" ] || {
+  cat "$log_file" >&2
+  echo "error: could not extract vendorHash from nix build output" >&2
+  exit 1
+}
+
+python3 - "$flake_file" "$new_hash" <<'PY'
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+new_hash = sys.argv[2]
+text = path.read_text(encoding="utf-8")
+pattern = re.compile(r'vendorHash\s*=\s*(?:"[^"]*"|pkgs\.lib\.fakeHash|lib\.fakeHash|null);')
+replacement = f'vendorHash = "{new_hash}";'
+updated, count = pattern.subn(replacement, text, count=1)
+if count != 1:
+    raise SystemExit(f"error: expected exactly one vendorHash assignment in {path}")
+path.write_text(updated, encoding="utf-8")
+PY
+
+keep_changes=1
+echo "Updated $flake_file vendorHash to $new_hash"


### PR DESCRIPTION
## Summary
- add `scripts/update-nix-vendor-hash.sh` to refresh `flake.nix`'s `vendorHash` from Nix output
- add `make nix-update-vendor-hash` as the maintainer entrypoint
- document that Go dependency bumps must refresh `vendorHash` before merge, not at release time

## Testing
- `bash -n scripts/update-nix-vendor-hash.sh`
- exercised the script against a mocked `nix` failure that emitted the standard `got: sha256-...` line and verified that it rewrote a sample `flake.nix` correctly

Refs #172

Review pending via peer check.