### PR TITLE
fix(auth): Harden Cloud OAuth credential recovery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/itchyny/gojq v0.12.19
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
+	golang.org/x/sys v0.43.0
 	golang.org/x/term v0.42.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -20,5 +21,4 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/itchyny/timefmt-go v0.1.8 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
-	golang.org/x/sys v0.43.0 // indirect
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -46,6 +47,9 @@ type Host struct {
 	Token              string `yaml:"token,omitempty"`
 	AuthMethod         string `yaml:"auth_method,omitempty"` // "basic" (default) or "bearer"
 	AllowInsecureStore bool   `yaml:"allow_insecure_store,omitempty"`
+
+	// OAuthExpiresAt is runtime-only metadata loaded from an OAuth token blob.
+	OAuthExpiresAt time.Time `yaml:"-"`
 }
 
 // MarshalYAML strips the token field so credentials are never written to disk.

--- a/internal/filelock/filelock.go
+++ b/internal/filelock/filelock.go
@@ -1,0 +1,27 @@
+package filelock
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// With holds an exclusive file lock while fn runs.
+func With(path string, fn func() error) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create lock dir: %w", err)
+	}
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return fmt.Errorf("open lock: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if err := lock(f); err != nil {
+		return fmt.Errorf("lock: %w", err)
+	}
+	defer func() { _ = unlock(f) }()
+
+	return fn()
+}

--- a/internal/filelock/filelock_fallback.go
+++ b/internal/filelock/filelock_fallback.go
@@ -1,0 +1,13 @@
+//go:build !darwin && !linux && !freebsd && !openbsd && !netbsd && !windows
+
+package filelock
+
+import "os"
+
+func lock(_ *os.File) error {
+	return nil
+}
+
+func unlock(_ *os.File) error {
+	return nil
+}

--- a/internal/filelock/filelock_unix.go
+++ b/internal/filelock/filelock_unix.go
@@ -1,0 +1,16 @@
+//go:build darwin || linux || freebsd || openbsd || netbsd
+
+package filelock
+
+import (
+	"os"
+	"syscall"
+)
+
+func lock(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
+}
+
+func unlock(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/internal/filelock/filelock_windows.go
+++ b/internal/filelock/filelock_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package filelock
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lock(f *os.File) error {
+	var overlapped windows.Overlapped
+	return windows.LockFileEx(windows.Handle(f.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &overlapped)
+}
+
+func unlock(f *os.File) error {
+	var overlapped windows.Overlapped
+	return windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, &overlapped)
+}

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -24,7 +24,8 @@ import (
 	"github.com/avivsinai/bitbucket-cli/pkg/oauth"
 )
 
-// CloudTokenURL is the URL where users create Bitbucket Cloud API tokens.
+// CloudTokenURL is Atlassian's token-management page. Atlassian does not
+// currently expose a stable deep link into the Bitbucket scoped-token wizard.
 const CloudTokenURL = "https://id.atlassian.com/manage-profile/security/api-tokens"
 
 // CloudEmailPrompt is the prompt shown when asking for the Atlassian account email.
@@ -42,7 +43,7 @@ func NewCmdAuth(f *cmdutil.Factory) *cobra.Command {
 
 Tokens are stored in the OS keychain by default. For Data Center hosts, bkt
 uses Personal Access Tokens (PATs). For Bitbucket Cloud, bkt uses Atlassian
-API tokens (app passwords).
+API tokens with scopes.
 
 Use "bkt auth login" to add a host, "bkt auth status" to inspect stored
 credentials, and "bkt auth logout" to remove them.`,
@@ -94,7 +95,7 @@ Credentials are verified against the remote host before being stored. If no
 OS keychain is available, pass --allow-insecure-store to use encrypted file
 fallback. In non-interactive environments, provide --username and --token
 on the command line or via stdin.`,
-		Example: `  # Login to Bitbucket Cloud via OAuth (recommended)
+		Example: `  # Login to Bitbucket Cloud via OAuth
   bkt auth login https://bitbucket.org --kind cloud --web
 
   # Login to Bitbucket Cloud with an API token
@@ -375,7 +376,13 @@ func runLogin(cmd *cobra.Command, f *cmdutil.Factory, opts *loginOptions) error 
 				if _, err := fmt.Fprintln(ios.Out, "Opening Atlassian to create a Bitbucket API token..."); err != nil {
 					return err
 				}
+				if _, err := fmt.Fprintf(ios.Out, "This opens Atlassian's generic API token page: %s\n", tokenURL); err != nil {
+					return err
+				}
 				if _, err := fmt.Fprintln(ios.Out, "\nIMPORTANT: Click \"Create API token with scopes\" and select \"Bitbucket\" as the application."); err != nil {
+					return err
+				}
+				if _, err := fmt.Fprintln(ios.Out, "Existing token values cannot be viewed again; create a new token if you do not already have the token string."); err != nil {
 					return err
 				}
 				if _, err := fmt.Fprintln(ios.Out, "\nRequired scopes:"); err != nil {
@@ -454,6 +461,7 @@ func runLogin(cmd *cobra.Command, f *cmdutil.Factory, opts *loginOptions) error 
 				Kind:               "cloud",
 				BaseURL:            apiURL,
 				Username:           opts.Username,
+				AuthMethod:         "basic",
 				AllowInsecureStore: opts.AllowInsecureStore,
 			})
 
@@ -516,6 +524,7 @@ func runStatus(cmd *cobra.Command, f *cmdutil.Factory) error {
 		AuthMethod  string `json:"auth_method"`
 		TokenSource string `json:"token_source"`
 		Expires     string `json:"expires,omitempty"`
+		Refresh     string `json:"refresh,omitempty"`
 	}
 
 	type contextSummary struct {
@@ -538,10 +547,7 @@ func runStatus(cmd *cobra.Command, f *cmdutil.Factory) error {
 	var hosts []hostSummary
 	for _, key := range hostKeys {
 		h := cfg.Hosts[key]
-		am := h.AuthMethod
-		if am == "" {
-			am = "basic"
-		}
+		am := detectedAuthMethod(key, h, tokenSource)
 		hs := hostSummary{
 			Key:         key,
 			Kind:        h.Kind,
@@ -552,6 +558,7 @@ func runStatus(cmd *cobra.Command, f *cmdutil.Factory) error {
 		}
 		if am == "oauth" && tokenSource != secret.EnvToken {
 			hs.Expires = oauthExpiryLabel(key, h)
+			hs.Refresh = oauthRefreshStatus(hs.Expires)
 		}
 		hosts = append(hosts, hs)
 	}
@@ -613,6 +620,11 @@ func runStatus(cmd *cobra.Command, f *cmdutil.Factory) error {
 			}
 			if h.Expires != "" {
 				if _, err := fmt.Fprintf(ios.Out, "    expires: %s\n", h.Expires); err != nil {
+					return err
+				}
+			}
+			if h.Refresh != "" {
+				if _, err := fmt.Fprintf(ios.Out, "    refresh: %s\n", h.Refresh); err != nil {
 					return err
 				}
 			}
@@ -849,6 +861,44 @@ func resolvedTokenSource() string {
 	return "keyring"
 }
 
+func detectedAuthMethod(hostKey string, host *config.Host, tokenSource string) string {
+	if tokenSource == secret.EnvToken {
+		if m := strings.TrimSpace(os.Getenv(secret.EnvAuthMethod)); m != "" {
+			return m
+		}
+		return "basic"
+	}
+	if host == nil {
+		return "basic"
+	}
+	if host.AuthMethod != "" {
+		return host.AuthMethod
+	}
+	if host.Kind != "cloud" {
+		return "basic"
+	}
+	if storedTokenIsOAuthBlob(hostKey, host) {
+		return "oauth"
+	}
+	return "basic"
+}
+
+func storedTokenIsOAuthBlob(hostKey string, host *config.Host) bool {
+	opts := []secret.Option{}
+	if host != nil && host.AllowInsecureStore {
+		opts = append(opts, secret.WithAllowFileFallback(true))
+	}
+	store, err := secret.Open(opts...)
+	if err != nil {
+		return false
+	}
+	raw, err := store.Get(secret.TokenKey(hostKey))
+	if err != nil {
+		return false
+	}
+	return oauth.IsTokenBlob(raw)
+}
+
 // oauthExpiryLabel reads the OAuth JSON blob from the keyring and returns a
 // human-readable expiry string. Returns "" on any error (best-effort).
 func oauthExpiryLabel(hostKey string, host *config.Host) string {
@@ -876,4 +926,14 @@ func oauthExpiryLabel(hostKey string, host *config.Host) string {
 	}
 	remaining := time.Until(tok.ExpiresAt).Truncate(time.Minute)
 	return fmt.Sprintf("%s (in %s)", tok.ExpiresAt.Format(time.RFC3339), remaining)
+}
+
+func oauthRefreshStatus(expires string) string {
+	if expires != "expired" {
+		return ""
+	}
+	if oauth.CloudClientID() == "" || oauth.CloudClientSecret() == "" {
+		return "unavailable; set BKT_OAUTH_CLIENT_ID and BKT_OAUTH_CLIENT_SECRET to refresh OAuth, or run `bkt auth login https://bitbucket.org --kind cloud --web-token` to replace it with a scoped API token"
+	}
+	return "available"
 }

--- a/pkg/cmd/auth/auth_test.go
+++ b/pkg/cmd/auth/auth_test.go
@@ -49,6 +49,9 @@ func TestLoginFlagHelpTextNoAppPassword(t *testing.T) {
 	}
 
 	cmd := newLoginCmd(f)
+	if strings.Contains(strings.ToLower(cmd.Long), "app password") {
+		t.Fatalf("login long help should not mention app password, got: %s", cmd.Long)
+	}
 
 	// Check --token flag usage
 	tokenFlag := cmd.Flag("token")
@@ -386,7 +389,8 @@ func TestRunLoginRejectsUnsupportedKind(t *testing.T) {
 }
 
 func TestRunStatusShowsOAuthMethod(t *testing.T) {
-	t.Setenv(secret.EnvToken, "test-env-token")
+	setupFileKeyring(t)
+	t.Setenv(secret.EnvToken, "")
 
 	cfg := &config.Config{
 		Hosts: map[string]*config.Host{
@@ -408,6 +412,89 @@ func TestRunStatusShowsOAuthMethod(t *testing.T) {
 	output := stdout.String()
 	if !strings.Contains(output, "auth: oauth") {
 		t.Errorf("expected 'auth: oauth' in output, got:\n%s", output)
+	}
+}
+
+func TestRunStatusDetectsOAuthBlobWhenAuthMethodMissing(t *testing.T) {
+	setupFileKeyring(t)
+	t.Setenv(secret.EnvToken, "")
+
+	store, err := secret.Open(secret.WithAllowFileFallback(true))
+	if err != nil {
+		t.Fatalf("secret.Open: %v", err)
+	}
+	blob := `{"access_token":"at-from-keyring","refresh_token":"rt-456","expires_at":"2099-01-01T00:00:00Z"}`
+	if err := store.Set(secret.TokenKey("api.bitbucket.org"), blob); err != nil {
+		t.Fatalf("store.Set: %v", err)
+	}
+
+	cfg := &config.Config{
+		Hosts: map[string]*config.Host{
+			"api.bitbucket.org": {
+				Kind:               "cloud",
+				BaseURL:            "https://api.bitbucket.org/2.0",
+				Username:           "erank@example.com",
+				AllowInsecureStore: true,
+			},
+		},
+		Contexts: make(map[string]*config.Context),
+	}
+	f, stdout, _ := newAuthTestFactory(cfg)
+
+	if err := runStatus(&cobra.Command{}, f); err != nil {
+		t.Fatalf("runStatus error: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "auth: oauth") {
+		t.Errorf("expected detected oauth auth in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "expires:") {
+		t.Errorf("expected oauth expiry in output, got:\n%s", output)
+	}
+}
+
+func TestRunStatusWarnsWhenOAuthExpiredAndRefreshUnavailable(t *testing.T) {
+	setupFileKeyring(t)
+	t.Setenv(secret.EnvToken, "")
+	t.Setenv("BKT_OAUTH_CLIENT_ID", "")
+	t.Setenv("BKT_OAUTH_CLIENT_SECRET", "")
+
+	store, err := secret.Open(secret.WithAllowFileFallback(true))
+	if err != nil {
+		t.Fatalf("secret.Open: %v", err)
+	}
+	blob := `{"access_token":"at-from-keyring","refresh_token":"rt-456","expires_at":"2000-01-01T00:00:00Z"}`
+	if err := store.Set(secret.TokenKey("api.bitbucket.org"), blob); err != nil {
+		t.Fatalf("store.Set: %v", err)
+	}
+
+	cfg := &config.Config{
+		Hosts: map[string]*config.Host{
+			"api.bitbucket.org": {
+				Kind:               "cloud",
+				BaseURL:            "https://api.bitbucket.org/2.0",
+				Username:           "erank@example.com",
+				AllowInsecureStore: true,
+			},
+		},
+		Contexts: make(map[string]*config.Context),
+	}
+	f, stdout, _ := newAuthTestFactory(cfg)
+
+	if err := runStatus(&cobra.Command{}, f); err != nil {
+		t.Fatalf("runStatus error: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "expires: expired") {
+		t.Errorf("expected expired oauth status, got:\n%s", output)
+	}
+	if !strings.Contains(output, "refresh: unavailable") {
+		t.Errorf("expected unavailable refresh guidance, got:\n%s", output)
+	}
+	if strings.Contains(output, "auth logout") {
+		t.Errorf("status recovery guidance should not recommend logout, got:\n%s", output)
 	}
 }
 
@@ -437,6 +524,9 @@ func TestRunStatusHidesOAuthExpiryWithBKTToken(t *testing.T) {
 	}
 	if !strings.Contains(output, "token source: BKT_TOKEN") {
 		t.Errorf("expected BKT_TOKEN source, got:\n%s", output)
+	}
+	if !strings.Contains(output, "auth: basic") {
+		t.Errorf("expected BKT_TOKEN to report basic auth by default, got:\n%s", output)
 	}
 }
 
@@ -822,6 +912,18 @@ func TestRunLoginCloudAPITokenFullFlow(t *testing.T) {
 	}
 	if !strings.Contains(output, "erank") {
 		t.Errorf("expected username in output, got:\n%s", output)
+	}
+
+	hostKey, err := cmdutil.HostKeyFromURL(srv.URL)
+	if err != nil {
+		t.Fatalf("HostKeyFromURL: %v", err)
+	}
+	host := cfg.Hosts[hostKey]
+	if host == nil {
+		t.Fatalf("expected host %q to be configured", hostKey)
+	}
+	if host.AuthMethod != "basic" {
+		t.Errorf("AuthMethod = %q, want basic", host.AuthMethod)
 	}
 }
 

--- a/pkg/cmdutil/client.go
+++ b/pkg/cmdutil/client.go
@@ -3,9 +3,13 @@ package cmdutil
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/avivsinai/bitbucket-cli/internal/config"
+	"github.com/avivsinai/bitbucket-cli/internal/filelock"
 	"github.com/avivsinai/bitbucket-cli/internal/secret"
 	"github.com/avivsinai/bitbucket-cli/pkg/bbcloud"
 	"github.com/avivsinai/bitbucket-cli/pkg/bbdc"
@@ -67,6 +71,9 @@ func NewCloudClient(host *config.Host) (*bbcloud.Client, error) {
 		if err != nil {
 			return nil, fmt.Errorf("resolve host key: %w", err)
 		}
+		if err := preflightExpiredOAuth(hostKey, host); err != nil {
+			return nil, err
+		}
 		opts.TokenRefresher = oauthTokenRefresher(hostKey, host)
 	}
 
@@ -78,46 +85,91 @@ func NewCloudClient(host *config.Host) (*bbcloud.Client, error) {
 // closure can persist the new token.
 func oauthTokenRefresher(hostKey string, host *config.Host) func(ctx context.Context) (string, error) {
 	return func(ctx context.Context) (string, error) {
-		if oauth.CloudClientID() == "" || oauth.CloudClientSecret() == "" {
-			return "", fmt.Errorf("token expired and Cloud OAuth consumer credentials are missing; set BKT_OAUTH_CLIENT_ID and BKT_OAUTH_CLIENT_SECRET or re-login with `bkt auth login --web-token`")
-		}
-
-		store, err := secret.Open(secretOpts(host)...)
+		lockPath, err := oauthRefreshLockPath(hostKey)
 		if err != nil {
-			return "", fmt.Errorf("open secret store: %w", err)
+			return "", fmt.Errorf("resolve OAuth refresh lock: %w", err)
 		}
 
-		raw, err := store.Get(secret.TokenKey(hostKey))
+		var accessToken string
+		err = filelock.With(lockPath, func() error {
+			store, err := secret.Open(secretOpts(host)...)
+			if err != nil {
+				return fmt.Errorf("open secret store: %w", err)
+			}
+
+			raw, err := store.Get(secret.TokenKey(hostKey))
+			if err != nil {
+				return fmt.Errorf("read token: %w", err)
+			}
+
+			tok, err := oauth.Unmarshal(raw)
+			if err != nil {
+				return fmt.Errorf("parse stored token: %w", err)
+			}
+
+			if !tok.IsExpired() && tok.AccessToken != host.Token {
+				accessToken = tok.AccessToken
+				host.OAuthExpiresAt = tok.ExpiresAt
+				return nil
+			}
+			if oauth.CloudClientID() == "" || oauth.CloudClientSecret() == "" {
+				return oauthMissingCredsError(hostKey, tok.ExpiresAt)
+			}
+
+			newTok, err := oauth.RefreshToken(ctx,
+				tok.RefreshToken,
+				oauth.CloudClientID(),
+				oauth.CloudClientSecret(),
+				oauth.CloudTokenURL,
+			)
+			if err != nil {
+				return fmt.Errorf("refresh failed (re-login with `bkt auth login --web`): %w", err)
+			}
+
+			blob, err := newTok.Marshal()
+			if err != nil {
+				return fmt.Errorf("encode refreshed token: %w", err)
+			}
+			if err := store.Set(secret.TokenKey(hostKey), blob); err != nil {
+				return fmt.Errorf("store refreshed token: %w", err)
+			}
+
+			accessToken = newTok.AccessToken
+			host.OAuthExpiresAt = newTok.ExpiresAt
+			return nil
+		})
 		if err != nil {
-			return "", fmt.Errorf("read token: %w", err)
+			return "", err
 		}
 
-		tok, err := oauth.Unmarshal(raw)
-		if err != nil {
-			return "", fmt.Errorf("parse stored token: %w", err)
-		}
-
-		newTok, err := oauth.RefreshToken(ctx,
-			tok.RefreshToken,
-			oauth.CloudClientID(),
-			oauth.CloudClientSecret(),
-			oauth.CloudTokenURL,
-		)
-		if err != nil {
-			return "", fmt.Errorf("refresh failed (re-login with `bkt auth login --web`): %w", err)
-		}
-
-		blob, err := newTok.Marshal()
-		if err != nil {
-			return "", fmt.Errorf("encode refreshed token: %w", err)
-		}
-		if err := store.Set(secret.TokenKey(hostKey), blob); err != nil {
-			return "", fmt.Errorf("store refreshed token: %w", err)
-		}
-
-		host.Token = newTok.AccessToken
-		return newTok.AccessToken, nil
+		host.Token = accessToken
+		return accessToken, nil
 	}
+}
+
+func preflightExpiredOAuth(hostKey string, host *config.Host) error {
+	if host == nil || host.OAuthExpiresAt.IsZero() || time.Now().Before(host.OAuthExpiresAt) {
+		return nil
+	}
+	if oauth.CloudClientID() != "" && oauth.CloudClientSecret() != "" {
+		return nil
+	}
+	return oauthMissingCredsError(hostKey, host.OAuthExpiresAt)
+}
+
+func oauthMissingCredsError(hostKey string, expiresAt time.Time) error {
+	if !expiresAt.IsZero() && time.Now().After(expiresAt) {
+		return fmt.Errorf("oauth access token for %s expired at %s, and BKT_OAUTH_CLIENT_ID / BKT_OAUTH_CLIENT_SECRET are not set. Run `bkt auth login https://bitbucket.org --kind cloud --web-token` to replace it with a scoped API token, or restore the OAuth consumer env vars", hostKey, expiresAt.Format(time.RFC3339))
+	}
+	return fmt.Errorf("cloud OAuth consumer credentials are missing for %s; set BKT_OAUTH_CLIENT_ID and BKT_OAUTH_CLIENT_SECRET to refresh OAuth, or run `bkt auth login https://bitbucket.org --kind cloud --web-token` to replace the stored OAuth credential with a scoped API token", hostKey)
+}
+
+func oauthRefreshLockPath(hostKey string) (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve config dir: %w", err)
+	}
+	return filepath.Join(dir, "bkt", "locks", "oauth-refresh-"+url.PathEscape(hostKey)+".lock"), nil
 }
 
 func secretOpts(host *config.Host) []secret.Option {

--- a/pkg/cmdutil/client_test.go
+++ b/pkg/cmdutil/client_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/avivsinai/bitbucket-cli/internal/config"
 	"github.com/avivsinai/bitbucket-cli/internal/secret"
@@ -71,6 +72,32 @@ func TestNewCloudClientOAuthSkipsRefresherWithBKTToken(t *testing.T) {
 	}
 }
 
+func TestNewCloudClientOAuthExpiredMissingCredsPreflight(t *testing.T) {
+	host := &config.Host{
+		Kind:           "cloud",
+		BaseURL:        "https://api.bitbucket.org/2.0",
+		Username:       "erank_ai21",
+		AuthMethod:     "oauth",
+		Token:          "expired-access",
+		OAuthExpiresAt: time.Now().Add(-time.Minute),
+	}
+
+	t.Setenv(secret.EnvToken, "")
+	t.Setenv("BKT_OAUTH_CLIENT_ID", "")
+	t.Setenv("BKT_OAUTH_CLIENT_SECRET", "")
+
+	_, err := NewCloudClient(host)
+	if err == nil {
+		t.Fatal("expected expired OAuth preflight error")
+	}
+	if !strings.Contains(err.Error(), "oauth access token for api.bitbucket.org expired at") {
+		t.Errorf("error = %q, want expired OAuth message", err)
+	}
+	if !strings.Contains(err.Error(), "bkt auth login https://bitbucket.org --kind cloud --web-token") {
+		t.Errorf("error = %q, want API-token recovery command", err)
+	}
+}
+
 func TestNewCloudClientNilHostError(t *testing.T) {
 	_, err := NewCloudClient(nil)
 	if err == nil {
@@ -120,21 +147,132 @@ func TestSecretOptsNilHost(t *testing.T) {
 func TestOAuthTokenRefresherMissingCreds(t *testing.T) {
 	t.Setenv("BKT_OAUTH_CLIENT_ID", "")
 	t.Setenv("BKT_OAUTH_CLIENT_SECRET", "")
+	t.Setenv("BKT_ALLOW_INSECURE_STORE", "1")
+	t.Setenv("BKT_KEYRING_PASSPHRASE", "test-pass")
+	t.Setenv("KEYRING_BACKEND", "file")
+	fileDir := t.TempDir()
+	t.Setenv("KEYRING_FILE_DIR", fileDir)
+
+	tok := oauth.FromResponse("old-access", "old-refresh", -60)
+	blob, err := tok.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	store, err := secret.Open(secret.WithAllowFileFallback(true), secret.WithPassphrase("test-pass"), secret.WithFileDir(fileDir))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := store.Set(secret.TokenKey("api.bitbucket.org"), blob); err != nil {
+		t.Fatalf("store.Set: %v", err)
+	}
 
 	host := &config.Host{
 		Kind:               "cloud",
 		BaseURL:            "https://api.bitbucket.org/2.0",
 		AuthMethod:         "oauth",
+		Token:              "old-access",
 		AllowInsecureStore: true,
 	}
 
 	refresher := oauthTokenRefresher("api.bitbucket.org", host)
-	_, err := refresher(context.Background())
+	_, err = refresher(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), "Cloud OAuth consumer credentials are missing") {
+	if !strings.Contains(err.Error(), "BKT_OAUTH_CLIENT_ID / BKT_OAUTH_CLIENT_SECRET are not set") {
 		t.Errorf("error = %q", err)
+	}
+	if strings.Contains(err.Error(), "auth logout") {
+		t.Errorf("error = %q, should not recommend logout", err)
+	}
+	if !strings.Contains(err.Error(), "bkt auth login https://bitbucket.org --kind cloud --web-token") {
+		t.Errorf("error = %q, want API-token recovery command", err)
+	}
+}
+
+func TestOAuthTokenRefresherUsesNewerKeyringTokenWithoutCreds(t *testing.T) {
+	t.Setenv("BKT_OAUTH_CLIENT_ID", "")
+	t.Setenv("BKT_OAUTH_CLIENT_SECRET", "")
+	t.Setenv("BKT_ALLOW_INSECURE_STORE", "1")
+	t.Setenv("BKT_KEYRING_PASSPHRASE", "test-pass")
+	t.Setenv("KEYRING_BACKEND", "file")
+	fileDir := t.TempDir()
+	t.Setenv("KEYRING_FILE_DIR", fileDir)
+
+	tok := oauth.FromResponse("new-access", "new-refresh", 7200)
+	blob, err := tok.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	store, err := secret.Open(secret.WithAllowFileFallback(true), secret.WithPassphrase("test-pass"), secret.WithFileDir(fileDir))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := store.Set(secret.TokenKey("api.bitbucket.org"), blob); err != nil {
+		t.Fatalf("store.Set: %v", err)
+	}
+
+	host := &config.Host{
+		Kind:               "cloud",
+		BaseURL:            "https://api.bitbucket.org/2.0",
+		AuthMethod:         "oauth",
+		Token:              "old-access",
+		AllowInsecureStore: true,
+	}
+
+	refresher := oauthTokenRefresher("api.bitbucket.org", host)
+	got, err := refresher(context.Background())
+	if err != nil {
+		t.Fatalf("refresher: %v", err)
+	}
+	if got != "new-access" {
+		t.Errorf("token = %q, want new-access", got)
+	}
+	if host.Token != "new-access" {
+		t.Errorf("host.Token = %q, want new-access", host.Token)
+	}
+}
+
+func TestOAuthTokenRefresherUsesNewerKeyringTokenWithCreds(t *testing.T) {
+	t.Setenv("BKT_OAUTH_CLIENT_ID", "cid")         // gitleaks:allow
+	t.Setenv("BKT_OAUTH_CLIENT_SECRET", "csecret") // gitleaks:allow
+	t.Setenv("BKT_ALLOW_INSECURE_STORE", "1")
+	t.Setenv("BKT_KEYRING_PASSPHRASE", "test-pass")
+	t.Setenv("KEYRING_BACKEND", "file")
+	fileDir := t.TempDir()
+	t.Setenv("KEYRING_FILE_DIR", fileDir)
+
+	tok := oauth.FromResponse("new-access", "new-refresh", 7200)
+	blob, err := tok.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	store, err := secret.Open(secret.WithAllowFileFallback(true), secret.WithPassphrase("test-pass"), secret.WithFileDir(fileDir))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := store.Set(secret.TokenKey("api.bitbucket.org"), blob); err != nil {
+		t.Fatalf("store.Set: %v", err)
+	}
+
+	host := &config.Host{
+		Kind:               "cloud",
+		BaseURL:            "https://api.bitbucket.org/2.0",
+		AuthMethod:         "oauth",
+		Token:              "old-access",
+		AllowInsecureStore: true,
+	}
+
+	refresher := oauthTokenRefresher("api.bitbucket.org", host)
+	got, err := refresher(context.Background())
+	if err != nil {
+		t.Fatalf("refresher: %v", err)
+	}
+	if got != "new-access" {
+		t.Errorf("token = %q, want new-access", got)
+	}
+	if host.Token != "new-access" {
+		t.Errorf("host.Token = %q, want new-access", host.Token)
 	}
 }
 
@@ -219,7 +357,7 @@ func TestOAuthTokenRefresherSuccess(t *testing.T) {
 	t.Setenv("KEYRING_FILE_DIR", fileDir)
 
 	// Store a valid OAuth token blob in the keyring.
-	tok := oauth.FromResponse("old-access", "old-refresh", 7200)
+	tok := oauth.FromResponse("old-access", "old-refresh", -60)
 	blob, err := tok.Marshal()
 	if err != nil {
 		t.Fatalf("marshal: %v", err)

--- a/pkg/cmdutil/context.go
+++ b/pkg/cmdutil/context.go
@@ -293,16 +293,32 @@ func loadHostToken(executable, hostKey string, host *config.Host) error {
 		return err
 	}
 
+	switch host.AuthMethod {
+	case "oauth":
+		tok, parseErr := oauth.Unmarshal(token)
+		if parseErr != nil {
+			return fmt.Errorf("stored OAuth token for host %q is invalid: %w", hostKey, parseErr)
+		}
+		host.Token = tok.AccessToken
+		host.OAuthExpiresAt = tok.ExpiresAt
+		return nil
+	case "basic", "bearer":
+		host.Token = token
+		return nil
+	}
+
 	if oauth.IsTokenBlob(token) {
 		tok, parseErr := oauth.Unmarshal(token)
 		if parseErr != nil {
-			return fmt.Errorf("parse OAuth token for host %q: %w", hostKey, parseErr)
+			return fmt.Errorf("stored OAuth token for host %q is invalid: %w", hostKey, parseErr)
 		}
 		host.Token = tok.AccessToken
-		if host.AuthMethod == "" {
-			host.AuthMethod = "oauth"
-		}
+		host.AuthMethod = "oauth"
+		host.OAuthExpiresAt = tok.ExpiresAt
 		return nil
+	}
+	if strings.HasPrefix(strings.TrimSpace(token), "{") {
+		return fmt.Errorf("stored credential for host %q looks like JSON but is not a valid OAuth token; run `%s auth login %s` to replace it", hostKey, executable, hostKey)
 	}
 
 	host.Token = token

--- a/pkg/cmdutil/context_test.go
+++ b/pkg/cmdutil/context_test.go
@@ -960,6 +960,9 @@ func TestLoadHostTokenDetectsOAuthBlobFromKeyring(t *testing.T) {
 	if host.AuthMethod != "oauth" {
 		t.Errorf("AuthMethod = %q, want oauth", host.AuthMethod)
 	}
+	if host.OAuthExpiresAt.IsZero() {
+		t.Error("OAuthExpiresAt should be populated")
+	}
 }
 
 func TestLoadHostTokenPreservesExistingAuthMethodOnBlob(t *testing.T) {
@@ -985,6 +988,77 @@ func TestLoadHostTokenPreservesExistingAuthMethodOnBlob(t *testing.T) {
 	}
 }
 
+func TestLoadHostTokenExplicitBasicTreatsJSONAsPlainToken(t *testing.T) {
+	store := setupFileKeyring(t)
+
+	stored := `{"not_oauth":true}`
+	if err := store.Set(secret.TokenKey("api.bitbucket.org"), stored); err != nil {
+		t.Fatalf("store.Set: %v", err)
+	}
+
+	host := &config.Host{
+		Kind:               "cloud",
+		BaseURL:            "https://api.bitbucket.org/2.0",
+		AuthMethod:         "basic",
+		AllowInsecureStore: true,
+	}
+
+	if err := loadHostToken("bkt", "api.bitbucket.org", host); err != nil {
+		t.Fatalf("loadHostToken: %v", err)
+	}
+	if host.Token != stored {
+		t.Errorf("Token = %q, want literal stored token", host.Token)
+	}
+	if host.AuthMethod != "basic" {
+		t.Errorf("AuthMethod = %q, want basic", host.AuthMethod)
+	}
+}
+
+func TestLoadHostTokenExplicitOAuthRejectsPlainToken(t *testing.T) {
+	store := setupFileKeyring(t)
+
+	if err := store.Set(secret.TokenKey("api.bitbucket.org"), "plain-token"); err != nil {
+		t.Fatalf("store.Set: %v", err)
+	}
+
+	host := &config.Host{
+		Kind:               "cloud",
+		BaseURL:            "https://api.bitbucket.org/2.0",
+		AuthMethod:         "oauth",
+		AllowInsecureStore: true,
+	}
+
+	err := loadHostToken("bkt", "api.bitbucket.org", host)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "stored OAuth token") {
+		t.Errorf("error = %q, want stored OAuth token", err)
+	}
+}
+
+func TestLoadHostTokenRejectsJSONMissingOAuthFields(t *testing.T) {
+	store := setupFileKeyring(t)
+
+	if err := store.Set(secret.TokenKey("api.bitbucket.org"), `{"foo":"bar"}`); err != nil {
+		t.Fatalf("store.Set: %v", err)
+	}
+
+	host := &config.Host{
+		Kind:               "cloud",
+		BaseURL:            "https://api.bitbucket.org/2.0",
+		AllowInsecureStore: true,
+	}
+
+	err := loadHostToken("bkt", "api.bitbucket.org", host)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "looks like JSON but is not a valid OAuth token") {
+		t.Errorf("error = %q, want invalid OAuth token guidance", err)
+	}
+}
+
 func TestLoadHostTokenInvalidBlobFromKeyring(t *testing.T) {
 	store := setupFileKeyring(t)
 
@@ -1002,8 +1076,8 @@ func TestLoadHostTokenInvalidBlobFromKeyring(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for invalid JSON blob")
 	}
-	if !strings.Contains(err.Error(), "parse OAuth token") {
-		t.Errorf("error = %q, want 'parse OAuth token'", err)
+	if !strings.Contains(err.Error(), "looks like JSON but is not a valid OAuth token") {
+		t.Errorf("error = %q, want invalid OAuth token guidance", err)
 	}
 }
 

--- a/pkg/oauth/token.go
+++ b/pkg/oauth/token.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"time"
 )
@@ -48,15 +49,21 @@ func Unmarshal(s string) (*Token, error) {
 	if err := json.Unmarshal([]byte(s), &t); err != nil {
 		return nil, err
 	}
+	if strings.TrimSpace(t.AccessToken) == "" {
+		return nil, errors.New("missing access_token")
+	}
+	if strings.TrimSpace(t.RefreshToken) == "" {
+		return nil, errors.New("missing refresh_token")
+	}
+	if t.ExpiresAt.IsZero() {
+		return nil, errors.New("missing expires_at")
+	}
 	return &t, nil
 }
 
-// IsTokenBlob reports whether a keyring value is an OAuth JSON token blob
-// rather than a plain API token string.
-//
-// Detection relies on the fact that Bitbucket API tokens and PATs never begin
-// with '{'. This assumption should be verified if Bitbucket changes their
-// token format.
+// IsTokenBlob reports whether a keyring value is a complete OAuth JSON token
+// blob rather than a plain API token string.
 func IsTokenBlob(value string) bool {
-	return strings.HasPrefix(value, "{")
+	_, err := Unmarshal(value)
+	return err == nil
 }

--- a/pkg/oauth/token_test.go
+++ b/pkg/oauth/token_test.go
@@ -101,13 +101,29 @@ func TestUnmarshalInvalidJSON(t *testing.T) {
 	}
 }
 
+func TestUnmarshalMissingFields(t *testing.T) {
+	tests := []string{
+		`{}`,
+		`{"access_token":"acc","refresh_token":"ref"}`,
+		`{"access_token":"acc","expires_at":"2026-04-08T12:00:00Z"}`,
+		`{"refresh_token":"ref","expires_at":"2026-04-08T12:00:00Z"}`,
+	}
+	for _, input := range tests {
+		if _, err := Unmarshal(input); err == nil {
+			t.Fatalf("Unmarshal(%s) expected error", input)
+		}
+	}
+}
+
 func TestIsTokenBlob(t *testing.T) {
 	tests := []struct {
 		value string
 		want  bool
 	}{
-		{`{"access_token":"x"}`, true},
-		{`{}`, true},
+		{`{"access_token":"acc","refresh_token":"ref","expires_at":"2026-04-08T12:00:00Z"}`, true},
+		{`{"access_token":"x"}`, false},
+		{`{}`, false},
+		{`{invalid-json`, false},
 		{`plain-token-string`, false},
 		{``, false},
 		{`Bearer token`, false},

--- a/skills/bkt/rules/auth.md
+++ b/skills/bkt/rules/auth.md
@@ -6,7 +6,7 @@ Manage authentication credentials for Bitbucket Data Center and Cloud hosts.
 
 Tokens are stored in the OS keychain by default. For Data Center hosts, bkt
 uses Personal Access Tokens (PATs). For Bitbucket Cloud, bkt uses Atlassian
-API tokens (app passwords).
+API tokens with scopes.
 
 Use "bkt auth login" to add a host, "bkt auth status" to inspect stored
 credentials, and "bkt auth logout" to remove them.
@@ -120,7 +120,7 @@ bkt auth login [host] [flags]
 ### Examples
 
 ```bash
-# Login to Bitbucket Cloud via OAuth (recommended)
+# Login to Bitbucket Cloud via OAuth
   bkt auth login https://bitbucket.org --kind cloud --web
 
   # Login to Bitbucket Cloud with an API token


### PR DESCRIPTION
Harden Bitbucket Cloud credential handling around the OAuth/API-token split that caused expired OAuth credentials to look like API-token state.

Cloud API-token logins now persist `auth_method: basic`, and explicit configured auth methods are authoritative when loading keychain credentials. OAuth blob inference is limited to legacy missing-auth-method configs and now validates that stored JSON includes `access_token`, `refresh_token`, and `expires_at` before treating it as OAuth.

The Cloud client now carries runtime-only OAuth expiry metadata from the loaded token, fails fast when OAuth is already expired and consumer env vars are missing, and uses a per-host file lock around refresh and keychain write-back to avoid races with rotating refresh tokens. `bkt auth status` now surfaces inferred OAuth, expired OAuth, unavailable refresh state, and treats `BKT_TOKEN` as effective basic auth by default.

Recovery guidance now tells users to rerun `bkt auth login https://bitbucket.org --kind cloud --web-token` to replace stored OAuth credentials with a scoped API token, without recommending `auth logout` and deleting contexts. The login help also stops presenting OAuth as the recommended default for ordinary Cloud auth.