### PR TITLE
chore(release): v0.26.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.26.3",
+  "version": "0.26.4",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.26.3",
+  "version": "0.26.4",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,14 @@ All notable changes to this project will be documented here. The format follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
+## [0.26.4] - 2026-04-27
 ### Fixed
 - Restored zero-config Bitbucket Cloud browser OAuth in official release
   binaries by embedding the CLI OAuth consumer credentials through release
   ldflags again. `BKT_OAUTH_CLIENT_ID` and `BKT_OAUTH_CLIENT_SECRET` remain the
   fallback for source and Nix builds (#189).
+
 
 ## [0.26.3] - 2026-04-26
 ### Added
@@ -485,7 +488,8 @@ All notable changes to this project will be documented here. The format follows
 ## [0.1.0] - 2025-10-26
 - Initial public release of `bkt`.
 
-[Unreleased]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.3...HEAD
+[Unreleased]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.4...HEAD
+[0.26.4]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.3...v0.26.4
 [0.26.3]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.2...v0.26.3
 [0.26.2]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.1...v0.26.2
 [0.26.1]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.0...v0.26.1

--- a/skills/bkt/SKILL.md
+++ b/skills/bkt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bkt
-version: 0.26.3
+version: 0.26.4
 description: Bitbucket CLI for Data Center and Cloud. Use when users need to manage repositories, pull requests, branches, issues, webhooks, or pipelines in Bitbucket. Triggers include "bitbucket", "bkt", "pull request", "PR", "repo list", "branch create", "Bitbucket Data Center", "Bitbucket Cloud", "keyring timeout".
 metadata:
   short-description: Bitbucket CLI for repos, PRs, branches


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.26.4`
- aligns skill/plugin metadata to `0.26.4`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.26.4`, publishes the release, and publishes skills in the same workflow run