### PR TITLE
fix: infer Bitbucket Cloud auth for bitbucket.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ bkt --help
 #### Bitbucket Data Center
 
 ```bash
-# Guided flow: opens browser to create token
-bkt auth login https://bitbucket.mycorp.example --web
+# Guided flow: opens browser to create a Personal Access Token
+bkt auth login https://bitbucket.mycorp.example --web-token
 
 # Or provide credentials directly
 bkt auth login https://bitbucket.mycorp.example --username alice --token <PAT>
@@ -202,7 +202,7 @@ Create a **Personal Access Token (PAT)** in Bitbucket Data Center:
 #### Bitbucket Cloud
 
 ```bash
-# Guided flow: opens browser to create token
+# Browser OAuth flow for Bitbucket Cloud
 bkt auth login https://bitbucket.org --kind cloud --web
 
 # Or provide credentials directly

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"runtime"
 	"sort"
@@ -173,6 +174,9 @@ func runLogin(cmd *cobra.Command, f *cmdutil.Factory, opts *loginOptions) error 
 	kind := strings.ToLower(opts.Kind)
 	if kind == "" {
 		kind = "dc"
+	}
+	if kind == "dc" && isBitbucketCloudBaseURL(baseURL) {
+		kind = "cloud"
 	}
 
 	authMethod := strings.ToLower(strings.TrimSpace(opts.AuthMethod))
@@ -813,6 +817,15 @@ func deleteHostToken(hostKey string, host *config.Host) error {
 	}
 	host.Token = ""
 	return nil
+}
+
+func isBitbucketCloudBaseURL(baseURL string) bool {
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	return host == "bitbucket.org" || host == "api.bitbucket.org"
 }
 
 func promptString(reader *bufio.Reader, out io.Writer, label string) (string, error) {

--- a/pkg/cmd/auth/auth_test.go
+++ b/pkg/cmd/auth/auth_test.go
@@ -283,6 +283,32 @@ func TestRunLoginRejectsWebOnDC(t *testing.T) {
 	}
 }
 
+func TestRunLoginInfersCloudForBitbucketOrgWeb(t *testing.T) {
+	t.Setenv("BKT_OAUTH_CLIENT_ID", "")
+	t.Setenv("BKT_OAUTH_CLIENT_SECRET", "")
+
+	cfg := &config.Config{
+		Hosts:    make(map[string]*config.Host),
+		Contexts: make(map[string]*config.Context),
+	}
+	f, _, _ := newAuthTestFactory(cfg)
+
+	err := runLogin(&cobra.Command{}, f, &loginOptions{
+		Host: "https://bitbucket.org",
+		Kind: "dc",
+		Web:  true,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if strings.Contains(err.Error(), "only supported for Bitbucket Cloud") {
+		t.Errorf("bitbucket.org should infer cloud before --web validation, got %q", err)
+	}
+	if !strings.Contains(err.Error(), "cloud OAuth requires BKT_OAUTH_CLIENT_ID and BKT_OAUTH_CLIENT_SECRET") {
+		t.Errorf("error = %q", err)
+	}
+}
+
 func TestRunLoginRejectsWebAndWebToken(t *testing.T) {
 	cfg := &config.Config{
 		Hosts:    make(map[string]*config.Host),


### PR DESCRIPTION
## Summary
- fix the Data Center README example to use `--web-token` instead of unsupported `--web`
- infer Bitbucket Cloud for `https://bitbucket.org` and `https://api.bitbucket.org` before validating `--web`
- add a regression test proving `bitbucket.org --web` reaches the Cloud OAuth path

Fixes #194.

## Test plan
- `go test ./pkg/cmd/auth -run 'TestRunLogin(RejectsWebOnDC|InfersCloudForBitbucketOrgWeb|RejectsWebWithoutOAuthCreds)'`\n- `go test ./...`\n- `make build`\n- `make lint`\n- `git diff --check`\n- manual smoke: `bkt auth login https://bitbucket.org --web` now reports missing Cloud OAuth env instead of the Data Center `--web` rejection\n- manual smoke: `bkt auth login https://bitbucket.example.com --web` still rejects Data Center `--web` with the `--web-token` guidance