### PR TITLE
fix(release): Correct Homebrew formula test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Check OAuth release contract
         run: ./scripts/check-oauth-release-contract.sh
 
+      - name: Check Homebrew formula test
+        run: ./scripts/check-homebrew-formula-test.sh
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,8 @@ jobs:
         run: make test
       - name: Check OAuth release contract
         run: ./scripts/check-oauth-release-contract.sh
+      - name: Check Homebrew formula test
+        run: ./scripts/check-homebrew-formula-test.sh
       - name: Build CLI
         run: VERSION=${{ needs.prepare.outputs.tag }} make build
         env:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -154,7 +154,7 @@ brews:
     install: |
       bin.install "bkt"
     test: |
-      system "#{bin}/bkt", "version"
+      system "#{bin}/bkt", "--version"
 
 scoops:
   - name: bitbucket-cli

--- a/scripts/check-homebrew-formula-test.sh
+++ b/scripts/check-homebrew-formula-test.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+expected='system "#{bin}/bkt", "--version"'
+old='system "#{bin}/bkt", "version"'
+
+if grep -Fq "$old" .goreleaser.yaml; then
+  fail ".goreleaser.yaml Homebrew test uses nonexistent 'bkt version' command"
+fi
+
+if ! grep -Fq "$expected" .goreleaser.yaml; then
+  fail ".goreleaser.yaml Homebrew test must run 'bkt --version'"
+fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -241,6 +241,7 @@ if [ "$skip_verify" -eq 0 ]; then
   fi
   go vet ./...
   make test
+  ./scripts/check-homebrew-formula-test.sh
   make build
 fi
 


### PR DESCRIPTION
Correct the GoReleaser Homebrew formula test to call `bkt --version`, which is the supported version command.

This was found while validating the `0.26.3 -> 0.26.4` Homebrew upgrade path after the OAuth hotfix: the upgrade itself works, but `brew test` fails because the generated formula calls the nonexistent `bkt version` subcommand.

This also adds a release-contract guard so CI and release verification fail if the GoReleaser config regresses back to the bad test command.