### PR TITLE
chore(release): v0.26.6

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.26.5",
+  "version": "0.26.6",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.26.5",
+  "version": "0.26.6",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ All notable changes to this project will be documented here. The format follows
 
 ## [Unreleased]
 
+## [0.26.6] - 2026-05-13
 ### Fixed
 - Bitbucket Cloud pipeline steps now decode `state.result` the same way as
   pipeline runs, so `bkt pipeline view`, `bkt pipeline view --json`, and
   `bkt status pipeline` show per-step outcomes (for example `FAILED` vs
   `SUCCESSFUL`) instead of only `COMPLETED`.
+
 
 ## [0.26.5] - 2026-05-11
 ### Fixed
@@ -501,7 +503,8 @@ All notable changes to this project will be documented here. The format follows
 ## [0.1.0] - 2025-10-26
 - Initial public release of `bkt`.
 
-[Unreleased]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.5...HEAD
+[Unreleased]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.6...HEAD
+[0.26.6]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.5...v0.26.6
 [0.26.5]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.4...v0.26.5
 [0.26.4]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.3...v0.26.4
 [0.26.3]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.2...v0.26.3

--- a/skills/bkt/SKILL.md
+++ b/skills/bkt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bkt
-version: 0.26.5
+version: 0.26.6
 description: Bitbucket CLI for Data Center and Cloud. Use when users need to manage repositories, pull requests, branches, issues, webhooks, or pipelines in Bitbucket. Triggers include "bitbucket", "bkt", "pull request", "PR", "repo list", "branch create", "Bitbucket Data Center", "Bitbucket Cloud", "keyring timeout".
 metadata:
   short-description: Bitbucket CLI for repos, PRs, branches


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.26.6`
- aligns skill/plugin metadata to `0.26.6`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.26.6`, publishes the release, and publishes skills in the same workflow run