### PR TITLE
docs: add DC XSRF release note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented here. The format follows
 
 ## [Unreleased]
 ### Fixed
+- Bitbucket Data Center mutating requests now send
+  `X-Atlassian-Token: no-check`, fixing 403 XSRF failures for first-class
+  commands such as `bkt pr approve` and `bkt pr merge`.
 - Corrected the `bkt` skill's structured-output example: piping
   `bkt pr list --json` to `jq '.[].title'` fails because the command
   returns an object keyed by `pull_requests`, not a bare array. The


### PR DESCRIPTION
## Summary
- add the missing changelog entry for the Data Center `X-Atlassian-Token: no-check` fix before cutting 0.26.7

## Testing
- `git diff --check`