### PR TITLE
fix(auth): Restore release OAuth credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Check generated skill rules are up-to-date
         run: make check-generated-skill
 
+      - name: Check OAuth release contract
+        run: ./scripts/check-oauth-release-contract.sh
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -72,7 +75,10 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Build CLI
-        run: go build ./cmd/bkt
+        run: make build
+        env:
+          BKT_OAUTH_CLIENT_ID: ci-oauth-client-id
+          BKT_OAUTH_CLIENT_SECRET: ci-oauth-client-secret # gitleaks:allow
 
       - name: Generate SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,8 +147,13 @@ jobs:
         run: go vet ./...
       - name: Run tests
         run: make test
+      - name: Check OAuth release contract
+        run: ./scripts/check-oauth-release-contract.sh
       - name: Build CLI
         run: VERSION=${{ needs.prepare.outputs.tag }} make build
+        env:
+          BKT_OAUTH_CLIENT_ID: ${{ secrets.BKT_OAUTH_CLIENT_ID }}
+          BKT_OAUTH_CLIENT_SECRET: ${{ secrets.BKT_OAUTH_CLIENT_SECRET }}
       - name: Check embedded version
         run: ./bin/bkt --version | grep -Fx "bkt version ${{ needs.prepare.outputs.tag }}"
 
@@ -221,6 +226,16 @@ jobs:
           output_path.write_text(match.group(0).strip() + "\n", encoding="utf-8")
           PY
 
+      - name: Validate OAuth secrets
+        env:
+          BKT_OAUTH_CLIENT_ID: ${{ secrets.BKT_OAUTH_CLIENT_ID }}
+          BKT_OAUTH_CLIENT_SECRET: ${{ secrets.BKT_OAUTH_CLIENT_SECRET }}
+        run: |
+          if [ -z "$BKT_OAUTH_CLIENT_ID" ] || [ -z "$BKT_OAUTH_CLIENT_SECRET" ]; then
+            echo "::error::BKT_OAUTH_CLIENT_ID and BKT_OAUTH_CLIENT_SECRET must be set as repository secrets"
+            exit 1
+          fi
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
         with:
@@ -230,6 +245,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          BKT_OAUTH_CLIENT_ID: ${{ secrets.BKT_OAUTH_CLIENT_ID }}
+          BKT_OAUTH_CLIENT_SECRET: ${{ secrets.BKT_OAUTH_CLIENT_SECRET }}
 
       - name: Collect attestation subjects
         id: attestation_subjects

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,6 +24,8 @@ builds:
       - -X github.com/avivsinai/bitbucket-cli/internal/build.versionFromLdflags={{.Version}}
       - -X github.com/avivsinai/bitbucket-cli/internal/build.commitFromLdflags={{.Commit}}
       - -X github.com/avivsinai/bitbucket-cli/internal/build.dateFromLdflags={{.Date}}
+      - -X github.com/avivsinai/bitbucket-cli/pkg/oauth.cloudClientID={{ .Env.BKT_OAUTH_CLIENT_ID }}
+      - -X github.com/avivsinai/bitbucket-cli/pkg/oauth.cloudClientSecret={{ .Env.BKT_OAUTH_CLIENT_SECRET }}
     mod_timestamp: '{{ .CommitTimestamp }}'
     hooks:
       post:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented here. The format follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Restored zero-config Bitbucket Cloud browser OAuth in official release
+  binaries by embedding the CLI OAuth consumer credentials through release
+  ldflags again. `BKT_OAUTH_CLIENT_ID` and `BKT_OAUTH_CLIENT_SECRET` remain the
+  fallback for source and Nix builds (#189).
 
 ## [0.26.3] - 2026-04-26
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,13 @@ This is the master agent instruction file for this repository. Keep repository p
 - Release from `master` only through `./scripts/release.sh X.Y.Z` and the resulting release PR; do not create manual tags or GitHub releases.
 - A push to `master` updates the AvivSinai marketplace immediately for the `bkt` skill.
 - Keep `CHANGELOG.md` and skill/plugin metadata on one version in the release commit; after the release PR merges, CI validates the merged commit, creates the tag, publishes GitHub/Homebrew artifacts, and uses the committed changelog entry as the GitHub release notes.
+- Official release binaries must keep Bitbucket Cloud browser OAuth
+  (`bkt auth login --kind cloud --web`) zero-config by embedding bkt's OAuth
+  consumer credentials through GoReleaser ldflags. Source and Nix builds may
+  rely on `BKT_OAUTH_CLIENT_ID` / `BKT_OAUTH_CLIENT_SECRET`, but removing
+  release-binary embedding is a breaking user-facing auth change and must not
+  be done as generic security hardening. Keep
+  `scripts/check-oauth-release-contract.sh` in CI/release verification.
 - See `docs/RELEASE.md` for the full release handbook.
 
 ## Commit & Pull Request Guidelines

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,14 @@ VERSION ?= $(shell \
 )
 COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
 BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+BKT_OAUTH_CLIENT_ID ?=
+BKT_OAUTH_CLIENT_SECRET ?=
 LDFLAGS := -s -w \
 	-X github.com/avivsinai/bitbucket-cli/internal/build.versionFromLdflags=$(VERSION) \
 	-X github.com/avivsinai/bitbucket-cli/internal/build.commitFromLdflags=$(COMMIT) \
-	-X github.com/avivsinai/bitbucket-cli/internal/build.dateFromLdflags=$(BUILD_DATE)
+	-X github.com/avivsinai/bitbucket-cli/internal/build.dateFromLdflags=$(BUILD_DATE) \
+	-X github.com/avivsinai/bitbucket-cli/pkg/oauth.cloudClientID=$(BKT_OAUTH_CLIENT_ID) \
+	-X github.com/avivsinai/bitbucket-cli/pkg/oauth.cloudClientSecret=$(BKT_OAUTH_CLIENT_SECRET)
 
 .PHONY: build fmt lint test tidy sbom release snapshot clean check-skills check-generated-skill release-local generate-skill nix-update-vendor-hash
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Don't have Nix yet? See [nixos.asia/en/install](https://nixos.asia/en/install) f
 Download pre-built binaries for your platform from the [releases page](https://github.com/avivsinai/bitbucket-cli/releases/latest).
 The `.tar.gz` and `.zip` release archives also include `skills/bkt/`, so the CLI and canonical skill files stay in sync when you install from a release artifact.
 
-For Bitbucket Cloud OAuth (`bkt auth login --kind cloud --web`), set `BKT_OAUTH_CLIENT_ID` and `BKT_OAUTH_CLIENT_SECRET` in your environment. Official binaries, source installs, and Nix builds do not embed Cloud OAuth consumer credentials. API-token login via `--web-token` works without that extra setup.
+Official binaries support Bitbucket Cloud OAuth (`bkt auth login --kind cloud --web`) out of the box. Source and Nix builds can use the same flow by setting `BKT_OAUTH_CLIENT_ID` and `BKT_OAUTH_CLIENT_SECRET` in the environment. API-token login via `--web-token` works without that extra setup.
 
 ### Bitbucket Pipelines
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -35,9 +35,11 @@
 ## Guardrails
 
 - Treat `scripts/release.sh` as the only supported release entrypoint.
-- Release artifacts must not embed Bitbucket Cloud OAuth consumer credentials.
-  Cloud OAuth is env-driven at runtime (`BKT_OAUTH_CLIENT_ID` /
-  `BKT_OAUTH_CLIENT_SECRET`) and API-token login remains the zero-config path.
+- Official release artifacts must embed bkt's Bitbucket Cloud OAuth consumer
+  credentials through GoReleaser ldflags so `bkt auth login --kind cloud --web`
+  remains zero-config for release binaries. Do not remove the ldflags, release
+  workflow secret validation, or `scripts/check-oauth-release-contract.sh`
+  without an explicit breaking-change decision and changelog entry.
 - Refresh `flake.nix`'s `vendorHash` whenever `go.mod` or `go.sum` changes; do not wait until release time because Nix CI runs on pull requests. Use `make nix-update-vendor-hash` after dependency bumps.
 - `scripts/check-release-version.sh vX.Y.Z` now validates both metadata versions and the matching `CHANGELOG.md` heading.
 - If a release PR merges but the tag publish fails verification, fix forward with the next patch version instead of rewriting the failed tag.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -10,10 +10,11 @@ implementation details.
   Linux Secret Service) or an encrypted local file backend. Host metadata lives
   in `$XDG_CONFIG_HOME/bkt/config.yml` with permissions `0600`. The `BKT_TOKEN`
   environment variable provides runtime-only injection for CI/headless use.
-- Bitbucket Cloud OAuth consumer credentials are runtime-only too. Set
-  `BKT_OAUTH_CLIENT_ID` and `BKT_OAUTH_CLIENT_SECRET` in the environment when
-  using `bkt auth login --kind cloud --web`; release artifacts never bake them
-  into the binary.
+- Official release artifacts embed bkt's Bitbucket Cloud OAuth consumer
+  credentials so `bkt auth login --kind cloud --web` works out of the box.
+  Treat those credentials as public-client material owned by this CLI, not as
+  user secrets. Source and Nix builds read `BKT_OAUTH_CLIENT_ID` and
+  `BKT_OAUTH_CLIENT_SECRET` from the runtime environment.
 - For development, set `BKT_CONFIG_DIR` to a throwaway directory.
 - Never commit test credentials. Use environment variables or the
   `internal/config/testdata` fixtures when unit testing.

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -85,11 +85,11 @@ Access Token (PAT). The token needs Repository Read/Write and Project Read
 permissions. Use --web-token to open the PAT management page in your browser.
 
 For Bitbucket Cloud (--kind cloud), the simplest method is --web-token, which
-opens the Atlassian API token page and prompts for the token locally. If you
-prefer browser-based OAuth, use --web with BKT_OAUTH_CLIENT_ID and
-BKT_OAUTH_CLIENT_SECRET set in your environment. The CLI receives a short-lived
-access token that is automatically refreshed while those environment variables
-remain available.
+opens the Atlassian API token page and prompts for the token locally.
+Browser-based OAuth via --web works out of the box in official release
+binaries. For source and Nix builds, set BKT_OAUTH_CLIENT_ID and
+BKT_OAUTH_CLIENT_SECRET before running --web. The CLI receives a short-lived
+access token that is automatically refreshed.
 
 Credentials are verified against the remote host before being stored. If no
 OS keychain is available, pass --allow-insecure-store to use encrypted file

--- a/pkg/oauth/cloud.go
+++ b/pkg/oauth/cloud.go
@@ -6,8 +6,9 @@ import "os"
 //
 // The flow uses PKCE (RFC 7636, S256) for defense-in-depth. Bitbucket Cloud
 // still requires a client secret for authorization_code and refresh_token
-// exchanges, so bkt reads the consumer credentials from runtime environment
-// variables instead of embedding them in public release binaries.
+// exchanges. Official bkt release binaries embed the CLI's OAuth consumer
+// credentials so browser login works out of the box; source and Nix builds can
+// provide their own credentials through environment variables.
 const (
 	// CloudAuthorizeURL is the Bitbucket Cloud authorization endpoint.
 	CloudAuthorizeURL = "https://bitbucket.org/site/oauth2/authorize"
@@ -16,13 +17,27 @@ const (
 	CloudTokenURL = "https://bitbucket.org/site/oauth2/access_token"
 )
 
+// CloudClientID and CloudClientSecret are injected at build time via ldflags.
+// Environment variables remain the fallback for source, Nix, and development
+// builds that do not carry the official release credentials.
+var (
+	cloudClientID     string // set via -ldflags -X
+	cloudClientSecret string // set via -ldflags -X
+)
+
 // CloudClientID returns the OAuth consumer key.
 func CloudClientID() string {
+	if cloudClientID != "" {
+		return cloudClientID
+	}
 	return os.Getenv("BKT_OAUTH_CLIENT_ID")
 }
 
 // CloudClientSecret returns the OAuth consumer secret.
 func CloudClientSecret() string {
+	if cloudClientSecret != "" {
+		return cloudClientSecret
+	}
 	return os.Getenv("BKT_OAUTH_CLIENT_SECRET")
 }
 

--- a/pkg/oauth/cloud_test.go
+++ b/pkg/oauth/cloud_test.go
@@ -5,6 +5,10 @@ import (
 )
 
 func TestCloudClientIDFromEnv(t *testing.T) {
+	orig := cloudClientID
+	defer func() { cloudClientID = orig }()
+
+	cloudClientID = ""                        // gitleaks:allow
 	t.Setenv("BKT_OAUTH_CLIENT_ID", "env-id") // gitleaks:allow
 
 	if got := CloudClientID(); got != "env-id" {
@@ -12,7 +16,23 @@ func TestCloudClientIDFromEnv(t *testing.T) {
 	}
 }
 
+func TestCloudClientIDFromLdflags(t *testing.T) {
+	orig := cloudClientID
+	defer func() { cloudClientID = orig }()
+
+	cloudClientID = "build-id"                // gitleaks:allow
+	t.Setenv("BKT_OAUTH_CLIENT_ID", "env-id") // gitleaks:allow
+
+	if got := CloudClientID(); got != "build-id" {
+		t.Errorf("CloudClientID() = %q, want build-time value %q", got, "build-id")
+	}
+}
+
 func TestCloudClientIDEmpty(t *testing.T) {
+	orig := cloudClientID
+	defer func() { cloudClientID = orig }()
+
+	cloudClientID = ""                  // gitleaks:allow
 	t.Setenv("BKT_OAUTH_CLIENT_ID", "") // gitleaks:allow
 
 	if got := CloudClientID(); got != "" {
@@ -21,6 +41,10 @@ func TestCloudClientIDEmpty(t *testing.T) {
 }
 
 func TestCloudClientSecretFromEnv(t *testing.T) {
+	orig := cloudClientSecret
+	defer func() { cloudClientSecret = orig }()
+
+	cloudClientSecret = ""                            // gitleaks:allow
 	t.Setenv("BKT_OAUTH_CLIENT_SECRET", "env-secret") // gitleaks:allow
 
 	if got := CloudClientSecret(); got != "env-secret" {
@@ -28,7 +52,23 @@ func TestCloudClientSecretFromEnv(t *testing.T) {
 	}
 }
 
+func TestCloudClientSecretFromLdflags(t *testing.T) {
+	orig := cloudClientSecret
+	defer func() { cloudClientSecret = orig }()
+
+	cloudClientSecret = "build-secret"                // gitleaks:allow
+	t.Setenv("BKT_OAUTH_CLIENT_SECRET", "env-secret") // gitleaks:allow
+
+	if got := CloudClientSecret(); got != "build-secret" {
+		t.Errorf("CloudClientSecret() = %q, want build-time value %q", got, "build-secret")
+	}
+}
+
 func TestCloudClientSecretEmpty(t *testing.T) {
+	orig := cloudClientSecret
+	defer func() { cloudClientSecret = orig }()
+
+	cloudClientSecret = ""                  // gitleaks:allow
 	t.Setenv("BKT_OAUTH_CLIENT_SECRET", "") // gitleaks:allow
 
 	if got := CloudClientSecret(); got != "" {

--- a/scripts/check-oauth-release-contract.sh
+++ b/scripts/check-oauth-release-contract.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+if ! grep -Fq 'pkg/oauth.cloudClientID={{ .Env.BKT_OAUTH_CLIENT_ID }}' .goreleaser.yaml; then
+  fail ".goreleaser.yaml must embed BKT_OAUTH_CLIENT_ID via ldflags"
+fi
+if ! grep -Fq 'pkg/oauth.cloudClientSecret={{ .Env.BKT_OAUTH_CLIENT_SECRET }}' .goreleaser.yaml; then # gitleaks:allow
+  fail ".goreleaser.yaml must embed BKT_OAUTH_CLIENT_SECRET via ldflags"
+fi
+
+if ! grep -Fq 'BKT_OAUTH_CLIENT_ID: ${{ secrets.BKT_OAUTH_CLIENT_ID }}' .github/workflows/release.yml; then
+  fail "release workflow must pass BKT_OAUTH_CLIENT_ID to release builds"
+fi
+if ! grep -Fq 'BKT_OAUTH_CLIENT_SECRET: ${{ secrets.BKT_OAUTH_CLIENT_SECRET }}' .github/workflows/release.yml; then
+  fail "release workflow must pass BKT_OAUTH_CLIENT_SECRET to release builds"
+fi
+if ! grep -Fq 'BKT_OAUTH_CLIENT_ID and BKT_OAUTH_CLIENT_SECRET must be set as repository secrets' .github/workflows/release.yml; then
+  fail "release workflow must validate OAuth release secrets before publishing"
+fi
+
+oauth_ldflags="-X github.com/avivsinai/bitbucket-cli/pkg/oauth.cloudClientID=build-id -X github.com/avivsinai/bitbucket-cli/pkg/oauth.cloudClientSecret=build-secret" # gitleaks:allow
+go test -run 'TestCloudClient(ID|Secret)FromLdflags' \
+  -ldflags "$oauth_ldflags" \
+  ./pkg/oauth

--- a/skills/bkt/SKILL.md
+++ b/skills/bkt/SKILL.md
@@ -48,14 +48,14 @@ If not authenticated, log in:
 # Data Center (PAT-based)
 bkt auth login https://bitbucket.example.com --username alice --token <PAT>
 
-# Bitbucket Cloud — OAuth (recommended; opens browser)
+# Bitbucket Cloud — OAuth (official binaries open browser out of the box)
 bkt auth login https://bitbucket.org --kind cloud --web
 
 # Bitbucket Cloud — API token (--web-token opens Atlassian's token creation page)
 bkt auth login https://bitbucket.org --kind cloud --web-token
 ```
 
-For `go install` builds, set `BKT_OAUTH_CLIENT_ID` and `BKT_OAUTH_CLIENT_SECRET` env vars before running `--web`.
+For source and Nix builds, set `BKT_OAUTH_CLIENT_ID` and `BKT_OAUTH_CLIENT_SECRET` env vars before running `--web`.
 
 **3. Set up a context** — contexts bind a host to a project/workspace and optional default repo, so you don't repeat flags on every command:
 

--- a/skills/bkt/rules/auth.md
+++ b/skills/bkt/rules/auth.md
@@ -76,11 +76,11 @@ Access Token (PAT). The token needs Repository Read/Write and Project Read
 permissions. Use --web-token to open the PAT management page in your browser.
 
 For Bitbucket Cloud (--kind cloud), the simplest method is --web-token, which
-opens the Atlassian API token page and prompts for the token locally. If you
-prefer browser-based OAuth, use --web with BKT_OAUTH_CLIENT_ID and
-BKT_OAUTH_CLIENT_SECRET set in your environment. The CLI receives a short-lived
-access token that is automatically refreshed while those environment variables
-remain available.
+opens the Atlassian API token page and prompts for the token locally.
+Browser-based OAuth via --web works out of the box in official release
+binaries. For source and Nix builds, set BKT_OAUTH_CLIENT_ID and
+BKT_OAUTH_CLIENT_SECRET before running --web. The CLI receives a short-lived
+access token that is automatically refreshed.
 
 Credentials are verified against the remote host before being stored. If no
 OS keychain is available, pass --allow-insecure-store to use encrypted file

--- a/skills/bkt/rules/headless.md
+++ b/skills/bkt/rules/headless.md
@@ -45,7 +45,7 @@ bkt pr list
 | `BKT_CONFIG_DIR` | Config directory override. |
 | `BKT_ALLOW_INSECURE_STORE` | Allow file-based credential storage. |
 | `BKT_KEYRING_TIMEOUT` | Keyring operation timeout (e.g. `2m`). |
-| `BKT_OAUTH_CLIENT_ID` | OAuth consumer key. Used at runtime when not embedded via ldflags (e.g. `go install` builds). |
+| `BKT_OAUTH_CLIENT_ID` | OAuth consumer key. Used at runtime when not embedded via ldflags (e.g. source and Nix builds). |
 | `BKT_OAUTH_CLIENT_SECRET` | OAuth consumer secret. Same fallback logic as `BKT_OAUTH_CLIENT_ID`. |
 
 ## Saved-host behaviour


### PR DESCRIPTION
Restore zero-config Bitbucket Cloud browser OAuth for official release binaries.

PR #179 removed the GoReleaser ldflags and release workflow secret injection that embedded bkt's OAuth consumer credentials. That made `bkt auth login --kind cloud --web` fail immediately in v0.26.1 through v0.26.3 unless users supplied their own OAuth app through environment variables.

This restores the ldflag-backed credential source with environment fallback for source and Nix builds, adds a CI/release guard for the contract, updates repository instructions so this is not repeated as generic security hardening, and corrects the docs/skill guidance.

Fixes #189