### PR TITLE
chore(release): v0.26.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.26.4",
+  "version": "0.26.5",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.26.4",
+  "version": "0.26.5",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ All notable changes to this project will be documented here. The format follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
+## [0.26.5] - 2026-05-11
 ### Fixed
 - Corrected the Bitbucket Data Center README login example to use
   `--web-token`, and made `bkt auth login https://bitbucket.org --web`
   infer Bitbucket Cloud before validating the browser OAuth flow (#194).
+
 
 ## [0.26.4] - 2026-04-27
 ### Fixed
@@ -492,7 +495,8 @@ All notable changes to this project will be documented here. The format follows
 ## [0.1.0] - 2025-10-26
 - Initial public release of `bkt`.
 
-[Unreleased]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.4...HEAD
+[Unreleased]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.5...HEAD
+[0.26.5]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.4...v0.26.5
 [0.26.4]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.3...v0.26.4
 [0.26.3]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.2...v0.26.3
 [0.26.2]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.1...v0.26.2

--- a/skills/bkt/SKILL.md
+++ b/skills/bkt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bkt
-version: 0.26.4
+version: 0.26.5
 description: Bitbucket CLI for Data Center and Cloud. Use when users need to manage repositories, pull requests, branches, issues, webhooks, or pipelines in Bitbucket. Triggers include "bitbucket", "bkt", "pull request", "PR", "repo list", "branch create", "Bitbucket Data Center", "Bitbucket Cloud", "keyring timeout".
 metadata:
   short-description: Bitbucket CLI for repos, PRs, branches


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.26.5`
- aligns skill/plugin metadata to `0.26.5`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.26.5`, publishes the release, and publishes skills in the same workflow run