### PR TITLE
fix: send DC no-check header on mutations

### DIFF
--- a/pkg/bbdc/client.go
+++ b/pkg/bbdc/client.go
@@ -3,6 +3,7 @@ package bbdc
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -25,6 +26,8 @@ type Client struct {
 	http *httpx.Client
 }
 
+const atlassianTokenNoCheck = "no-check"
+
 // HTTP exposes the underlying HTTP client for advanced scenarios.
 func (c *Client) HTTP() *httpx.Client {
 	return c.http
@@ -44,12 +47,29 @@ func New(opts Options) (*Client, error) {
 		UserAgent:   "bkt-cli",
 		EnableCache: opts.EnableCache,
 		Retry:       opts.Retry,
+		RequestHook: addNoCheckHeader,
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	return &Client{http: httpClient}, nil
+}
+
+func addNoCheckHeader(req *http.Request) {
+	if req == nil || !requiresNoCheck(req.Method) {
+		return
+	}
+	req.Header.Set("X-Atlassian-Token", atlassianTokenNoCheck)
+}
+
+func requiresNoCheck(method string) bool {
+	switch strings.ToUpper(method) {
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
 }
 
 // User represents a Bitbucket user.

--- a/pkg/bbdc/client_test.go
+++ b/pkg/bbdc/client_test.go
@@ -34,6 +34,30 @@ func TestNewRequiresBaseURL(t *testing.T) {
 	}
 }
 
+func TestNewRequestAddsNoCheckHeaderToMutatingMethods(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		t.Run(method, func(t *testing.T) {
+			req, err := client.HTTP().NewRequest(context.Background(), method, "/rest/api/1.0/projects", nil)
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			if got := req.Header.Get("X-Atlassian-Token"); got != "no-check" {
+				t.Fatalf("X-Atlassian-Token = %q, want no-check", got)
+			}
+		})
+	}
+
+	req, err := client.HTTP().NewRequest(context.Background(), http.MethodGet, "/rest/api/1.0/projects", nil)
+	if err != nil {
+		t.Fatalf("NewRequest GET: %v", err)
+	}
+	if got := req.Header.Get("X-Atlassian-Token"); got != "" {
+		t.Fatalf("GET X-Atlassian-Token = %q, want empty", got)
+	}
+}
+
 func TestListRepositoriesPaginates(t *testing.T) {
 	var hits int32
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/cmd/pr/pr_view_approve_merge_test.go
+++ b/pkg/cmd/pr/pr_view_approve_merge_test.go
@@ -174,6 +174,10 @@ func TestPRApproveDataCenter(t *testing.T) {
 		}
 
 		if r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/pull-requests/42/approve") {
+			if got := r.Header.Get("X-Atlassian-Token"); got != "no-check" {
+				http.Error(w, "missing no-check header", http.StatusForbidden)
+				return
+			}
 			approveCalled = true
 			w.WriteHeader(http.StatusOK)
 			return
@@ -209,6 +213,10 @@ func TestPRApproveCloud(t *testing.T) {
 		}
 
 		if r.Method == "POST" && r.URL.Path == "/repositories/myworkspace/my-repo/pullrequests/42/approve" {
+			if got := r.Header.Get("X-Atlassian-Token"); got != "" {
+				http.Error(w, "unexpected no-check header", http.StatusBadRequest)
+				return
+			}
 			approveCalled = true
 			w.WriteHeader(http.StatusOK)
 			return
@@ -253,6 +261,10 @@ func TestPRMergeDataCenter(t *testing.T) {
 				"version": 3,
 			})
 		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/pull-requests/42/merge"):
+			if got := r.Header.Get("X-Atlassian-Token"); got != "no-check" {
+				http.Error(w, "missing no-check header", http.StatusForbidden)
+				return
+			}
 			_ = json.NewDecoder(r.Body).Decode(&mergeBody)
 			w.WriteHeader(http.StatusOK)
 		default:
@@ -296,6 +308,10 @@ func TestPRMergeCloud(t *testing.T) {
 		}
 
 		if r.Method == "POST" && r.URL.Path == "/repositories/myworkspace/my-repo/pullrequests/42/merge" {
+			if got := r.Header.Get("X-Atlassian-Token"); got != "" {
+				http.Error(w, "unexpected no-check header", http.StatusBadRequest)
+				return
+			}
 			_ = json.NewDecoder(r.Body).Decode(&mergeBody)
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{})

--- a/pkg/httpx/client.go
+++ b/pkg/httpx/client.go
@@ -39,6 +39,7 @@ type Client struct {
 	// a new access token. The client retries the original request once with the
 	// updated credentials.
 	tokenRefresher func(ctx context.Context) (string, error)
+	requestHook    func(*http.Request)
 
 	debug bool
 }
@@ -61,6 +62,10 @@ type Options struct {
 	// credentials and retries the request once. If the retry also returns 401
 	// the error is returned to the caller without a second refresh attempt.
 	TokenRefresher func(ctx context.Context) (string, error)
+
+	// RequestHook can apply host-specific defaults after standard headers and
+	// auth are set.
+	RequestHook func(*http.Request)
 }
 
 // RetryPolicy defines exponential backoff characteristics for retries.
@@ -144,6 +149,7 @@ func New(opts Options) (*Client, error) {
 	}
 	client.retry = policy
 	client.tokenRefresher = opts.TokenRefresher
+	client.requestHook = opts.RequestHook
 
 	return client, nil
 }
@@ -228,6 +234,7 @@ func (c *Client) NewRequest(ctx context.Context, method, path string, body any) 
 	req.Header.Set("User-Agent", c.userAgent)
 
 	c.applyAuth(req)
+	c.applyRequestHook(req)
 
 	return req, nil
 }
@@ -243,6 +250,12 @@ func (c *Client) applyAuth(req *http.Request) {
 		if c.username != "" || c.password != "" {
 			req.SetBasicAuth(c.username, c.password)
 		}
+	}
+}
+
+func (c *Client) applyRequestHook(req *http.Request) {
+	if c.requestHook != nil {
+		c.requestHook(req)
 	}
 }
 
@@ -765,6 +778,7 @@ func (c *Client) NewMultipartRequest(ctx context.Context, method, path string, f
 	}
 
 	c.applyAuth(req)
+	c.applyRequestHook(req)
 
 	return req, nil
 }


### PR DESCRIPTION
## Summary
- add a request hook to the shared HTTP client so platform clients can apply host-specific headers
- make Bitbucket Data Center clients send `X-Atlassian-Token: no-check` on mutating requests
- cover DC approve/merge regression paths while asserting Cloud approve/merge stays unchanged

## Testing
- `go test ./...`
- `git diff --check`