### PR TITLE
docs(skill): fix jq example for object-shaped pr list output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented here. The format follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Corrected the `bkt` skill's structured-output example: piping
+  `bkt pr list --json` to `jq '.[].title'` fails because the command
+  returns an object keyed by `pull_requests`, not a bare array. The
+  example now uses `jq '.pull_requests[].title'`.
 
 ## [0.26.6] - 2026-05-13
 ### Fixed

--- a/skills/bkt/SKILL.md
+++ b/skills/bkt/SKILL.md
@@ -115,7 +115,7 @@ bkt pr checkout 42               # Creates pr/42 branch
 All commands support `--json`, `--yaml`, `--jq`, and `--template`:
 
 ```bash
-bkt pr list --mine --json | jq '.[].title'
+bkt pr list --mine --json | jq '.pull_requests[].title'
 ```
 
 ### Raw API escape hatch


### PR DESCRIPTION
## Summary

The `bkt` skill's structured-output example in `skills/bkt/SKILL.md`
pipes `bkt pr list --json` to `jq '.[].title'`, which fails with
`jq: error ... Cannot iterate over object`. The command's JSON
output is an object keyed by `pull_requests`, `repo`, and
`workspace` (see `pkg/cmd/pr/pr.go:195, 261, 308, 385`), not a bare
array, so the iteration needs to descend into `.pull_requests[]`.

Reproduction against the current master:

```bash
$ bkt pr list --mine --json | jq '.[].title'
jq: error (at <stdin>:1): Cannot iterate over object (...)
$ bkt pr list --mine --json | jq '.pull_requests[].title'
"feat: add caching"
```

Docs-only change; no code or behavior is affected.

## Testing

- [x] `make fmt`
- [x] `make test`
- [x] `make build`
- [ ] Other (please specify):

## Screenshots / recordings

N/A — text/docs change.

## Checklist

- [x] Adds or updates documentation
- [x] Updates `CHANGELOG.md`
- [x] Signed commits (`git commit -s`)

## Notes for reviewers

Scoped intentionally narrow — single example line in `SKILL.md`
plus one `[Unreleased]` changelog entry. Happy to broaden the
example (e.g., to mention the object shape inline) if preferred.