### PR TITLE
chore(release): v0.26.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented here. The format follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
+## [0.26.2] - 2026-04-24
 ### Added
 - `bkt auth doctor [host]` diagnoses macOS Keychain re-prompt issues without reading the stored secret. Reports the binary's signature, Designated Requirement, and whether a Keychain entry is present for the host (#181).
 
@@ -12,6 +14,7 @@ All notable changes to this project will be documented here. The format follows
 - macOS Keychain "Always Allow" now survives `brew upgrade bkt`. The release codesign script pins the Designated Requirement to the bundle identifier (`-r='designated => identifier "…"'`) instead of letting it default to the cdhash, which changes on every build. The previous claim in 0.21.0 that the stable identifier alone preserved approvals was incomplete — without an explicit DR, `codesign` still derived one from the cdhash. (#181)
 - Token saves on macOS now delete any stale Keychain item before writing, so the new entry is created with the current binary's DR instead of inheriting an ACL from a previous bkt build. Re-run `bkt auth login` once after upgrading to benefit. (#181)
 - macOS Keychain items created by bkt now set `KeychainTrustApplication` on darwin, so fresh items trust the calling binary at create time instead of prompting on every access. `KeychainAccessibleWhenUnlocked` is set alongside for forward compatibility (currently a no-op on the file-based Keychain path 99designs/keyring uses). (#181)
+
 
 ## [0.26.1] - 2026-04-22
 ### Added
@@ -463,7 +466,8 @@ All notable changes to this project will be documented here. The format follows
 ## [0.1.0] - 2025-10-26
 - Initial public release of `bkt`.
 
-[Unreleased]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.1...HEAD
+[Unreleased]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.2...HEAD
+[0.26.2]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.1...v0.26.2
 [0.26.1]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.0...v0.26.1
 [0.26.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.24.1...v0.25.0

--- a/skills/bkt/SKILL.md
+++ b/skills/bkt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bkt
-version: 0.26.1
+version: 0.26.2
 description: Bitbucket CLI for Data Center and Cloud. Use when users need to manage repositories, pull requests, branches, issues, webhooks, or pipelines in Bitbucket. Triggers include "bitbucket", "bkt", "pull request", "PR", "repo list", "branch create", "Bitbucket Data Center", "Bitbucket Cloud", "keyring timeout".
 metadata:
   short-description: Bitbucket CLI for repos, PRs, branches


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.26.2`
- aligns skill/plugin metadata to `0.26.2`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.26.2`, publishes the release, and publishes skills in the same workflow run