### PR TITLE
chore(release): v0.26.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ All notable changes to this project will be documented here. The format follows
 
 ## [Unreleased]
 
+## [0.26.1] - 2026-04-22
 ### Added
 - Release `.tar.gz` and `.zip` archives now bundle `skills/bkt/` alongside the CLI binary and docs.
 
 ### Fixed
 - Bitbucket Cloud 401 auth failures now explain the most common API-token misconfigurations, including the required Atlassian-account email username and `read:user:bitbucket` scope.
+
 
 ## [0.26.0] - 2026-04-18
 ### Added
@@ -454,7 +456,8 @@ All notable changes to this project will be documented here. The format follows
 ## [0.1.0] - 2025-10-26
 - Initial public release of `bkt`.
 
-[Unreleased]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.0...HEAD
+[Unreleased]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.1...HEAD
+[0.26.1]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.0...v0.26.1
 [0.26.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.24.1...v0.25.0
 [0.24.1]: https://github.com/avivsinai/bitbucket-cli/compare/v0.24.0...v0.24.1

--- a/skills/bkt/SKILL.md
+++ b/skills/bkt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bkt
-version: 0.26.0
+version: 0.26.1
 description: Bitbucket CLI for Data Center and Cloud. Use when users need to manage repositories, pull requests, branches, issues, webhooks, or pipelines in Bitbucket. Triggers include "bitbucket", "bkt", "pull request", "PR", "repo list", "branch create", "Bitbucket Data Center", "Bitbucket Cloud", "keyring timeout".
 metadata:
   short-description: Bitbucket CLI for repos, PRs, branches


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.26.1`
- aligns skill/plugin metadata to `0.26.1`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.26.1`, publishes the release, and publishes skills in the same workflow run