### PR TITLE
fix: correctly show step result for pipeline view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+- Bitbucket Cloud pipeline steps now decode `state.result` the same way as
+  pipeline runs, so `bkt pipeline view`, `bkt pipeline view --json`, and
+  `bkt status pipeline` show per-step outcomes (for example `FAILED` vs
+  `SUCCESSFUL`) instead of only `COMPLETED`.
+
 ## [0.26.5] - 2026-05-11
 ### Fixed
 - Corrected the Bitbucket Data Center README login example to use

--- a/pkg/bbcloud/client.go
+++ b/pkg/bbcloud/client.go
@@ -2,6 +2,7 @@ package bbcloud
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"regexp"
@@ -476,17 +477,78 @@ func (c *Client) GetPipelineByBuildNumber(ctx context.Context, workspace, repoSl
 
 // PipelineStep represents an individual pipeline step execution.
 type PipelineStep struct {
-	UUID  string        `json:"uuid"`
-	Name  string        `json:"name"`
-	State PipelineState `json:"state"`
+	UUID   string        `json:"uuid"`
+	Name   string        `json:"name"`
+	State  PipelineState `json:"state"`
+	Result struct {
+		Name string `json:"name,omitempty"`
+	} `json:"result,omitempty"` // compatibility alias; API outcome lives in state.result
+}
+
+// UnmarshalJSON decodes Bitbucket step JSON and keeps Result in sync with state.result
+// so Status() and legacy JSON consumers that read steps[].result.name keep working.
+func (s *PipelineStep) UnmarshalJSON(data []byte) error {
+	type rawStep struct {
+		UUID   string        `json:"uuid"`
+		Name   string        `json:"name"`
+		State  PipelineState `json:"state"`
+		Result struct {
+			Name string `json:"name"`
+		} `json:"result"`
+	}
+	var raw rawStep
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	s.UUID = raw.UUID
+	s.Name = raw.Name
+	s.State = raw.State
+	switch {
+	case raw.State.Result.Name != "":
+		s.Result.Name = raw.State.Result.Name
+	case raw.Result.Name != "":
+		s.Result.Name = raw.Result.Name
+		s.State.Result.Name = raw.Result.Name
+	}
+	return nil
+}
+
+// MarshalJSON emits state.result and a top-level result alias for structured CLI output.
+func (s PipelineStep) MarshalJSON() ([]byte, error) {
+	type out struct {
+		UUID   string        `json:"uuid"`
+		Name   string        `json:"name"`
+		State  PipelineState `json:"state"`
+		Result struct {
+			Name string `json:"name,omitempty"`
+		} `json:"result,omitempty"`
+	}
+	resultName := s.State.Result.Name
+	if resultName == "" {
+		resultName = s.Result.Name
+	}
+	var alias struct {
+		Name string `json:"name,omitempty"`
+	}
+	alias.Name = resultName
+	return json.Marshal(out{
+		UUID:   s.UUID,
+		Name:   s.Name,
+		State:  s.State,
+		Result: alias,
+	})
 }
 
 // Status returns the step state and result as a single string.
 // When the step is completed the result is appended (e.g. "COMPLETED SUCCESSFUL"),
 // otherwise only the state is returned (e.g. "PENDING").
 func (s PipelineStep) Status() string {
-	if s.State.Result.Name != "" {
-		return s.State.Name + " " + s.State.Result.Name
+	result := s.State.Result.Name
+	if result == "" {
+		result = s.Result.Name
+	}
+	if result != "" {
+		return s.State.Name + " " + result
 	}
 	return s.State.Name
 }

--- a/pkg/bbcloud/client.go
+++ b/pkg/bbcloud/client.go
@@ -116,20 +116,24 @@ type Repository struct {
 	} `json:"project"`
 }
 
+// PipelineState is the nested state object returned by Bitbucket for pipeline runs
+// and for individual pipeline steps (phase in Name, outcome in Result when finished).
+type PipelineState struct {
+	Result struct {
+		Name string `json:"name"`
+	} `json:"result"`
+	Stage struct {
+		Name string `json:"name"`
+	} `json:"stage"`
+	Name string `json:"name"`
+}
+
 // Pipeline represents a pipeline execution.
 type Pipeline struct {
-	UUID        string `json:"uuid"`
-	BuildNumber int    `json:"build_number"`
-	State       struct {
-		Result struct {
-			Name string `json:"name"`
-		} `json:"result"`
-		Stage struct {
-			Name string `json:"name"`
-		} `json:"stage"`
-		Name string `json:"name"`
-	} `json:"state"`
-	Target struct {
+	UUID        string        `json:"uuid"`
+	BuildNumber int           `json:"build_number"`
+	State       PipelineState `json:"state"`
+	Target      struct {
 		Type string `json:"type"`
 		Ref  struct {
 			Name string `json:"name"`
@@ -472,22 +476,17 @@ func (c *Client) GetPipelineByBuildNumber(ctx context.Context, workspace, repoSl
 
 // PipelineStep represents an individual pipeline step execution.
 type PipelineStep struct {
-	UUID  string `json:"uuid"`
-	Name  string `json:"name"`
-	State struct {
-		Name string `json:"name"`
-	} `json:"state"`
-	Result struct {
-		Name string `json:"name"`
-	} `json:"result"`
+	UUID  string        `json:"uuid"`
+	Name  string        `json:"name"`
+	State PipelineState `json:"state"`
 }
 
 // Status returns the step state and result as a single string.
 // When the step is completed the result is appended (e.g. "COMPLETED SUCCESSFUL"),
 // otherwise only the state is returned (e.g. "PENDING").
 func (s PipelineStep) Status() string {
-	if s.Result.Name != "" {
-		return s.State.Name + " " + s.Result.Name
+	if s.State.Result.Name != "" {
+		return s.State.Name + " " + s.State.Result.Name
 	}
 	return s.State.Name
 }

--- a/pkg/bbcloud/client_test.go
+++ b/pkg/bbcloud/client_test.go
@@ -30,8 +30,82 @@ func TestPipelineStepJSONNestedStateResult(t *testing.T) {
 	if step.State.Name != "COMPLETED" || step.State.Result.Name != "FAILED" {
 		t.Fatalf("state not parsed: %+v", step.State)
 	}
+	if step.Result.Name != "FAILED" {
+		t.Fatalf("compatibility Result.Name = %q, want FAILED", step.Result.Name)
+	}
 	if got := step.Status(); got != "COMPLETED FAILED" {
 		t.Fatalf("Status() = %q, want COMPLETED FAILED", got)
+	}
+	out, err := json.Marshal(step)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(out, &obj); err != nil {
+		t.Fatalf("round-trip: %v", err)
+	}
+	rawResult, ok := obj["result"]
+	if !ok {
+		t.Fatalf("marshaled step JSON missing top-level result: %s", out)
+	}
+	var resultObj struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(rawResult, &resultObj); err != nil {
+		t.Fatalf("result object: %v", err)
+	}
+	if resultObj.Name != "FAILED" {
+		t.Fatalf("result.name = %q, want FAILED", resultObj.Name)
+	}
+}
+
+func TestPipelineStepJSONLegacyTopLevelResult(t *testing.T) {
+	// Some payloads may carry the outcome only at the top-level result field.
+	const payload = `{
+		"uuid": "{123e4567-e89b-12d3-a456-426614174000}",
+		"name": "lint",
+		"state": {"name": "COMPLETED"},
+		"result": {"name": "SUCCESSFUL"}
+	}`
+	var step PipelineStep
+	if err := json.Unmarshal([]byte(payload), &step); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if step.State.Result.Name != "SUCCESSFUL" || step.Result.Name != "SUCCESSFUL" {
+		t.Fatalf("expected state and alias result: state=%+v result=%+v", step.State.Result, step.Result)
+	}
+	if got := step.Status(); got != "COMPLETED SUCCESSFUL" {
+		t.Fatalf("Status() = %q, want COMPLETED SUCCESSFUL", got)
+	}
+}
+
+func TestPipelineStepMarshalJSONTopLevelResultFromStateOnly(t *testing.T) {
+	step := PipelineStep{
+		UUID: "{123e4567-e89b-12d3-a456-426614174000}",
+		Name: "lint",
+	}
+	step.State.Name = "COMPLETED"
+	step.State.Result.Name = "SUCCESSFUL"
+	out, err := json.Marshal(step)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(out, &obj); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	rawResult, ok := obj["result"]
+	if !ok {
+		t.Fatalf("expected top-level result in JSON: %s", out)
+	}
+	var got struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(rawResult, &got); err != nil {
+		t.Fatalf("result: %v", err)
+	}
+	if got.Name != "SUCCESSFUL" {
+		t.Fatalf("result.name = %q", got.Name)
 	}
 }
 

--- a/pkg/bbcloud/client_test.go
+++ b/pkg/bbcloud/client_test.go
@@ -12,6 +12,29 @@ import (
 	"github.com/avivsinai/bitbucket-cli/pkg/httpx"
 )
 
+func TestPipelineStepJSONNestedStateResult(t *testing.T) {
+	const payload = `{
+		"uuid": "{123e4567-e89b-12d3-a456-426614174000}",
+		"name": "lint",
+		"state": {
+			"name": "COMPLETED",
+			"result": {
+				"name": "FAILED"
+			}
+		}
+	}`
+	var step PipelineStep
+	if err := json.Unmarshal([]byte(payload), &step); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if step.State.Name != "COMPLETED" || step.State.Result.Name != "FAILED" {
+		t.Fatalf("state not parsed: %+v", step.State)
+	}
+	if got := step.Status(); got != "COMPLETED FAILED" {
+		t.Fatalf("Status() = %q, want COMPLETED FAILED", got)
+	}
+}
+
 func TestPipelineStepStatus(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -32,7 +55,7 @@ func TestPipelineStepStatus(t *testing.T) {
 				Name: "lint",
 			}
 			step.State.Name = tt.state
-			step.Result.Name = tt.result
+			step.State.Result.Name = tt.result
 			if got := step.Status(); got != tt.want {
 				t.Errorf("Status() = %q, want %q", got, tt.want)
 			}


### PR DESCRIPTION
First of all, thanks for making this tool :)  I rarely have to open Bitbucket's UI anymore

## Summary

When running the `bkt pipeline view` command, currently we can see that the overall pipeline failed but not which individual steps caused the failure (which just show "COMPLETED"). This PR fixes this by parsing the `PipelineState` object properly from the API response. 

## Testing

- [x] `make fmt`
- [x] `make test`
- [x] `make build`
- [x] Other (please specify): make sbom

## Screenshots / recordings

Below I've added the CLI output from running this against one of my own repos.

Before:
```json
{
  "pipeline": {
    "uuid": "{some-uuid}",
    "build_number": 2571,
    "state": {
      "result": {
        "name": "FAILED"
      },
      "stage": {
        "name": ""
      },
      "name": "COMPLETED"
    },
    "target": {
      "type": "pipeline_pullrequest_target",
      "ref": {
        "name": ""
      }
    },
    "created_on": "some-date",
    "completed_on": "some-date"
  },
  "steps": [
    {
      "uuid": "{some-uuid}",
      "name": "DB Tests - PostgreSQL",
      "state": {
        "name": "COMPLETED"
      },
      "result": {
        "name": ""
      }
    }
  ]
}
```

After:
```json
{
  "pipeline": {
    "uuid": "{some-uuid}",
    "build_number": 2571,
    "state": {
      "result": {
        "name": "FAILED"
      },
      "stage": {
        "name": ""
      },
      "name": "COMPLETED"
    },
    "target": {
      "type": "pipeline_pullrequest_target",
      "ref": {
        "name": ""
      }
    },
    "created_on": "some-date",
    "completed_on": "some-date"
  },
  "steps": [
    {
      "uuid": "{some-uuid}",
      "name": "DB Tests - PostgreSQL",
      "state": {
        "result": {
          "name": "FAILED"
        },
        "stage": {
          "name": ""
        },
        "name": "COMPLETED"
      },
      "result": {
        "name": "FAILED"
      }
    }
  ]
}
```

## Checklist

- [ ] Adds or updates documentation
- [x] Updates `CHANGELOG.md`
- [x] Signed commits (`git commit -s`)

## Notes for reviewers

This seemed like a benign change so I didn't open an issue for it. Please let me know if this was an incorrect assumption!