### PR TITLE
fix: support numeric pipeline build numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented here. The format follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fixed `bkt pipeline view <build-number>` and `bkt pipeline logs <build-number>`
+  so numeric build numbers use the Bitbucket Cloud build-number lookup without
+  falling through to UUID validation.
 
 ## [0.27.0] - 2026-05-29
 ### Added

--- a/pkg/bbcloud/client.go
+++ b/pkg/bbcloud/client.go
@@ -461,7 +461,13 @@ func (c *Client) GetPipeline(ctx context.Context, workspace, repoSlug, uuid stri
 
 // GetPipelineByBuildNumber fetches a pipeline by its build number.
 func (c *Client) GetPipelineByBuildNumber(ctx context.Context, workspace, repoSlug string, buildNumber int) (*Pipeline, error) {
-	// Bitbucket Cloud API supports querying by build number via the same endpoint
+	if workspace == "" || repoSlug == "" {
+		return nil, fmt.Errorf("workspace and repository slug are required")
+	}
+	if buildNumber <= 0 {
+		return nil, fmt.Errorf("pipeline build number must be positive")
+	}
+
 	path := fmt.Sprintf("/repositories/%s/%s/pipelines/%d",
 		url.PathEscape(workspace),
 		url.PathEscape(repoSlug),

--- a/pkg/bbcloud/client_test.go
+++ b/pkg/bbcloud/client_test.go
@@ -265,6 +265,56 @@ func TestListPipelinesRespectsLimit(t *testing.T) {
 	}
 }
 
+func TestGetPipelineByBuildNumberUsesDirectEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repositories/work/repo/pipelines/42" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Pipeline{UUID: "{22222222-2222-4222-8222-222222222222}", BuildNumber: 42})
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{BaseURL: server.URL})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	pipeline, err := client.GetPipelineByBuildNumber(context.Background(), "work", "repo", 42)
+	if err != nil {
+		t.Fatalf("GetPipelineByBuildNumber: %v", err)
+	}
+	if pipeline.UUID != "{22222222-2222-4222-8222-222222222222}" {
+		t.Fatalf("UUID = %q, want {22222222-2222-4222-8222-222222222222}", pipeline.UUID)
+	}
+}
+
+func TestGetPipelineByBuildNumberReturnsDirectEndpointError(t *testing.T) {
+	var hits int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		if r.URL.Path != "/repositories/work/repo/pipelines/42" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		http.Error(w, `{"error":{"message":"Not found"}}`, http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{BaseURL: server.URL})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_, err = client.GetPipelineByBuildNumber(context.Background(), "work", "repo", 42)
+	if err == nil {
+		t.Fatal("expected direct endpoint error")
+	}
+	if hits != 1 {
+		t.Fatalf("expected 1 request, got %d", hits)
+	}
+}
+
 func TestCommitStatuses(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/pkg/cmd/pipeline/pipeline.go
+++ b/pkg/cmd/pipeline/pipeline.go
@@ -283,18 +283,10 @@ func runPipelineList(cmd *cobra.Command, f *cmdutil.Factory, opts *listOptions) 
 }
 
 // resolvePipeline fetches a pipeline by build number or UUID.
-// If the identifier looks like a number, tries build number first, then falls back to UUID.
 func resolvePipeline(ctx context.Context, client *bbcloud.Client, workspace, repo, identifier string) (*bbcloud.Pipeline, error) {
-	// Try parsing as build number first
 	if buildNum, err := strconv.Atoi(strings.TrimPrefix(identifier, "#")); err == nil {
-		pipeline, err := client.GetPipelineByBuildNumber(ctx, workspace, repo, buildNum)
-		if err == nil {
-			return pipeline, nil
-		}
-		// If build number lookup failed, fall back to treating as UUID
-		// (in case the numeric string is actually part of a UUID)
+		return client.GetPipelineByBuildNumber(ctx, workspace, repo, buildNum)
 	}
-	// Treat as UUID
 	return client.GetPipeline(ctx, workspace, repo, identifier)
 }
 


### PR DESCRIPTION
## Summary

Fixes `bkt pipeline view <build-number>` and `bkt pipeline logs <build-number>` for Bitbucket Cloud pipeline result numbers.

Previously, numeric pipeline identifiers were parsed as build numbers first, but if that lookup returned an error, the command fell through to UUID lookup. That produced a misleading error like:

```text
pipeline UUID must be a canonical UUID
```

for valid build numbers such as `2056`.

This change keeps numeric identifiers on the build-number path: `view`/`logs` now return the direct build-number lookup result or its real error, while canonical UUID inputs continue to use the UUID path.

Also adds client tests for:

- successful direct build-number lookup;
- direct endpoint error without extra fallback requests.

## Testing

- [x] `make fmt`
- [x] `make test`
- [x] `make build`
- [x] Other:
  - `gofmt -w pkg/bbcloud/client.go pkg/bbcloud/client_test.go pkg/cmd/pipeline/pipeline.go`
  - `go test ./pkg/bbcloud ./pkg/cmd/pipeline`
  - `go test ./...`
  - `go build -o /tmp/bkt-fixed-direct ./cmd/bkt`
  - `pre-commit run --files CHANGELOG.md pkg/bbcloud/client.go pkg/bbcloud/client_test.go pkg/cmd/pipeline/pipeline.go`
  - Live Bitbucket Cloud smoke checks:
    - `bkt pipeline view 2056 --workspace kodavr --repo rubin`
    - `bkt pipeline view '{d406f52f-7d94-4bbb-be34-68634e646e18}' --workspace kodavr --repo rubin`
    - `bkt pipeline logs 2056 --workspace kodavr --repo rubin`

## Screenshots / recordings

Terminal smoke output confirmed that both numeric build number and UUID inputs resolve the same pipeline, and logs by build number are retrievable.

## Checklist

- [ ] Adds or updates documentation
- [x] Updates `CHANGELOG.md`
- [ ] Signed commits (`git commit -s`)

## Notes for reviewers

Please pay special attention to `resolvePipeline`: numeric identifiers now return the build-number lookup result directly instead of falling through to UUID validation after an error. This preserves UUID behavior for canonical UUID inputs while avoiding misleading UUID errors for numeric pipeline result IDs.