### PR TITLE
fix(release): harden cloud validation and metadata

### DIFF
--- a/.github/workflows/publish-skill.yml
+++ b/.github/workflows/publish-skill.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to publish (e.g. v0.14.2)'
+        description: 'Tag to publish (e.g. v1.2.3)'
         required: true
         type: string
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Existing tag to (re)release (e.g. v0.14.4)'
+        description: 'Existing tag to (re)release (e.g. v1.2.3)'
         required: true
         type: string
       skip-skill-publish:
@@ -149,9 +149,6 @@ jobs:
         run: make test
       - name: Build CLI
         run: VERSION=${{ needs.prepare.outputs.tag }} make build
-        env:
-          BKT_OAUTH_CLIENT_ID: ${{ secrets.BKT_OAUTH_CLIENT_ID }}
-          BKT_OAUTH_CLIENT_SECRET: ${{ secrets.BKT_OAUTH_CLIENT_SECRET }}
       - name: Check embedded version
         run: ./bin/bkt --version | grep -Fx "bkt version ${{ needs.prepare.outputs.tag }}"
 
@@ -224,16 +221,6 @@ jobs:
           output_path.write_text(match.group(0).strip() + "\n", encoding="utf-8")
           PY
 
-      - name: Validate OAuth secrets
-        env:
-          BKT_OAUTH_CLIENT_ID: ${{ secrets.BKT_OAUTH_CLIENT_ID }}
-          BKT_OAUTH_CLIENT_SECRET: ${{ secrets.BKT_OAUTH_CLIENT_SECRET }}
-        run: |
-          if [ -z "$BKT_OAUTH_CLIENT_ID" ] || [ -z "$BKT_OAUTH_CLIENT_SECRET" ]; then
-            echo "::error::BKT_OAUTH_CLIENT_ID and BKT_OAUTH_CLIENT_SECRET must be set as repository secrets"
-            exit 1
-          fi
-
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
         with:
@@ -243,8 +230,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
-          BKT_OAUTH_CLIENT_ID: ${{ secrets.BKT_OAUTH_CLIENT_ID }}
-          BKT_OAUTH_CLIENT_SECRET: ${{ secrets.BKT_OAUTH_CLIENT_SECRET }}
 
       - name: Collect attestation subjects
         id: attestation_subjects

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,8 +24,6 @@ builds:
       - -X github.com/avivsinai/bitbucket-cli/internal/build.versionFromLdflags={{.Version}}
       - -X github.com/avivsinai/bitbucket-cli/internal/build.commitFromLdflags={{.Commit}}
       - -X github.com/avivsinai/bitbucket-cli/internal/build.dateFromLdflags={{.Date}}
-      - -X github.com/avivsinai/bitbucket-cli/pkg/oauth.cloudClientID={{ .Env.BKT_OAUTH_CLIENT_ID }}
-      - -X github.com/avivsinai/bitbucket-cli/pkg/oauth.cloudClientSecret={{ .Env.BKT_OAUTH_CLIENT_SECRET }}
     mod_timestamp: '{{ .CommitTimestamp }}'
     hooks:
       post:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -454,7 +454,33 @@ All notable changes to this project will be documented here. The format follows
 ## [0.1.0] - 2025-10-26
 - Initial public release of `bkt`.
 
-[Unreleased]: https://github.com/avivsinai/bitbucket-cli/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.0...HEAD
+[0.26.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.25.0...v0.26.0
+[0.25.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.24.1...v0.25.0
+[0.24.1]: https://github.com/avivsinai/bitbucket-cli/compare/v0.24.0...v0.24.1
+[0.24.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.23.0...v0.24.0
+[0.23.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.22.0...v0.23.0
+[0.22.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.21.0...v0.22.0
+[0.21.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.20.0...v0.21.0
+[0.20.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.19.0...v0.20.0
+[0.19.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.18.0...v0.19.0
+[0.18.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.17.0...v0.18.0
+[0.17.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.16.4...v0.17.0
+[0.16.4]: https://github.com/avivsinai/bitbucket-cli/compare/v0.16.3...v0.16.4
+[0.16.3]: https://github.com/avivsinai/bitbucket-cli/compare/v0.16.2...v0.16.3
+[0.16.2]: https://github.com/avivsinai/bitbucket-cli/compare/v0.16.1...v0.16.2
+[0.16.1]: https://github.com/avivsinai/bitbucket-cli/compare/v0.15.0...v0.16.1
+[0.15.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.14.7...v0.15.0
+[0.14.7]: https://github.com/avivsinai/bitbucket-cli/compare/v0.14.6...v0.14.7
+[0.14.6]: https://github.com/avivsinai/bitbucket-cli/compare/v0.14.5...v0.14.6
+[0.14.5]: https://github.com/avivsinai/bitbucket-cli/compare/v0.14.4...v0.14.5
+[0.14.4]: https://github.com/avivsinai/bitbucket-cli/compare/v0.14.3...v0.14.4
+[0.14.3]: https://github.com/avivsinai/bitbucket-cli/compare/v0.14.2...v0.14.3
+[0.14.2]: https://github.com/avivsinai/bitbucket-cli/compare/v0.14.1...v0.14.2
+[0.14.1]: https://github.com/avivsinai/bitbucket-cli/compare/v0.14.0...v0.14.1
+[0.14.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.13.1...v0.14.0
+[0.13.1]: https://github.com/avivsinai/bitbucket-cli/compare/v0.13.0...v0.13.1
+[0.13.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/avivsinai/bitbucket-cli/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.10.0...v0.11.0

--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,10 @@ VERSION ?= $(shell \
 )
 COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
 BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
-BKT_OAUTH_CLIENT_ID ?=
-BKT_OAUTH_CLIENT_SECRET ?=
 LDFLAGS := -s -w \
 	-X github.com/avivsinai/bitbucket-cli/internal/build.versionFromLdflags=$(VERSION) \
 	-X github.com/avivsinai/bitbucket-cli/internal/build.commitFromLdflags=$(COMMIT) \
-	-X github.com/avivsinai/bitbucket-cli/internal/build.dateFromLdflags=$(BUILD_DATE) \
-	-X github.com/avivsinai/bitbucket-cli/pkg/oauth.cloudClientID=$(BKT_OAUTH_CLIENT_ID) \
-	-X github.com/avivsinai/bitbucket-cli/pkg/oauth.cloudClientSecret=$(BKT_OAUTH_CLIENT_SECRET)
+	-X github.com/avivsinai/bitbucket-cli/internal/build.dateFromLdflags=$(BUILD_DATE)
 
 .PHONY: build fmt lint test tidy sbom release snapshot clean check-skills check-generated-skill release-local generate-skill nix-update-vendor-hash
 

--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ nix profile install github:avivsinai/bitbucket-cli
 
 Pin to a specific tag or commit by appending a ref (e.g. `github:avivsinai/bitbucket-cli/v1.2.3`).
 
-> **Note:** The Nix package does not embed OAuth client credentials. For Bitbucket Cloud OAuth (`bkt auth login --kind cloud --web`), set `BKT_OAUTH_CLIENT_ID` and `BKT_OAUTH_CLIENT_SECRET` in your environment.
-
 Don't have Nix yet? See [nixos.asia/en/install](https://nixos.asia/en/install) for a quick setup guide (installs Nix with flakes enabled out of the box).
 
 ### Binary Downloads
 
 Download pre-built binaries for your platform from the [releases page](https://github.com/avivsinai/bitbucket-cli/releases/latest).
 The `.tar.gz` and `.zip` release archives also include `skills/bkt/`, so the CLI and canonical skill files stay in sync when you install from a release artifact.
+
+For Bitbucket Cloud OAuth (`bkt auth login --kind cloud --web`), set `BKT_OAUTH_CLIENT_ID` and `BKT_OAUTH_CLIENT_SECRET` in your environment. Official binaries, source installs, and Nix builds do not embed Cloud OAuth consumer credentials. API-token login via `--web-token` works without that extra setup.
 
 ### Bitbucket Pipelines
 
@@ -72,7 +72,7 @@ pipelines:
     - step:
         name: Open PR
         script:
-          - export BKT_VERSION="0.19.0"  # pin to a specific release
+          - export BKT_VERSION="0.26.0"  # pin to a released version
           - curl -sL "https://github.com/avivsinai/bitbucket-cli/releases/download/v${BKT_VERSION}/bkt_${BKT_VERSION}_linux_x86_64.tar.gz" | tar xz -C /tmp && install /tmp/bkt /usr/local/bin/
           - bkt pr create --title "Auto PR" --source "$BITBUCKET_BRANCH"
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,10 +4,10 @@
 
 | Version | Supported |
 | ------- | --------- |
-| main    | ✅        |
+| master  | ✅        |
 | tags    | ✅        |
 
-We support the latest release and the `main` branch. Older tags are archived as
+We support the latest release and the `master` branch. Older tags are archived as
 read-only snapshots.
 
 ## Reporting a vulnerability

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -55,6 +55,7 @@ pipelines:
           image: alpine:3.21
           script:
             - apk add --no-cache curl
-            - curl -sL https://github.com/avivsinai/bitbucket-cli/releases/download/v0.16.4/bkt_0.16.4_linux_x86_64.tar.gz | tar xz -C /tmp && install /tmp/bkt /usr/local/bin/
+            - export BKT_VERSION="0.26.0"
+            - curl -sL "https://github.com/avivsinai/bitbucket-cli/releases/download/v${BKT_VERSION}/bkt_${BKT_VERSION}_linux_x86_64.tar.gz" | tar xz -C /tmp && install /tmp/bkt /usr/local/bin/
             - bkt --version
             - bkt --help

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -35,6 +35,9 @@
 ## Guardrails
 
 - Treat `scripts/release.sh` as the only supported release entrypoint.
+- Release artifacts must not embed Bitbucket Cloud OAuth consumer credentials.
+  Cloud OAuth is env-driven at runtime (`BKT_OAUTH_CLIENT_ID` /
+  `BKT_OAUTH_CLIENT_SECRET`) and API-token login remains the zero-config path.
 - Refresh `flake.nix`'s `vendorHash` whenever `go.mod` or `go.sum` changes; do not wait until release time because Nix CI runs on pull requests. Use `make nix-update-vendor-hash` after dependency bumps.
 - `scripts/check-release-version.sh vX.Y.Z` now validates both metadata versions and the matching `CHANGELOG.md` heading.
 - If a release PR merges but the tag publish fails verification, fix forward with the next patch version instead of rewriting the failed tag.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -10,6 +10,10 @@ implementation details.
   Linux Secret Service) or an encrypted local file backend. Host metadata lives
   in `$XDG_CONFIG_HOME/bkt/config.yml` with permissions `0600`. The `BKT_TOKEN`
   environment variable provides runtime-only injection for CI/headless use.
+- Bitbucket Cloud OAuth consumer credentials are runtime-only too. Set
+  `BKT_OAUTH_CLIENT_ID` and `BKT_OAUTH_CLIENT_SECRET` in the environment when
+  using `bkt auth login --kind cloud --web`; release artifacts never bake them
+  into the binary.
 - For development, set `BKT_CONFIG_DIR` to a throwaway directory.
 - Never commit test credentials. Use environment variables or the
   `internal/config/testdata` fixtures when unit testing.

--- a/internal/remote/remote.go
+++ b/internal/remote/remote.go
@@ -106,14 +106,16 @@ func ListRemotes(repoPath string) (map[string][]string, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 
-	out, err := cmd.Output()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			return nil, ErrNoGitRemote
-		}
 		if errors.Is(err, exec.ErrNotFound) {
 			return nil, fmt.Errorf("git executable not found: %w", err)
+		}
+		if ctx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("git remote -v timed out after 30s")
+		}
+		if message := strings.TrimSpace(string(out)); message != "" {
+			return nil, fmt.Errorf("git remote -v: %s", message)
 		}
 		return nil, fmt.Errorf("git remote -v: %w", err)
 	}

--- a/internal/remote/remote_test.go
+++ b/internal/remote/remote_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 )
 
@@ -91,6 +92,21 @@ func TestDetectNoRemote(t *testing.T) {
 	_, err := Detect(dir)
 	if !errors.Is(err, ErrNoGitRemote) {
 		t.Fatalf("Detect() error = %v, want %v", err, ErrNoGitRemote)
+	}
+}
+
+func TestDetectNotGitRepoPreservesUnderlyingError(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := Detect(dir)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if errors.Is(err, ErrNoGitRemote) {
+		t.Fatalf("Detect() error = %v, did not want %v", err, ErrNoGitRemote)
+	}
+	if !strings.Contains(err.Error(), "git remote -v:") {
+		t.Fatalf("error = %q, want git remote context", err)
 	}
 }
 

--- a/pkg/bbcloud/bbql.go
+++ b/pkg/bbcloud/bbql.go
@@ -1,0 +1,17 @@
+package bbcloud
+
+import "strings"
+
+var bbqlStringEscaper = strings.NewReplacer(`\`, `\\`, `"`, `\"`)
+
+func bbqlStringLiteral(value string) string {
+	return `"` + bbqlStringEscaper.Replace(value) + `"`
+}
+
+func bbqlEquals(field, value string) string {
+	return field + " = " + bbqlStringLiteral(value)
+}
+
+func bbqlContains(field, value string) string {
+	return field + " ~ " + bbqlStringLiteral(value)
+}

--- a/pkg/bbcloud/branches.go
+++ b/pkg/bbcloud/branches.go
@@ -47,8 +47,8 @@ func (c *Client) ListBranches(ctx context.Context, workspace, repoSlug string, o
 
 	var params []string
 	params = append(params, fmt.Sprintf("pagelen=%d", pageLen))
-	if strings.TrimSpace(opts.Filter) != "" {
-		params = append(params, "q="+url.QueryEscape(fmt.Sprintf("name ~ \"%s\"", opts.Filter)))
+	if filter := strings.TrimSpace(opts.Filter); filter != "" {
+		params = append(params, "q="+url.QueryEscape(bbqlContains("name", filter)))
 	}
 
 	path := fmt.Sprintf("/repositories/%s/%s/refs/branches?%s",

--- a/pkg/bbcloud/branches_test.go
+++ b/pkg/bbcloud/branches_test.go
@@ -1,0 +1,45 @@
+package bbcloud_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/bitbucket-cli/pkg/bbcloud"
+)
+
+func TestListBranchesEscapesBBQLFilter(t *testing.T) {
+	var capturedURL string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedURL = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"values": []map[string]any{}})
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := bbcloud.New(bbcloud.Options{BaseURL: server.URL, Username: "u", Token: "t"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_, err = client.ListBranches(context.Background(), "workspace", "repo", bbcloud.BranchListOptions{
+		Filter: `release "1"\draft`,
+	})
+	if err != nil {
+		t.Fatalf("ListBranches: %v", err)
+	}
+
+	parsedURL, err := url.Parse(capturedURL)
+	if err != nil {
+		t.Fatalf("Parse URL: %v", err)
+	}
+	rawQuery, _ := url.QueryUnescape(parsedURL.RawQuery)
+	if !strings.Contains(rawQuery, `q=name ~ "release \"1\"\\draft"`) {
+		t.Fatalf("raw query = %q", rawQuery)
+	}
+}

--- a/pkg/bbcloud/client.go
+++ b/pkg/bbcloud/client.go
@@ -139,10 +139,23 @@ type Pipeline struct {
 	CompletedOn string `json:"completed_on"`
 }
 
-// NormalizeUUID ensures a UUID has curly braces, as required by Bitbucket Cloud API.
+// NormalizeUUID wraps a canonical UUID in curly braces, as required by the
+// Bitbucket Cloud API. Invalid inputs return an empty string.
 func NormalizeUUID(uuid string) string {
+	uuid = strings.TrimSpace(uuid)
+	if !LooksLikeUUID(uuid) {
+		return ""
+	}
 	uuid = strings.Trim(uuid, "{}")
 	return "{" + uuid + "}"
+}
+
+func normalizeUUIDArg(label, value string) (string, error) {
+	normalized := NormalizeUUID(value)
+	if normalized == "" {
+		return "", fmt.Errorf("%s must be a canonical UUID", label)
+	}
+	return normalized, nil
 }
 
 // uuidPattern matches canonical UUIDs (8-4-4-4-12 hex segments), either bare
@@ -414,10 +427,18 @@ func (c *Client) TriggerPipeline(ctx context.Context, workspace, repoSlug string
 
 // GetPipeline fetches pipeline details.
 func (c *Client) GetPipeline(ctx context.Context, workspace, repoSlug, uuid string) (*Pipeline, error) {
+	if workspace == "" || repoSlug == "" {
+		return nil, fmt.Errorf("workspace and repository slug are required")
+	}
+	pipelineUUID, err := normalizeUUIDArg("pipeline UUID", uuid)
+	if err != nil {
+		return nil, err
+	}
+
 	path := fmt.Sprintf("/repositories/%s/%s/pipelines/%s",
 		url.PathEscape(workspace),
 		url.PathEscape(repoSlug),
-		url.PathEscape(NormalizeUUID(uuid)),
+		url.PathEscape(pipelineUUID),
 	)
 	req, err := c.http.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
@@ -473,10 +494,18 @@ func (s PipelineStep) Status() string {
 
 // ListPipelineSteps enumerates step executions for the pipeline.
 func (c *Client) ListPipelineSteps(ctx context.Context, workspace, repoSlug, pipelineUUID string) ([]PipelineStep, error) {
+	if workspace == "" || repoSlug == "" {
+		return nil, fmt.Errorf("workspace and repository slug are required")
+	}
+	normalizedPipelineUUID, err := normalizeUUIDArg("pipeline UUID", pipelineUUID)
+	if err != nil {
+		return nil, err
+	}
+
 	path := fmt.Sprintf("/repositories/%s/%s/pipelines/%s/steps/",
 		url.PathEscape(workspace),
 		url.PathEscape(repoSlug),
-		url.PathEscape(NormalizeUUID(pipelineUUID)),
+		url.PathEscape(normalizedPipelineUUID),
 	)
 	req, err := c.http.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
@@ -505,11 +534,23 @@ type CommitStatus = types.CommitStatus
 
 // GetPipelineLogs fetches logs for a pipeline step.
 func (c *Client) GetPipelineLogs(ctx context.Context, workspace, repoSlug, pipelineUUID, stepUUID string) ([]byte, error) {
+	if workspace == "" || repoSlug == "" {
+		return nil, fmt.Errorf("workspace and repository slug are required")
+	}
+	normalizedPipelineUUID, err := normalizeUUIDArg("pipeline UUID", pipelineUUID)
+	if err != nil {
+		return nil, err
+	}
+	normalizedStepUUID, err := normalizeUUIDArg("step UUID", stepUUID)
+	if err != nil {
+		return nil, err
+	}
+
 	path := fmt.Sprintf("/repositories/%s/%s/pipelines/%s/steps/%s/log",
 		url.PathEscape(workspace),
 		url.PathEscape(repoSlug),
-		url.PathEscape(NormalizeUUID(pipelineUUID)),
-		url.PathEscape(NormalizeUUID(stepUUID)),
+		url.PathEscape(normalizedPipelineUUID),
+		url.PathEscape(normalizedStepUUID),
 	)
 
 	req, err := c.http.NewRequest(ctx, "GET", path, nil)

--- a/pkg/bbcloud/client_test.go
+++ b/pkg/bbcloud/client_test.go
@@ -354,12 +354,16 @@ func TestNormalizeUUID(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{"abc-123", "{abc-123}"},
-		{"{abc-123}", "{abc-123}"},
-		{"abc-123}", "{abc-123}"},
-		{"{abc-123", "{abc-123}"},
-		{"{}", "{}"},
-		{"", "{}"},
+		{"550e8400-e29b-41d4-a716-446655440000", "{550e8400-e29b-41d4-a716-446655440000}"},
+		{"{550e8400-e29b-41d4-a716-446655440000}", "{550e8400-e29b-41d4-a716-446655440000}"},
+		{" 550e8400-e29b-41d4-a716-446655440000 ", "{550e8400-e29b-41d4-a716-446655440000}"},
+		{"550E8400-E29B-41D4-A716-446655440000", "{550E8400-E29B-41D4-A716-446655440000}"},
+		{"abc-123", ""},
+		{"{abc-123}", ""},
+		{"abc-123}", ""},
+		{"{abc-123", ""},
+		{"{}", ""},
+		{"", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
@@ -694,41 +698,43 @@ func TestTriggerPipelineValidation(t *testing.T) {
 }
 
 func TestGetPipelineNormalizesUUID(t *testing.T) {
+	const pipelineUUID = "{550e8400-e29b-41d4-a716-446655440000}"
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// normalizeUUID wraps the UUID in braces; verify they appear in the path
-		if !strings.Contains(r.URL.Path, "{abc-123}") {
+		if !strings.Contains(r.URL.Path, pipelineUUID) {
 			t.Errorf("expected normalized UUID in path, got: %s", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(Pipeline{UUID: "{abc-123}"})
+		_ = json.NewEncoder(w).Encode(Pipeline{UUID: pipelineUUID})
 	})
 
 	client := newTestClient(t, handler)
-	pipeline, err := client.GetPipeline(context.Background(), "ws", "repo", "{abc-123}")
+	pipeline, err := client.GetPipeline(context.Background(), "ws", "repo", "550e8400-e29b-41d4-a716-446655440000")
 	if err != nil {
 		t.Fatalf("GetPipeline: %v", err)
 	}
-	if pipeline.UUID != "{abc-123}" {
+	if pipeline.UUID != pipelineUUID {
 		t.Fatalf("expected UUID preserved in response, got %q", pipeline.UUID)
 	}
 }
 
 func TestListPipelineStepsNormalizesUUID(t *testing.T) {
+	const pipelineUUID = "{550e8400-e29b-41d4-a716-446655440000}"
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// normalizeUUID wraps the UUID in braces; verify they appear in the path
-		if !strings.Contains(r.URL.Path, "{pipeline-uuid}") {
+		if !strings.Contains(r.URL.Path, pipelineUUID) {
 			t.Errorf("expected normalized UUID in path, got: %s", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"values": []map[string]any{
-				{"uuid": "{step-1}", "name": "Build"},
+				{"uuid": "{123e4567-e89b-12d3-a456-426614174000}", "name": "Build"},
 			},
 		})
 	})
 
 	client := newTestClient(t, handler)
-	steps, err := client.ListPipelineSteps(context.Background(), "ws", "repo", "{pipeline-uuid}")
+	steps, err := client.ListPipelineSteps(context.Background(), "ws", "repo", "550e8400-e29b-41d4-a716-446655440000")
 	if err != nil {
 		t.Fatalf("ListPipelineSteps: %v", err)
 	}
@@ -738,12 +744,14 @@ func TestListPipelineStepsNormalizesUUID(t *testing.T) {
 }
 
 func TestGetPipelineLogsNormalizesUUIDs(t *testing.T) {
+	const pipelineUUID = "{550e8400-e29b-41d4-a716-446655440000}"
+	const stepUUID = "{123e4567-e89b-12d3-a456-426614174000}"
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// normalizeUUID wraps UUIDs in braces; verify they appear in the path
-		if !strings.Contains(r.URL.Path, "{pipeline-uuid}") {
+		if !strings.Contains(r.URL.Path, pipelineUUID) {
 			t.Errorf("expected normalized pipeline UUID in path, got: %s", r.URL.Path)
 		}
-		if !strings.Contains(r.URL.Path, "{step-uuid}") {
+		if !strings.Contains(r.URL.Path, stepUUID) {
 			t.Errorf("expected normalized step UUID in path, got: %s", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "text/plain")
@@ -751,12 +759,69 @@ func TestGetPipelineLogsNormalizesUUIDs(t *testing.T) {
 	})
 
 	client := newTestClient(t, handler)
-	logs, err := client.GetPipelineLogs(context.Background(), "ws", "repo", "{pipeline-uuid}", "{step-uuid}")
+	logs, err := client.GetPipelineLogs(context.Background(), "ws", "repo", "550e8400-e29b-41d4-a716-446655440000", "123e4567-e89b-12d3-a456-426614174000")
 	if err != nil {
 		t.Fatalf("GetPipelineLogs: %v", err)
 	}
 	if string(logs) != "build output here" {
 		t.Fatalf("expected log content, got %q", string(logs))
+	}
+}
+
+func TestPipelineEndpointsRejectInvalidUUIDs(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected HTTP request to %s", r.URL.Path)
+	}))
+
+	tests := []struct {
+		name string
+		call func() error
+		want string
+	}{
+		{
+			name: "get pipeline",
+			call: func() error {
+				_, err := client.GetPipeline(context.Background(), "ws", "repo", "not-a-uuid")
+				return err
+			},
+			want: "pipeline UUID must be a canonical UUID",
+		},
+		{
+			name: "list pipeline steps",
+			call: func() error {
+				_, err := client.ListPipelineSteps(context.Background(), "ws", "repo", "not-a-uuid")
+				return err
+			},
+			want: "pipeline UUID must be a canonical UUID",
+		},
+		{
+			name: "get pipeline logs rejects pipeline UUID",
+			call: func() error {
+				_, err := client.GetPipelineLogs(context.Background(), "ws", "repo", "not-a-uuid", "123e4567-e89b-12d3-a456-426614174000")
+				return err
+			},
+			want: "pipeline UUID must be a canonical UUID",
+		},
+		{
+			name: "get pipeline logs rejects step UUID",
+			call: func() error {
+				_, err := client.GetPipelineLogs(context.Background(), "ws", "repo", "550e8400-e29b-41d4-a716-446655440000", "not-a-uuid")
+				return err
+			},
+			want: "step UUID must be a canonical UUID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.call()
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %q, want substring %q", err, tt.want)
+			}
+		})
 	}
 }
 

--- a/pkg/bbcloud/diffstat.go
+++ b/pkg/bbcloud/diffstat.go
@@ -54,7 +54,11 @@ func (c *Client) PullRequestDiffStat(ctx context.Context, workspace, repoSlug st
 
 	result := &DiffStatResult{}
 
-	for pageNum := 0; path != "" && pageNum < maxDiffStatPages; pageNum++ {
+	for pageNum := 0; path != ""; pageNum++ {
+		if pageNum >= maxDiffStatPages {
+			return nil, fmt.Errorf("diffstat pagination exceeded safety limit (%d pages)", maxDiffStatPages)
+		}
+
 		req, err := c.http.NewRequest(ctx, "GET", path, nil)
 		if err != nil {
 			return nil, err

--- a/pkg/bbcloud/diffstat_test.go
+++ b/pkg/bbcloud/diffstat_test.go
@@ -159,3 +159,46 @@ func TestPullRequestDiffStatPagination(t *testing.T) {
 		t.Errorf("expected 2 requests, got %d", hits)
 	}
 }
+
+func TestPullRequestDiffStatRejectsTruncatedResults(t *testing.T) {
+	var hits int32
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+
+		resp := map[string]any{
+			"values": []map[string]any{
+				{
+					"status":        "modified",
+					"lines_added":   1,
+					"lines_removed": 1,
+					"old":           map[string]string{"path": "file.go"},
+					"new":           map[string]string{"path": "file.go"},
+				},
+			},
+		}
+		if count <= 50 {
+			resp["next"] = serverURL + "/repositories/ws/repo/pullrequests/1/diffstat?page=overflow"
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	serverURL = server.URL
+	t.Cleanup(server.Close)
+
+	client, err := bbcloud.New(bbcloud.Options{BaseURL: server.URL, Username: "u", Token: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.PullRequestDiffStat(context.Background(), "ws", "repo", 1)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := err.Error(); got != "diffstat pagination exceeded safety limit (50 pages)" {
+		t.Fatalf("error = %q", got)
+	}
+	if hits != 50 {
+		t.Fatalf("expected 50 requests, got %d", hits)
+	}
+}

--- a/pkg/bbcloud/issues.go
+++ b/pkg/bbcloud/issues.go
@@ -130,22 +130,22 @@ func (c *Client) ListIssues(ctx context.Context, workspace, repoSlug string, opt
 	// Build BBQL query
 	var queryParts []string
 	if state := strings.TrimSpace(opts.State); state != "" && !strings.EqualFold(state, "all") {
-		queryParts = append(queryParts, fmt.Sprintf("state = \"%s\"", state))
+		queryParts = append(queryParts, bbqlEquals("state", state))
 	}
 	if kind := strings.TrimSpace(opts.Kind); kind != "" {
-		queryParts = append(queryParts, fmt.Sprintf("kind = \"%s\"", kind))
+		queryParts = append(queryParts, bbqlEquals("kind", kind))
 	}
 	if priority := strings.TrimSpace(opts.Priority); priority != "" {
-		queryParts = append(queryParts, fmt.Sprintf("priority = \"%s\"", priority))
+		queryParts = append(queryParts, bbqlEquals("priority", priority))
 	}
 	if assignee := strings.TrimSpace(opts.Assignee); assignee != "" {
-		queryParts = append(queryParts, fmt.Sprintf("assignee.uuid = \"%s\"", assignee))
+		queryParts = append(queryParts, bbqlEquals("assignee.uuid", assignee))
 	}
 	if reporter := strings.TrimSpace(opts.Reporter); reporter != "" {
-		queryParts = append(queryParts, fmt.Sprintf("reporter.uuid = \"%s\"", reporter))
+		queryParts = append(queryParts, bbqlEquals("reporter.uuid", reporter))
 	}
 	if milestone := strings.TrimSpace(opts.Milestone); milestone != "" {
-		queryParts = append(queryParts, fmt.Sprintf("milestone.name = \"%s\"", milestone))
+		queryParts = append(queryParts, bbqlEquals("milestone.name", milestone))
 	}
 	if opts.Query != "" {
 		queryParts = append(queryParts, opts.Query)

--- a/pkg/bbcloud/issues_test.go
+++ b/pkg/bbcloud/issues_test.go
@@ -75,6 +75,13 @@ func TestListIssuesBBQLQueryBuilding(t *testing.T) {
 			wantQueryParts: []string{`milestone.name = "v1.0"`},
 		},
 		{
+			name: "escapes quoted BBQL values",
+			opts: IssueListOptions{
+				Milestone: `release "1"\draft`,
+			},
+			wantQueryParts: []string{`milestone.name = "release \"1\"\\draft"`},
+		},
+		{
 			name: "multiple filters combined with AND",
 			opts: IssueListOptions{
 				State:    "open",

--- a/pkg/bbcloud/pullrequests.go
+++ b/pkg/bbcloud/pullrequests.go
@@ -94,8 +94,8 @@ func (c *Client) ListPullRequests(ctx context.Context, workspace, repoSlug strin
 	if state := strings.TrimSpace(opts.State); state != "" && !strings.EqualFold(state, "all") {
 		params = append(params, "state="+url.QueryEscape(strings.ToUpper(state)))
 	}
-	if opts.Mine != "" {
-		params = append(params, "q="+url.QueryEscape(fmt.Sprintf("author.username=\"%s\"", opts.Mine)))
+	if mine := strings.TrimSpace(opts.Mine); mine != "" {
+		params = append(params, "q="+url.QueryEscape(bbqlEquals("author.username", mine)))
 	}
 
 	path := fmt.Sprintf("/repositories/%s/%s/pullrequests?%s",

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -81,14 +81,12 @@ For Data Center (--kind dc, the default), you authenticate with a Personal
 Access Token (PAT). The token needs Repository Read/Write and Project Read
 permissions. Use --web-token to open the PAT management page in your browser.
 
-For Bitbucket Cloud (--kind cloud), the recommended method is --web, which
-uses OAuth 2.0 to authenticate in the browser. The CLI receives a short-lived
-access token that is automatically refreshed. Alternatively, use --web-token
-to create an Atlassian API token manually.
-
-OAuth credentials are embedded at build time via ldflags. For source installs
-(go install), set BKT_OAUTH_CLIENT_ID and BKT_OAUTH_CLIENT_SECRET environment
-variables before running --web.
+For Bitbucket Cloud (--kind cloud), the simplest method is --web-token, which
+opens the Atlassian API token page and prompts for the token locally. If you
+prefer browser-based OAuth, use --web with BKT_OAUTH_CLIENT_ID and
+BKT_OAUTH_CLIENT_SECRET set in your environment. The CLI receives a short-lived
+access token that is automatically refreshed while those environment variables
+remain available.
 
 Credentials are verified against the remote host before being stored. If no
 OS keychain is available, pass --allow-insecure-store to use encrypted file
@@ -318,7 +316,7 @@ func runLogin(cmd *cobra.Command, f *cmdutil.Factory, opts *loginOptions) error 
 		if opts.Web {
 			// OAuth 2.0 browser-based flow.
 			if oauth.CloudClientID() == "" || oauth.CloudClientSecret() == "" {
-				return fmt.Errorf("OAuth credentials were not embedded in this build; rebuild with BKT_OAUTH_CLIENT_ID and BKT_OAUTH_CLIENT_SECRET or use --web-token for API token login")
+				return fmt.Errorf("Cloud OAuth requires BKT_OAUTH_CLIENT_ID and BKT_OAUTH_CLIENT_SECRET in the environment; use --web-token for API token login")
 			}
 			if _, err := fmt.Fprintln(ios.Out, "Authenticating with Bitbucket Cloud via OAuth..."); err != nil {
 				return err

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -316,7 +316,7 @@ func runLogin(cmd *cobra.Command, f *cmdutil.Factory, opts *loginOptions) error 
 		if opts.Web {
 			// OAuth 2.0 browser-based flow.
 			if oauth.CloudClientID() == "" || oauth.CloudClientSecret() == "" {
-				return fmt.Errorf("Cloud OAuth requires BKT_OAUTH_CLIENT_ID and BKT_OAUTH_CLIENT_SECRET in the environment; use --web-token for API token login")
+				return fmt.Errorf("cloud OAuth requires BKT_OAUTH_CLIENT_ID and BKT_OAUTH_CLIENT_SECRET in the environment; use --web-token for API token login")
 			}
 			if _, err := fmt.Fprintln(ios.Out, "Authenticating with Bitbucket Cloud via OAuth..."); err != nil {
 				return err

--- a/pkg/cmd/auth/auth_test.go
+++ b/pkg/cmd/auth/auth_test.go
@@ -319,7 +319,7 @@ func TestRunLoginRejectsWebWithoutOAuthCreds(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), "OAuth credentials were not embedded") {
+	if !strings.Contains(err.Error(), "Cloud OAuth requires BKT_OAUTH_CLIENT_ID and BKT_OAUTH_CLIENT_SECRET") {
 		t.Errorf("error = %q", err)
 	}
 }

--- a/pkg/cmd/auth/auth_test.go
+++ b/pkg/cmd/auth/auth_test.go
@@ -319,7 +319,7 @@ func TestRunLoginRejectsWebWithoutOAuthCreds(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), "Cloud OAuth requires BKT_OAUTH_CLIENT_ID and BKT_OAUTH_CLIENT_SECRET") {
+	if !strings.Contains(err.Error(), "cloud OAuth requires BKT_OAUTH_CLIENT_ID and BKT_OAUTH_CLIENT_SECRET") {
 		t.Errorf("error = %q", err)
 	}
 }

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -1485,7 +1485,9 @@ func getDCDefaultReviewers(ctx context.Context, client *bbdc.Client, projectKey,
 func cloudUserKeys(user bbcloud.User) []string {
 	keys := make([]string, 0, 3)
 	if user.UUID != "" {
-		keys = append(keys, "uuid:"+bbcloud.NormalizeUUID(user.UUID))
+		if normalized := bbcloud.NormalizeUUID(user.UUID); normalized != "" {
+			keys = append(keys, "uuid:"+normalized)
+		}
 	}
 	if user.AccountID != "" {
 		keys = append(keys, "account_id:"+user.AccountID)

--- a/pkg/cmdutil/client.go
+++ b/pkg/cmdutil/client.go
@@ -79,7 +79,7 @@ func NewCloudClient(host *config.Host) (*bbcloud.Client, error) {
 func oauthTokenRefresher(hostKey string, host *config.Host) func(ctx context.Context) (string, error) {
 	return func(ctx context.Context) (string, error) {
 		if oauth.CloudClientID() == "" || oauth.CloudClientSecret() == "" {
-			return "", fmt.Errorf("token expired and OAuth client credentials are missing; rebuild with BKT_OAUTH_CLIENT_ID/BKT_OAUTH_CLIENT_SECRET or re-login with `bkt auth login --web-token`")
+			return "", fmt.Errorf("token expired and Cloud OAuth consumer credentials are missing; set BKT_OAUTH_CLIENT_ID and BKT_OAUTH_CLIENT_SECRET or re-login with `bkt auth login --web-token`")
 		}
 
 		store, err := secret.Open(secretOpts(host)...)

--- a/pkg/cmdutil/client_test.go
+++ b/pkg/cmdutil/client_test.go
@@ -133,7 +133,7 @@ func TestOAuthTokenRefresherMissingCreds(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), "OAuth client credentials are missing") {
+	if !strings.Contains(err.Error(), "Cloud OAuth consumer credentials are missing") {
 		t.Errorf("error = %q", err)
 	}
 }

--- a/pkg/oauth/cloud.go
+++ b/pkg/oauth/cloud.go
@@ -5,9 +5,9 @@ import "os"
 // Cloud OAuth 2.0 configuration for Bitbucket Cloud.
 //
 // The flow uses PKCE (RFC 7636, S256) for defense-in-depth. Bitbucket Cloud
-// still requires client_secret at token exchange, so it is embedded in the
-// binary at build time via ldflags — the same trade-off made by tools like
-// gh (GitHub CLI).
+// still requires a client secret for authorization_code and refresh_token
+// exchanges, so bkt reads the consumer credentials from runtime environment
+// variables instead of embedding them in public release binaries.
 const (
 	// CloudAuthorizeURL is the Bitbucket Cloud authorization endpoint.
 	CloudAuthorizeURL = "https://bitbucket.org/site/oauth2/authorize"
@@ -16,29 +16,13 @@ const (
 	CloudTokenURL = "https://bitbucket.org/site/oauth2/access_token"
 )
 
-// CloudClientID and CloudClientSecret are injected at build time via ldflags.
-// For source installs (go install) that lack ldflags, they fall back to the
-// BKT_OAUTH_CLIENT_ID / BKT_OAUTH_CLIENT_SECRET environment variables.
-var (
-	cloudClientID     string // set via -ldflags -X
-	cloudClientSecret string // set via -ldflags -X
-)
-
 // CloudClientID returns the OAuth consumer key.
-// Prefers the build-time value; falls back to BKT_OAUTH_CLIENT_ID env var.
 func CloudClientID() string {
-	if cloudClientID != "" {
-		return cloudClientID
-	}
 	return os.Getenv("BKT_OAUTH_CLIENT_ID")
 }
 
 // CloudClientSecret returns the OAuth consumer secret.
-// Prefers the build-time value; falls back to BKT_OAUTH_CLIENT_SECRET env var.
 func CloudClientSecret() string {
-	if cloudClientSecret != "" {
-		return cloudClientSecret
-	}
 	return os.Getenv("BKT_OAUTH_CLIENT_SECRET")
 }
 

--- a/pkg/oauth/cloud_test.go
+++ b/pkg/oauth/cloud_test.go
@@ -4,35 +4,15 @@ import (
 	"testing"
 )
 
-func TestCloudClientIDFromLdflags(t *testing.T) {
-	orig := cloudClientID
-	defer func() { cloudClientID = orig }()
-
-	cloudClientID = "build-id"                // gitleaks:allow
-	t.Setenv("BKT_OAUTH_CLIENT_ID", "env-id") // gitleaks:allow
-
-	if got := CloudClientID(); got != "build-id" {
-		t.Errorf("CloudClientID() = %q, want build-time value %q", got, "build-id")
-	}
-}
-
 func TestCloudClientIDFromEnv(t *testing.T) {
-	orig := cloudClientID
-	defer func() { cloudClientID = orig }()
-
-	cloudClientID = ""                        // gitleaks:allow
 	t.Setenv("BKT_OAUTH_CLIENT_ID", "env-id") // gitleaks:allow
 
 	if got := CloudClientID(); got != "env-id" {
-		t.Errorf("CloudClientID() = %q, want env fallback %q", got, "env-id")
+		t.Errorf("CloudClientID() = %q, want env value %q", got, "env-id")
 	}
 }
 
 func TestCloudClientIDEmpty(t *testing.T) {
-	orig := cloudClientID
-	defer func() { cloudClientID = orig }()
-
-	cloudClientID = ""                  // gitleaks:allow
 	t.Setenv("BKT_OAUTH_CLIENT_ID", "") // gitleaks:allow
 
 	if got := CloudClientID(); got != "" {
@@ -40,27 +20,19 @@ func TestCloudClientIDEmpty(t *testing.T) {
 	}
 }
 
-func TestCloudClientSecretFromLdflags(t *testing.T) {
-	orig := cloudClientSecret
-	defer func() { cloudClientSecret = orig }()
-
-	cloudClientSecret = "build-secret"                // gitleaks:allow
-	t.Setenv("BKT_OAUTH_CLIENT_SECRET", "env-secret") // gitleaks:allow
-
-	if got := CloudClientSecret(); got != "build-secret" {
-		t.Errorf("CloudClientSecret() = %q, want build-time value %q", got, "build-secret")
-	}
-}
-
 func TestCloudClientSecretFromEnv(t *testing.T) {
-	orig := cloudClientSecret
-	defer func() { cloudClientSecret = orig }()
-
-	cloudClientSecret = ""                            // gitleaks:allow
 	t.Setenv("BKT_OAUTH_CLIENT_SECRET", "env-secret") // gitleaks:allow
 
 	if got := CloudClientSecret(); got != "env-secret" {
-		t.Errorf("CloudClientSecret() = %q, want env fallback %q", got, "env-secret")
+		t.Errorf("CloudClientSecret() = %q, want env value %q", got, "env-secret")
+	}
+}
+
+func TestCloudClientSecretEmpty(t *testing.T) {
+	t.Setenv("BKT_OAUTH_CLIENT_SECRET", "") // gitleaks:allow
+
+	if got := CloudClientSecret(); got != "" {
+		t.Errorf("CloudClientSecret() = %q, want empty", got)
 	}
 }
 

--- a/scripts/check-release-version.sh
+++ b/scripts/check-release-version.sh
@@ -46,6 +46,24 @@ else:
     pattern = rf"(?m)^## \[{re.escape(version)}\] - \d{{4}}-\d{{2}}-\d{{2}}$"
     if not re.search(pattern, text):
         mismatches.append(("CHANGELOG.md", "<missing release heading>"))
+    else:
+        versions = re.findall(r"(?m)^## \[([0-9A-Za-z.+-]+)\] - \d{4}-\d{2}-\d{2}$", text)
+        compare_prefix = "https://github.com/avivsinai/bitbucket-cli/compare/"
+        release_prefix = "https://github.com/avivsinai/bitbucket-cli/releases/tag/"
+
+        expected_refs = {"Unreleased": f"{compare_prefix}v{versions[0]}...HEAD"}
+        for i, current in enumerate(versions):
+            if i + 1 < len(versions):
+                expected_refs[current] = f"{compare_prefix}v{versions[i + 1]}...v{current}"
+            else:
+                expected_refs[current] = f"{release_prefix}v{current}"
+
+        for label, expected in expected_refs.items():
+            ref_pattern = rf"(?m)^\[{re.escape(label)}\]: (.+)$"
+            match = re.search(ref_pattern, text)
+            actual = match.group(1) if match else "<missing>"
+            if actual != expected:
+                mismatches.append((f"CHANGELOG.md [{label}]", actual))
 
 if mismatches:
     print(f"release metadata version mismatch for {version}:")

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -24,8 +24,8 @@ Options:
   -h, --help         Show this help text
 
 Examples:
-  ./scripts/release.sh 0.16.2
-  ./scripts/release.sh 0.16.2 --no-auto-merge
+  ./scripts/release.sh 1.2.3
+  ./scripts/release.sh 1.2.3 --no-auto-merge
 EOF
 }
 
@@ -150,6 +150,8 @@ import re
 import sys
 
 version, release_date, allow_empty = sys.argv[1], sys.argv[2], sys.argv[3] == "1"
+repo_compare_prefix = "https://github.com/avivsinai/bitbucket-cli/compare/"
+repo_release_prefix = "https://github.com/avivsinai/bitbucket-cli/releases/tag/"
 
 changelog = pathlib.Path("CHANGELOG.md")
 text = changelog.read_text()
@@ -175,6 +177,26 @@ release_header = f"\n\n## [{version}] - {release_date}\n"
 new_text = text[:start] + marker + release_header + unreleased_body.lstrip("\n")
 if suffix:
     new_text += suffix if suffix.startswith("\n") else "\n" + suffix
+
+versions = re.findall(r"(?m)^## \[([0-9A-Za-z.+-]+)\] - \d{4}-\d{2}-\d{2}$", new_text)
+if not versions:
+    raise SystemExit("error: CHANGELOG.md contains no version headings")
+
+footer_lines = [f"[Unreleased]: {repo_compare_prefix}v{versions[0]}...HEAD"]
+for i, current in enumerate(versions):
+    if i + 1 < len(versions):
+        footer_lines.append(
+            f"[{current}]: {repo_compare_prefix}v{versions[i + 1]}...v{current}"
+        )
+    else:
+        footer_lines.append(f"[{current}]: {repo_release_prefix}v{current}")
+
+new_text = re.sub(
+    r"(?ms)\n\[Unreleased\]: https://github\.com/avivsinai/bitbucket-cli/.*\Z",
+    "",
+    new_text.rstrip(),
+)
+new_text = new_text.rstrip() + "\n\n" + "\n".join(footer_lines) + "\n"
 changelog.write_text(new_text)
 
 changed = ["CHANGELOG.md"]

--- a/skills/bkt/rules/auth.md
+++ b/skills/bkt/rules/auth.md
@@ -32,14 +32,12 @@ For Data Center (--kind dc, the default), you authenticate with a Personal
 Access Token (PAT). The token needs Repository Read/Write and Project Read
 permissions. Use --web-token to open the PAT management page in your browser.
 
-For Bitbucket Cloud (--kind cloud), the recommended method is --web, which
-uses OAuth 2.0 to authenticate in the browser. The CLI receives a short-lived
-access token that is automatically refreshed. Alternatively, use --web-token
-to create an Atlassian API token manually.
-
-OAuth credentials are embedded at build time via ldflags. For source installs
-(go install), set BKT_OAUTH_CLIENT_ID and BKT_OAUTH_CLIENT_SECRET environment
-variables before running --web.
+For Bitbucket Cloud (--kind cloud), the simplest method is --web-token, which
+opens the Atlassian API token page and prompts for the token locally. If you
+prefer browser-based OAuth, use --web with BKT_OAUTH_CLIENT_ID and
+BKT_OAUTH_CLIENT_SECRET set in your environment. The CLI receives a short-lived
+access token that is automatically refreshed while those environment variables
+remain available.
 
 Credentials are verified against the remote host before being stored. If no
 OS keychain is available, pass --allow-insecure-store to use encrypted file


### PR DESCRIPTION
## Summary
- escape BBQL string literals and reject invalid pipeline UUIDs locally
- fail clearly on diffstat truncation and preserve real git remote errors
- stop embedding Cloud OAuth consumer credentials in public build artifacts
- sync release docs/metadata and teach the release scripts to maintain changelog compare links

## Verification
- go test ./...
- make check-skills
- make build
- bash -n scripts/release.sh scripts/check-release-version.sh
- ./scripts/check-release-version.sh v0.26.0
- goreleaser release --snapshot --clean --skip=publish