### PR TITLE
[codex] Grant Gitleaks PR read permission

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  pull-requests: read
   contents: read
   security-events: write
   actions: read


### PR DESCRIPTION
## Summary
- Grant the Gitleaks workflow explicit `pull-requests: read` permission.

## Why
Repository default `GITHUB_TOKEN` permissions are now read-only. `gitleaks/gitleaks-action` reads pull request commits via the GitHub API during PR scans, so it needs this explicit minimal permission.

## Validation
- Triggered by the token-permission hardening pass; no scan rules were loosened.
