### PR TITLE
fix(auth): narrow Cloud token hint classification

### DIFF
--- a/pkg/httpx/client.go
+++ b/pkg/httpx/client.go
@@ -454,8 +454,7 @@ func isCaptchaException(exceptionName string) bool {
 
 func withBitbucketCloudAuthHint(msg string) string {
 	lower := strings.ToLower(msg)
-	if !strings.Contains(lower, "token is invalid, expired, or not supported for this endpoint") &&
-		!strings.Contains(lower, "this api is not accessible by this authentication mechanism") {
+	if !strings.Contains(lower, "token is invalid, expired, or not supported for this endpoint") {
 		return msg
 	}
 	if strings.Contains(lower, "read:user:bitbucket") || strings.Contains(lower, "atlassian account email") {

--- a/pkg/httpx/client_test.go
+++ b/pkg/httpx/client_test.go
@@ -480,6 +480,41 @@ func TestDecodeErrorBitbucketCloudTokenHint(t *testing.T) {
 	}
 }
 
+func TestDecodeErrorBitbucketCloudAuthMechanismMessageHasNoTokenHint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"type": "error",
+			"error": map[string]any{
+				"message": "This API is not accessible by this authentication mechanism",
+			},
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{BaseURL: server.URL, Retry: RetryPolicy{MaxAttempts: 1}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "/api", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	err = client.Do(req, nil)
+	if err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+	if strings.Contains(err.Error(), "read:user:bitbucket") {
+		t.Fatalf("expected auth mechanism error without token hint, got %v", err)
+	}
+	if strings.Contains(err.Error(), "Atlassian account email") {
+		t.Fatalf("expected auth mechanism error without username hint, got %v", err)
+	}
+}
+
 func TestDecodeErrorPlainText(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")


### PR DESCRIPTION
## Summary
- limit the Bitbucket Cloud token hint to the specific invalid-token error that motivated #174
- leave the broader authentication-mechanism error unchanged
- add a regression test covering the non-token message

## Testing
- `go test ./pkg/httpx ./pkg/cmdutil ./pkg/bbcloud ./pkg/cmd/auth ./pkg/cmd/pr`

Refs #174