### PR TITLE
feat(release): bundle skills in archive downloads

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -47,6 +47,7 @@ archives:
       - README.md
       - LICENSE
       - CHANGELOG.md
+      - skills/**/*
     format_overrides:
       - goos: windows
         format: zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+- Release `.tar.gz` and `.zip` archives now bundle `skills/bkt/` alongside the CLI binary and docs.
+
 ### Fixed
 - Bitbucket Cloud 401 auth failures now explain the most common API-token misconfigurations, including the required Atlassian-account email username and `read:user:bitbucket` scope.
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Don't have Nix yet? See [nixos.asia/en/install](https://nixos.asia/en/install) f
 ### Binary Downloads
 
 Download pre-built binaries for your platform from the [releases page](https://github.com/avivsinai/bitbucket-cli/releases/latest).
+The `.tar.gz` and `.zip` release archives also include `skills/bkt/`, so the CLI and canonical skill files stay in sync when you install from a release artifact.
 
 ### Bitbucket Pipelines
 


### PR DESCRIPTION
## Summary
- add `skills/**/*` to the GoReleaser archive payloads
- document that release `.tar.gz` and `.zip` archives include `skills/bkt/`
- record the archive packaging change in the changelog

## Scope
- includes GitHub release archives only (`.tar.gz` and `.zip`)
- does not change `.deb`, Homebrew, or Scoop installs

## Testing
- `BKT_OAUTH_CLIENT_ID= BKT_OAUTH_CLIENT_SECRET= goreleaser release --snapshot --clean --skip=homebrew,scoop,nfpm,sbom,sign`\n- verified the generated linux tarball and windows zip both contain `skills/bkt/`\n\nFixes #173