### PR TITLE
feat(pr): rework `pr task` for Data Center and Cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented here. The format follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Added
+- `bkt pr task` now works on Bitbucket Cloud, using its first-class pull request
+  tasks API (`list`, `create`, `complete`, `reopen`).
+
+### Fixed
+- `bkt pr task` on Bitbucket Data Center no longer calls endpoints that never
+  existed (the old `create`, `complete`, and `reopen` paths returned 404). It
+  now uses blocker comments on DC 7.2+ and the legacy `/tasks` API on older
+  servers, selectable via `--task-api auto|blocker-comments|legacy`
+  (auto-detected from the server version by default). Legacy task creation
+  requires `--comment-id` to anchor the task to a comment.
 
 ## [0.26.7] - 2026-05-27
 ### Fixed

--- a/pkg/bbcloud/tasks.go
+++ b/pkg/bbcloud/tasks.go
@@ -1,0 +1,141 @@
+package bbcloud
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// Cloud pull request task states.
+const (
+	TaskStateUnresolved = "UNRESOLVED"
+	TaskStateResolved   = "RESOLVED"
+)
+
+// PullRequestTask models a task on a Bitbucket Cloud pull request. Unlike Data
+// Center, Cloud tasks are a first-class, standalone PR-level resource separate
+// from comments.
+type PullRequestTask struct {
+	ID      int    `json:"id"`
+	State   string `json:"state"`
+	Content struct {
+		Raw string `json:"raw"`
+	} `json:"content"`
+	Creator    *Account `json:"creator"`
+	CreatedOn  string   `json:"created_on"`
+	UpdatedOn  string   `json:"updated_on"`
+	ResolvedOn string   `json:"resolved_on,omitempty"`
+}
+
+type pullRequestTaskListPage struct {
+	Values []PullRequestTask `json:"values"`
+	Next   string            `json:"next"`
+}
+
+func pullRequestTasksPath(workspace, repoSlug string, prID int) string {
+	return fmt.Sprintf("/repositories/%s/%s/pullrequests/%d/tasks",
+		url.PathEscape(workspace),
+		url.PathEscape(repoSlug),
+		prID,
+	)
+}
+
+// ListPullRequestTasks lists tasks on a pull request, following pagination. A
+// limit of 0 returns all tasks.
+func (c *Client) ListPullRequestTasks(ctx context.Context, workspace, repoSlug string, prID, limit int) ([]PullRequestTask, error) {
+	if workspace == "" || repoSlug == "" {
+		return nil, fmt.Errorf("workspace and repository slug are required")
+	}
+
+	pageLen := limit
+	if pageLen <= 0 || pageLen > 100 {
+		pageLen = 100
+	}
+
+	path := fmt.Sprintf("%s?pagelen=%d", pullRequestTasksPath(workspace, repoSlug, prID), pageLen)
+
+	var tasks []PullRequestTask
+	for path != "" {
+		req, err := c.http.NewRequest(ctx, "GET", path, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var page pullRequestTaskListPage
+		if err := c.http.Do(req, &page); err != nil {
+			return nil, err
+		}
+
+		tasks = append(tasks, page.Values...)
+
+		if limit > 0 && len(tasks) >= limit {
+			tasks = tasks[:limit]
+			break
+		}
+
+		if page.Next == "" {
+			break
+		}
+
+		nextURL, err := url.Parse(page.Next)
+		if err != nil {
+			return nil, err
+		}
+		path = nextURL.RequestURI()
+	}
+
+	return tasks, nil
+}
+
+// CreatePullRequestTask creates a standalone PR-level task with the given text.
+func (c *Client) CreatePullRequestTask(ctx context.Context, workspace, repoSlug string, prID int, text string) (*PullRequestTask, error) {
+	if workspace == "" || repoSlug == "" {
+		return nil, fmt.Errorf("workspace and repository slug are required")
+	}
+	if strings.TrimSpace(text) == "" {
+		return nil, fmt.Errorf("task text is required")
+	}
+
+	body := map[string]any{
+		"content": map[string]string{"raw": text},
+	}
+
+	req, err := c.http.NewRequest(ctx, "POST", pullRequestTasksPath(workspace, repoSlug, prID), body)
+	if err != nil {
+		return nil, err
+	}
+
+	var task PullRequestTask
+	if err := c.http.Do(req, &task); err != nil {
+		return nil, err
+	}
+
+	return &task, nil
+}
+
+// SetPullRequestTaskState resolves (resolved=true) or reopens (resolved=false)
+// a task by updating its state.
+func (c *Client) SetPullRequestTaskState(ctx context.Context, workspace, repoSlug string, prID, taskID int, resolved bool) (*PullRequestTask, error) {
+	if workspace == "" || repoSlug == "" {
+		return nil, fmt.Errorf("workspace and repository slug are required")
+	}
+
+	state := TaskStateUnresolved
+	if resolved {
+		state = TaskStateResolved
+	}
+
+	path := fmt.Sprintf("%s/%d", pullRequestTasksPath(workspace, repoSlug, prID), taskID)
+	req, err := c.http.NewRequest(ctx, "PUT", path, map[string]any{"state": state})
+	if err != nil {
+		return nil, err
+	}
+
+	var task PullRequestTask
+	if err := c.http.Do(req, &task); err != nil {
+		return nil, err
+	}
+
+	return &task, nil
+}

--- a/pkg/bbcloud/tasks_test.go
+++ b/pkg/bbcloud/tasks_test.go
@@ -1,0 +1,145 @@
+package bbcloud_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/avivsinai/bitbucket-cli/pkg/bbcloud"
+)
+
+func TestListPullRequestTasksPagination(t *testing.T) {
+	var paths []string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.RequestURI())
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "2":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values": []map[string]any{
+					{"id": 3, "state": "RESOLVED", "content": map[string]string{"raw": "third"}},
+				},
+			})
+		default:
+			next := "http://" + r.Host + r.URL.Path + "?page=2&pagelen=100"
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values": []map[string]any{
+					{"id": 1, "state": "UNRESOLVED", "content": map[string]string{"raw": "first"}},
+					{"id": 2, "state": "UNRESOLVED", "content": map[string]string{"raw": "second"}},
+				},
+				"next": next,
+			})
+		}
+	}))
+
+	tasks, err := client.ListPullRequestTasks(context.Background(), "ws", "repo", 42, 0)
+	if err != nil {
+		t.Fatalf("ListPullRequestTasks: %v", err)
+	}
+	if len(tasks) != 3 {
+		t.Fatalf("got %d tasks, want 3", len(tasks))
+	}
+	if tasks[0].Content.Raw != "first" || tasks[2].State != bbcloud.TaskStateResolved {
+		t.Errorf("unexpected task contents: %+v", tasks)
+	}
+	wantFirst := "/repositories/ws/repo/pullrequests/42/tasks?pagelen=100"
+	if paths[0] != wantFirst {
+		t.Errorf("first path = %q, want %q", paths[0], wantFirst)
+	}
+	if len(paths) != 2 {
+		t.Errorf("expected 2 requests (paginated), got %d: %v", len(paths), paths)
+	}
+}
+
+func TestCreatePullRequestTask(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody map[string]any
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": 9, "state": "UNRESOLVED", "content": map[string]string{"raw": "do the thing"},
+		})
+	}))
+
+	task, err := client.CreatePullRequestTask(context.Background(), "ws", "repo", 42, "do the thing")
+	if err != nil {
+		t.Fatalf("CreatePullRequestTask: %v", err)
+	}
+	if gotMethod != "POST" {
+		t.Errorf("method = %s, want POST", gotMethod)
+	}
+	if gotPath != "/repositories/ws/repo/pullrequests/42/tasks" {
+		t.Errorf("path = %q", gotPath)
+	}
+	content, _ := gotBody["content"].(map[string]any)
+	if content["raw"] != "do the thing" {
+		t.Errorf("body content.raw = %v, want %q", content["raw"], "do the thing")
+	}
+	if task.ID != 9 {
+		t.Errorf("task.ID = %d, want 9", task.ID)
+	}
+}
+
+func TestSetPullRequestTaskState(t *testing.T) {
+	tests := []struct {
+		name      string
+		resolved  bool
+		wantState string
+	}{
+		{"resolve", true, bbcloud.TaskStateResolved},
+		{"reopen", false, bbcloud.TaskStateUnresolved},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotMethod, gotPath string
+			var gotBody map[string]any
+			client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotMethod = r.Method
+				gotPath = r.URL.Path
+				raw, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(raw, &gotBody)
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{"id": 9, "state": tt.wantState})
+			}))
+
+			task, err := client.SetPullRequestTaskState(context.Background(), "ws", "repo", 42, 9, tt.resolved)
+			if err != nil {
+				t.Fatalf("SetPullRequestTaskState: %v", err)
+			}
+			if gotMethod != "PUT" {
+				t.Errorf("method = %s, want PUT", gotMethod)
+			}
+			if gotPath != "/repositories/ws/repo/pullrequests/42/tasks/9" {
+				t.Errorf("path = %q", gotPath)
+			}
+			if gotBody["state"] != tt.wantState {
+				t.Errorf("body state = %v, want %s", gotBody["state"], tt.wantState)
+			}
+			if task.State != tt.wantState {
+				t.Errorf("task.State = %s, want %s", task.State, tt.wantState)
+			}
+		})
+	}
+}
+
+func TestCloudTaskValidation(t *testing.T) {
+	client, err := bbcloud.New(bbcloud.Options{BaseURL: "http://localhost", Username: "u", Token: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.CreatePullRequestTask(context.Background(), "", "repo", 1, "x"); err == nil {
+		t.Error("expected error for empty workspace")
+	}
+	if _, err := client.CreatePullRequestTask(context.Background(), "ws", "repo", 1, "   "); err == nil {
+		t.Error("expected error for blank task text")
+	}
+	if _, err := client.ListPullRequestTasks(context.Background(), "ws", "", 1, 0); err == nil {
+		t.Error("expected error for empty repo")
+	}
+}

--- a/pkg/bbdc/system.go
+++ b/pkg/bbdc/system.go
@@ -1,0 +1,32 @@
+package bbdc
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+type applicationProperties struct {
+	Version string `json:"version"`
+}
+
+// ServerVersion returns the Bitbucket Data Center server version.
+func (c *Client) ServerVersion(ctx context.Context) (string, error) {
+	req, err := c.http.NewRequest(ctx, http.MethodGet, "/rest/api/1.0/application-properties", nil)
+	if err != nil {
+		return "", err
+	}
+
+	var props applicationProperties
+	if err := c.http.Do(req, &props); err != nil {
+		return "", err
+	}
+
+	version := strings.TrimSpace(props.Version)
+	if version == "" {
+		return "", fmt.Errorf("server version is missing from application properties")
+	}
+
+	return version, nil
+}

--- a/pkg/bbdc/tasks.go
+++ b/pkg/bbdc/tasks.go
@@ -257,32 +257,6 @@ func (c *Client) DeleteLegacyTask(ctx context.Context, taskID int) error {
 	return c.http.Do(req, nil)
 }
 
-// CreatePullRequestTask creates a blocker comment for the pull request.
-//
-// Deprecated: use CreateBlockerComment for Data Center 7.2+ or CreateLegacyTask
-// for older servers after resolving the task API mode.
-func (c *Client) CreatePullRequestTask(ctx context.Context, projectKey, repoSlug string, prID int, text string) (*PullRequestTask, error) {
-	return c.CreateBlockerComment(ctx, projectKey, repoSlug, prID, text)
-}
-
-// CompletePullRequestTask marks a blocker comment as resolved.
-//
-// Deprecated: use SetBlockerCommentState or SetLegacyTaskState after resolving
-// the task API mode.
-func (c *Client) CompletePullRequestTask(ctx context.Context, projectKey, repoSlug string, prID, taskID int) error {
-	_, err := c.SetBlockerCommentState(ctx, projectKey, repoSlug, prID, taskID, true)
-	return err
-}
-
-// ReopenPullRequestTask reopens a blocker comment.
-//
-// Deprecated: use SetBlockerCommentState or SetLegacyTaskState after resolving
-// the task API mode.
-func (c *Client) ReopenPullRequestTask(ctx context.Context, projectKey, repoSlug string, prID, taskID int) error {
-	_, err := c.SetBlockerCommentState(ctx, projectKey, repoSlug, prID, taskID, false)
-	return err
-}
-
 func validatePullRequestTaskTarget(projectKey, repoSlug string, prID int) error {
 	if projectKey == "" || repoSlug == "" {
 		return fmt.Errorf("project key and repository slug are required")

--- a/pkg/bbdc/tasks.go
+++ b/pkg/bbdc/tasks.go
@@ -3,8 +3,17 @@ package bbdc
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
+)
+
+const (
+	pullRequestTaskPageSize = 25
+
+	TaskStateOpen     = "OPEN"
+	TaskStateResolved = "RESOLVED"
 )
 
 // PullRequestTask models a task attached to a pull request comment or diff.
@@ -17,49 +26,188 @@ type PullRequestTask struct {
 	UpdatedAt int64  `json:"updatedDate"`
 }
 
-// ListPullRequestTasks lists tasks for the pull request.
-func (c *Client) ListPullRequestTasks(ctx context.Context, projectKey, repoSlug string, prID int) ([]PullRequestTask, error) {
-	if projectKey == "" || repoSlug == "" {
-		return nil, fmt.Errorf("project key and repository slug are required")
-	}
-
-	req, err := c.http.NewRequest(ctx, "GET", fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/tasks",
-		url.PathEscape(projectKey),
-		url.PathEscape(repoSlug),
-		prID,
-	), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	var resp struct {
-		Values []PullRequestTask `json:"values"`
-	}
-	if err := c.http.Do(req, &resp); err != nil {
-		return nil, err
-	}
-
-	return resp.Values, nil
+type blockerComment struct {
+	ID        int    `json:"id"`
+	Version   int    `json:"version"`
+	State     string `json:"state"`
+	Text      string `json:"text"`
+	Author    User   `json:"author"`
+	CreatedAt int64  `json:"createdDate"`
+	UpdatedAt int64  `json:"updatedDate"`
 }
 
-// CreatePullRequestTask creates a new task attached to the pull request.
-func (c *Client) CreatePullRequestTask(ctx context.Context, projectKey, repoSlug string, prID int, text string) (*PullRequestTask, error) {
-	if projectKey == "" || repoSlug == "" {
-		return nil, fmt.Errorf("project key and repository slug are required")
+func (comment blockerComment) task() PullRequestTask {
+	return PullRequestTask{
+		ID:        comment.ID,
+		State:     comment.State,
+		Text:      comment.Text,
+		Author:    comment.Author,
+		CreatedAt: comment.CreatedAt,
+		UpdatedAt: comment.UpdatedAt,
 	}
-	if strings.TrimSpace(text) == "" {
-		return nil, fmt.Errorf("task text is required")
+}
+
+// ListPullRequestTasks lists legacy tasks for the pull request.
+func (c *Client) ListPullRequestTasks(ctx context.Context, projectKey, repoSlug string, prID int) ([]PullRequestTask, error) {
+	if err := validatePullRequestTaskTarget(projectKey, repoSlug, prID); err != nil {
+		return nil, err
+	}
+
+	var (
+		start int
+		tasks []PullRequestTask
+	)
+
+	for {
+		req, err := c.http.NewRequest(ctx, http.MethodGet, pagedTaskPath(legacyPullRequestTasksPath(projectKey, repoSlug, prID), start), nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var resp paged[PullRequestTask]
+		if err := c.http.Do(req, &resp); err != nil {
+			return nil, err
+		}
+
+		tasks = append(tasks, resp.Values...)
+		if resp.IsLastPage || len(resp.Values) == 0 {
+			break
+		}
+		start = resp.NextPageStart
+	}
+
+	return tasks, nil
+}
+
+// ListBlockerComments lists blocker comments for the pull request.
+func (c *Client) ListBlockerComments(ctx context.Context, projectKey, repoSlug string, prID int) ([]PullRequestTask, error) {
+	if err := validatePullRequestTaskTarget(projectKey, repoSlug, prID); err != nil {
+		return nil, err
+	}
+
+	var (
+		start int
+		tasks []PullRequestTask
+	)
+
+	for {
+		req, err := c.http.NewRequest(ctx, http.MethodGet, pagedTaskPath(blockerCommentsPath(projectKey, repoSlug, prID), start), nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var resp paged[blockerComment]
+		if err := c.http.Do(req, &resp); err != nil {
+			return nil, err
+		}
+
+		for _, comment := range resp.Values {
+			tasks = append(tasks, comment.task())
+		}
+		if resp.IsLastPage || len(resp.Values) == 0 {
+			break
+		}
+		start = resp.NextPageStart
+	}
+
+	return tasks, nil
+}
+
+// CreateBlockerComment creates a blocker comment for the pull request.
+func (c *Client) CreateBlockerComment(ctx context.Context, projectKey, repoSlug string, prID int, text string) (*PullRequestTask, error) {
+	if err := validatePullRequestTaskTarget(projectKey, repoSlug, prID); err != nil {
+		return nil, err
+	}
+	if err := validateTaskText(text); err != nil {
+		return nil, err
 	}
 
 	body := map[string]any{
 		"text": text,
 	}
 
-	req, err := c.http.NewRequest(ctx, "POST", fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/tasks",
-		url.PathEscape(projectKey),
-		url.PathEscape(repoSlug),
-		prID,
-	), body)
+	req, err := c.http.NewRequest(ctx, http.MethodPost, blockerCommentsPath(projectKey, repoSlug, prID), body)
+	if err != nil {
+		return nil, err
+	}
+
+	var comment blockerComment
+	if err := c.http.Do(req, &comment); err != nil {
+		return nil, err
+	}
+
+	task := comment.task()
+	return &task, nil
+}
+
+// SetBlockerCommentState updates a blocker comment state and returns the updated task.
+func (c *Client) SetBlockerCommentState(ctx context.Context, projectKey, repoSlug string, prID, commentID int, resolved bool) (*PullRequestTask, error) {
+	if err := validatePullRequestTaskTarget(projectKey, repoSlug, prID); err != nil {
+		return nil, err
+	}
+	if commentID <= 0 {
+		return nil, fmt.Errorf("comment id must be positive")
+	}
+
+	current, err := c.getBlockerComment(ctx, projectKey, repoSlug, prID, commentID)
+	if err != nil {
+		return nil, err
+	}
+
+	body := map[string]any{
+		"version": current.Version,
+		"state":   taskState(resolved),
+	}
+
+	req, err := c.http.NewRequest(ctx, http.MethodPut, blockerCommentPath(projectKey, repoSlug, prID, commentID), body)
+	if err != nil {
+		return nil, err
+	}
+
+	var updated blockerComment
+	if err := c.http.Do(req, &updated); err != nil {
+		return nil, err
+	}
+
+	task := updated.task()
+	return &task, nil
+}
+
+func (c *Client) getBlockerComment(ctx context.Context, projectKey, repoSlug string, prID, commentID int) (*blockerComment, error) {
+	req, err := c.http.NewRequest(ctx, http.MethodGet, blockerCommentPath(projectKey, repoSlug, prID, commentID), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var comment blockerComment
+	if err := c.http.Do(req, &comment); err != nil {
+		return nil, err
+	}
+
+	return &comment, nil
+}
+
+// CreateLegacyTask creates a legacy task anchored to an existing comment.
+func (c *Client) CreateLegacyTask(ctx context.Context, projectKey, repoSlug string, prID, commentID int, text string) (*PullRequestTask, error) {
+	if err := validatePullRequestTaskTarget(projectKey, repoSlug, prID); err != nil {
+		return nil, err
+	}
+	if commentID <= 0 {
+		return nil, fmt.Errorf("comment id must be positive")
+	}
+	if err := validateTaskText(text); err != nil {
+		return nil, err
+	}
+
+	body := map[string]any{
+		"anchor": map[string]any{
+			"id":   commentID,
+			"type": "COMMENT",
+		},
+		"text": text,
+	}
+
+	req, err := c.http.NewRequest(ctx, http.MethodPost, "/rest/api/1.0/tasks", body)
 	if err != nil {
 		return nil, err
 	}
@@ -72,18 +220,36 @@ func (c *Client) CreatePullRequestTask(ctx context.Context, projectKey, repoSlug
 	return &task, nil
 }
 
-// CompletePullRequestTask marks a task as resolved.
-func (c *Client) CompletePullRequestTask(ctx context.Context, projectKey, repoSlug string, prID, taskID int) error {
-	if projectKey == "" || repoSlug == "" {
-		return fmt.Errorf("project key and repository slug are required")
+// SetLegacyTaskState updates a legacy task state and returns the updated task.
+func (c *Client) SetLegacyTaskState(ctx context.Context, taskID int, resolved bool) (*PullRequestTask, error) {
+	if taskID <= 0 {
+		return nil, fmt.Errorf("task id must be positive")
 	}
 
-	req, err := c.http.NewRequest(ctx, "POST", fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/tasks/%d/resolve",
-		url.PathEscape(projectKey),
-		url.PathEscape(repoSlug),
-		prID,
-		taskID,
-	), nil)
+	body := map[string]any{
+		"state": taskState(resolved),
+	}
+
+	req, err := c.http.NewRequest(ctx, http.MethodPut, fmt.Sprintf("/rest/api/1.0/tasks/%d", taskID), body)
+	if err != nil {
+		return nil, err
+	}
+
+	var task PullRequestTask
+	if err := c.http.Do(req, &task); err != nil {
+		return nil, err
+	}
+
+	return &task, nil
+}
+
+// DeleteLegacyTask deletes a legacy task.
+func (c *Client) DeleteLegacyTask(ctx context.Context, taskID int) error {
+	if taskID <= 0 {
+		return fmt.Errorf("task id must be positive")
+	}
+
+	req, err := c.http.NewRequest(ctx, http.MethodDelete, fmt.Sprintf("/rest/api/1.0/tasks/%d", taskID), nil)
 	if err != nil {
 		return err
 	}
@@ -91,21 +257,81 @@ func (c *Client) CompletePullRequestTask(ctx context.Context, projectKey, repoSl
 	return c.http.Do(req, nil)
 }
 
-// ReopenPullRequestTask reopens a resolved task.
+// CreatePullRequestTask creates a blocker comment for the pull request.
+//
+// Deprecated: use CreateBlockerComment for Data Center 7.2+ or CreateLegacyTask
+// for older servers after resolving the task API mode.
+func (c *Client) CreatePullRequestTask(ctx context.Context, projectKey, repoSlug string, prID int, text string) (*PullRequestTask, error) {
+	return c.CreateBlockerComment(ctx, projectKey, repoSlug, prID, text)
+}
+
+// CompletePullRequestTask marks a blocker comment as resolved.
+//
+// Deprecated: use SetBlockerCommentState or SetLegacyTaskState after resolving
+// the task API mode.
+func (c *Client) CompletePullRequestTask(ctx context.Context, projectKey, repoSlug string, prID, taskID int) error {
+	_, err := c.SetBlockerCommentState(ctx, projectKey, repoSlug, prID, taskID, true)
+	return err
+}
+
+// ReopenPullRequestTask reopens a blocker comment.
+//
+// Deprecated: use SetBlockerCommentState or SetLegacyTaskState after resolving
+// the task API mode.
 func (c *Client) ReopenPullRequestTask(ctx context.Context, projectKey, repoSlug string, prID, taskID int) error {
+	_, err := c.SetBlockerCommentState(ctx, projectKey, repoSlug, prID, taskID, false)
+	return err
+}
+
+func validatePullRequestTaskTarget(projectKey, repoSlug string, prID int) error {
 	if projectKey == "" || repoSlug == "" {
 		return fmt.Errorf("project key and repository slug are required")
 	}
+	if prID <= 0 {
+		return fmt.Errorf("pull request id must be positive")
+	}
+	return nil
+}
 
-	req, err := c.http.NewRequest(ctx, "POST", fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/tasks/%d/reopen",
+func validateTaskText(text string) error {
+	if strings.TrimSpace(text) == "" {
+		return fmt.Errorf("task text is required")
+	}
+	return nil
+}
+
+func taskState(resolved bool) string {
+	if resolved {
+		return TaskStateResolved
+	}
+	return TaskStateOpen
+}
+
+func legacyPullRequestTasksPath(projectKey, repoSlug string, prID int) string {
+	return pullRequestPath(projectKey, repoSlug, prID, "/tasks")
+}
+
+func blockerCommentsPath(projectKey, repoSlug string, prID int) string {
+	return pullRequestPath(projectKey, repoSlug, prID, "/blocker-comments")
+}
+
+func blockerCommentPath(projectKey, repoSlug string, prID, commentID int) string {
+	return fmt.Sprintf("%s/%d", blockerCommentsPath(projectKey, repoSlug, prID), commentID)
+}
+
+func pullRequestPath(projectKey, repoSlug string, prID int, suffix string) string {
+	return fmt.Sprintf(
+		"/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d%s",
 		url.PathEscape(projectKey),
 		url.PathEscape(repoSlug),
 		prID,
-		taskID,
-	), nil)
-	if err != nil {
-		return err
-	}
+		suffix,
+	)
+}
 
-	return c.http.Do(req, nil)
+func pagedTaskPath(path string, start int) string {
+	query := url.Values{}
+	query.Set("limit", strconv.Itoa(pullRequestTaskPageSize))
+	query.Set("start", strconv.Itoa(start))
+	return path + "?" + query.Encode()
 }

--- a/pkg/bbdc/tasks_test.go
+++ b/pkg/bbdc/tasks_test.go
@@ -1,0 +1,268 @@
+package bbdc_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/avivsinai/bitbucket-cli/pkg/bbdc"
+)
+
+func TestServerVersionUsesApplicationProperties(t *testing.T) {
+	var gotPath string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"version":     "7.6.0",
+			"buildNumber": "760000",
+			"displayName": "Bitbucket",
+		})
+	}))
+
+	version, err := client.ServerVersion(context.Background())
+	if err != nil {
+		t.Fatalf("ServerVersion: %v", err)
+	}
+	if gotPath != "/rest/api/1.0/application-properties" {
+		t.Fatalf("path = %q, want /rest/api/1.0/application-properties", gotPath)
+	}
+	if version != "7.6.0" {
+		t.Fatalf("version = %q, want 7.6.0", version)
+	}
+}
+
+func TestListPullRequestTasksKeepsLegacyEndpoint(t *testing.T) {
+	var gotPath string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"isLastPage": true,
+			"values": []map[string]any{
+				{"id": 11, "text": "fix this", "state": "OPEN"},
+			},
+		})
+	}))
+
+	tasks, err := client.ListPullRequestTasks(context.Background(), "PROJ", "repo", 42)
+	if err != nil {
+		t.Fatalf("ListPullRequestTasks: %v", err)
+	}
+	if gotPath != "/rest/api/1.0/projects/PROJ/repos/repo/pull-requests/42/tasks" {
+		t.Fatalf("path = %q, want legacy tasks path", gotPath)
+	}
+	if len(tasks) != 1 || tasks[0].ID != 11 || tasks[0].Text != "fix this" {
+		t.Fatalf("tasks = %+v", tasks)
+	}
+}
+
+func TestListBlockerCommentsPaginates(t *testing.T) {
+	var hits int32
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		switch count {
+		case 1:
+			if r.URL.Query().Get("start") != "0" {
+				t.Fatalf("first start = %q, want 0", r.URL.Query().Get("start"))
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"isLastPage":    false,
+				"nextPageStart": 25,
+				"values":        []map[string]any{{"id": 1, "text": "first", "state": "OPEN"}},
+			})
+		case 2:
+			if r.URL.Query().Get("start") != "25" {
+				t.Fatalf("second start = %q, want 25", r.URL.Query().Get("start"))
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"isLastPage": true,
+				"values":     []map[string]any{{"id": 2, "text": "second", "state": "RESOLVED"}},
+			})
+		default:
+			t.Fatalf("unexpected request %d", count)
+		}
+	}))
+
+	tasks, err := client.ListBlockerComments(context.Background(), "PROJ", "repo", 42)
+	if err != nil {
+		t.Fatalf("ListBlockerComments: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Fatalf("len(tasks) = %d, want 2", len(tasks))
+	}
+	if hits != 2 {
+		t.Fatalf("hits = %d, want 2", hits)
+	}
+}
+
+func TestCreateBlockerComment(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/rest/api/1.0/projects/PROJ/repos/repo/pull-requests/42/blocker-comments" {
+			t.Fatalf("path = %q, want blocker-comments path", r.URL.Path)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["text"] != "fix docs" {
+			t.Fatalf("body = %#v, want text only", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 12, "version": 1, "text": "fix docs", "state": "OPEN"})
+	}))
+
+	task, err := client.CreateBlockerComment(context.Background(), "PROJ", "repo", 42, "fix docs")
+	if err != nil {
+		t.Fatalf("CreateBlockerComment: %v", err)
+	}
+	if task.ID != 12 || task.Text != "fix docs" {
+		t.Fatalf("task = %+v", task)
+	}
+}
+
+func TestSetBlockerCommentStateFetchesVersionBeforePUT(t *testing.T) {
+	var hits int32
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&hits, 1)
+		switch count {
+		case 1:
+			if r.Method != http.MethodGet {
+				t.Fatalf("method = %s, want GET", r.Method)
+			}
+			if r.URL.Path != "/rest/api/1.0/projects/PROJ/repos/repo/pull-requests/42/blocker-comments/99" {
+				t.Fatalf("path = %q, want blocker-comments get path", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 99, "version": 7, "text": "fix docs", "state": "OPEN"})
+		case 2:
+			if r.Method != http.MethodPut {
+				t.Fatalf("method = %s, want PUT", r.Method)
+			}
+			if r.URL.Path != "/rest/api/1.0/projects/PROJ/repos/repo/pull-requests/42/blocker-comments/99" {
+				t.Fatalf("path = %q, want blocker-comments put path", r.URL.Path)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if int(body["version"].(float64)) != 7 || body["state"] != "RESOLVED" {
+				t.Fatalf("body = %#v, want version=7 state=RESOLVED", body)
+			}
+			if _, ok := body["text"]; ok {
+				t.Fatalf("body should not update text: %#v", body)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 99, "version": 8, "state": "RESOLVED"})
+		default:
+			t.Fatalf("unexpected request %d", count)
+		}
+	}))
+
+	task, err := client.SetBlockerCommentState(context.Background(), "PROJ", "repo", 42, 99, true)
+	if err != nil {
+		t.Fatalf("SetBlockerCommentState: %v", err)
+	}
+	if task.ID != 99 || task.State != "RESOLVED" {
+		t.Fatalf("task = %+v, want id=99 state=RESOLVED", task)
+	}
+	if hits != 2 {
+		t.Fatalf("hits = %d, want 2", hits)
+	}
+}
+
+func TestCreateLegacyTaskRequiresCommentID(t *testing.T) {
+	client, err := bbdc.New(bbdc.Options{BaseURL: "http://localhost", Username: "u", Token: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.CreateLegacyTask(context.Background(), "PROJ", "repo", 42, 0, "legacy task")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestCreateLegacyTaskUsesTopLevelTaskAnchor(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/rest/api/1.0/tasks" {
+			t.Fatalf("path = %q, want /rest/api/1.0/tasks", r.URL.Path)
+		}
+		var body struct {
+			Anchor struct {
+				ID   int    `json:"id"`
+				Type string `json:"type"`
+			} `json:"anchor"`
+			Text string `json:"text"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body.Anchor.ID != 123 || body.Anchor.Type != "COMMENT" || body.Text != "legacy task" {
+			t.Fatalf("body = %+v", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99, "text": "legacy task", "state": "OPEN"})
+	}))
+
+	task, err := client.CreateLegacyTask(context.Background(), "PROJ", "repo", 42, 123, "legacy task")
+	if err != nil {
+		t.Fatalf("CreateLegacyTask: %v", err)
+	}
+	if task.ID != 99 {
+		t.Fatalf("task.ID = %d, want 99", task.ID)
+	}
+}
+
+func TestSetLegacyTaskStateUsesTopLevelTaskPUT(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Fatalf("method = %s, want PUT", r.Method)
+		}
+		if r.URL.Path != "/rest/api/1.0/tasks/99" {
+			t.Fatalf("path = %q, want /rest/api/1.0/tasks/99", r.URL.Path)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["state"] != "RESOLVED" {
+			t.Fatalf("body = %#v, want state=RESOLVED", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 99, "state": "RESOLVED"})
+	}))
+
+	task, err := client.SetLegacyTaskState(context.Background(), 99, true)
+	if err != nil {
+		t.Fatalf("SetLegacyTaskState: %v", err)
+	}
+	if task.ID != 99 || task.State != "RESOLVED" {
+		t.Fatalf("task = %+v, want id=99 state=RESOLVED", task)
+	}
+}
+
+func TestDeleteLegacyTaskUsesTopLevelTaskDELETE(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("method = %s, want DELETE", r.Method)
+		}
+		if r.URL.Path != "/rest/api/1.0/tasks/99" {
+			t.Fatalf("path = %q, want /rest/api/1.0/tasks/99", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	if err := client.DeleteLegacyTask(context.Background(), 99); err != nil {
+		t.Fatalf("DeleteLegacyTask: %v", err)
+	}
+}

--- a/pkg/cmd/pr/task_mode.go
+++ b/pkg/cmd/pr/task_mode.go
@@ -1,0 +1,115 @@
+package pr
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Task API modes selectable via --task-api. "auto" probes the Data Center
+// version to choose between the modern blocker-comments model (>= 7.2) and the
+// legacy /tasks model (< 7.2). Cloud always uses its first-class tasks API and
+// ignores this flag.
+const (
+	taskAPIAuto            = "auto"
+	taskAPIBlockerComments = "blocker-comments"
+	taskAPILegacy          = "legacy"
+)
+
+var validTaskAPIModes = []string{taskAPIAuto, taskAPIBlockerComments, taskAPILegacy}
+
+// validateTaskAPIMode ensures the user-supplied --task-api value is recognized.
+func validateTaskAPIMode(mode string) error {
+	for _, m := range validTaskAPIModes {
+		if mode == m {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid --task-api %q: must be one of %s", mode, strings.Join(validTaskAPIModes, ", "))
+}
+
+// dcSupportsBlockerComments reports whether a Data Center version string (e.g.
+// "8.19.1") is >= 7.2, the release that introduced blocker comments and
+// deprecated the legacy /tasks API.
+func dcSupportsBlockerComments(version string) (bool, error) {
+	major, minor, err := parseDCVersion(version)
+	if err != nil {
+		return false, err
+	}
+	if major > 7 {
+		return true, nil
+	}
+	return major == 7 && minor >= 2, nil
+}
+
+// parseDCVersion extracts the major and minor components from a Data Center
+// version string. Trailing components (patch, build metadata) are ignored.
+func parseDCVersion(version string) (major, minor int, err error) {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return 0, 0, fmt.Errorf("empty version string")
+	}
+	parts := strings.SplitN(version, ".", 3)
+	major, err = strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse major version from %q: %w", version, err)
+	}
+	if len(parts) > 1 {
+		// Tolerate suffixes like "2-rc1" by reading the leading digits.
+		minor, err = strconv.Atoi(leadingDigits(parts[1]))
+		if err != nil {
+			return 0, 0, fmt.Errorf("parse minor version from %q: %w", version, err)
+		}
+	}
+	return major, minor, nil
+}
+
+func leadingDigits(s string) string {
+	s = strings.TrimSpace(s)
+	end := 0
+	for end < len(s) && s[end] >= '0' && s[end] <= '9' {
+		end++
+	}
+	if end == 0 {
+		return s // let Atoi surface the error
+	}
+	return s[:end]
+}
+
+// resolveDCTaskMode resolves the effective Data Center task API.
+//
+//   - An explicit mode (blocker-comments or legacy) is honored as-is with no
+//     version probe.
+//   - "auto" calls lookupVersion and picks blocker-comments for >= 7.2, legacy
+//     otherwise.
+//   - If auto detection fails, mutating operations fail closed (returning an
+//     error that tells the user to pass --task-api explicitly) rather than risk
+//     writing through the wrong model; read operations fall back to the modern
+//     blocker-comments path.
+func resolveDCTaskMode(mode string, lookupVersion func() (string, error), mutating bool) (string, error) {
+	switch mode {
+	case taskAPIBlockerComments, taskAPILegacy:
+		return mode, nil
+	case taskAPIAuto, "":
+		version, err := lookupVersion()
+		if err != nil {
+			if mutating {
+				return "", fmt.Errorf("could not detect Data Center version (%w); pass --task-api blocker-comments or --task-api legacy", err)
+			}
+			return taskAPIBlockerComments, nil
+		}
+		supported, err := dcSupportsBlockerComments(version)
+		if err != nil {
+			if mutating {
+				return "", fmt.Errorf("could not parse Data Center version %q (%w); pass --task-api blocker-comments or --task-api legacy", version, err)
+			}
+			return taskAPIBlockerComments, nil
+		}
+		if supported {
+			return taskAPIBlockerComments, nil
+		}
+		return taskAPILegacy, nil
+	default:
+		return "", fmt.Errorf("invalid --task-api %q", mode)
+	}
+}

--- a/pkg/cmd/pr/task_mode_test.go
+++ b/pkg/cmd/pr/task_mode_test.go
@@ -1,0 +1,82 @@
+package pr
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestDCSupportsBlockerComments(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+		wantErr bool
+	}{
+		{"7.2.0", true, false},
+		{"7.1.9", false, false},
+		{"7.21.0", true, false},
+		{"8.19.1", true, false},
+		{"6.10.0", false, false},
+		{"7.2", true, false},
+		{"7", false, false},
+		{"not-a-version", false, true},
+		{"", false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			got, err := dcSupportsBlockerComments(tt.version)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil && got != tt.want {
+				t.Errorf("dcSupportsBlockerComments(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveDCTaskMode(t *testing.T) {
+	ok := func(v string) func() (string, error) { return func() (string, error) { return v, nil } }
+	fail := func() (string, error) { return "", fmt.Errorf("network down") }
+
+	tests := []struct {
+		name     string
+		mode     string
+		lookup   func() (string, error)
+		mutating bool
+		want     string
+		wantErr  bool
+	}{
+		{"explicit blocker-comments skips probe", taskAPIBlockerComments, fail, true, taskAPIBlockerComments, false},
+		{"explicit legacy skips probe", taskAPILegacy, fail, true, taskAPILegacy, false},
+		{"auto modern", taskAPIAuto, ok("8.19.1"), true, taskAPIBlockerComments, false},
+		{"auto old -> legacy", taskAPIAuto, ok("7.1.0"), true, taskAPILegacy, false},
+		{"auto exactly 7.2", taskAPIAuto, ok("7.2.0"), false, taskAPIBlockerComments, false},
+		{"auto probe fails + mutating -> error", taskAPIAuto, fail, true, "", true},
+		{"auto probe fails + read -> blocker-comments", taskAPIAuto, fail, false, taskAPIBlockerComments, false},
+		{"auto unparseable + mutating -> error", taskAPIAuto, ok("garbage"), true, "", true},
+		{"auto unparseable + read -> blocker-comments", taskAPIAuto, ok("garbage"), false, taskAPIBlockerComments, false},
+		{"empty defaults to auto", "", ok("8.0.0"), true, taskAPIBlockerComments, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveDCTaskMode(tt.mode, tt.lookup, tt.mutating)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("resolveDCTaskMode(%q, _, %v) = %q, want %q", tt.mode, tt.mutating, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateTaskAPIMode(t *testing.T) {
+	for _, m := range []string{taskAPIAuto, taskAPIBlockerComments, taskAPILegacy} {
+		if err := validateTaskAPIMode(m); err != nil {
+			t.Errorf("validateTaskAPIMode(%q) unexpected error: %v", m, err)
+		}
+	}
+	if err := validateTaskAPIMode("nonsense"); err == nil {
+		t.Error("expected error for invalid mode")
+	}
+}

--- a/pkg/cmd/pr/tasks.go
+++ b/pkg/cmd/pr/tasks.go
@@ -79,12 +79,6 @@ The flag is ignored on Cloud.`,
   # Complete / reopen a task
   bkt pr task complete 42 99
   bkt pr task reopen 42 99`,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if opts.TaskAPI == "" {
-				opts.TaskAPI = taskAPIAuto
-			}
-			return validateTaskAPIMode(opts.TaskAPI)
-		},
 	}
 
 	cmd.PersistentFlags().StringVar(&opts.TaskAPI, "task-api", taskAPIAuto, "Data Center task model: auto, blocker-comments, or legacy")
@@ -215,6 +209,9 @@ func cloudContext(opts *taskOptions, ctxWorkspace, ctxRepo string) (workspace, r
 }
 
 func runTaskList(cmd *cobra.Command, f *cmdutil.Factory, opts *taskOptions) error {
+	if err := validateTaskAPIMode(opts.TaskAPI); err != nil {
+		return err
+	}
 	ios, err := f.Streams()
 	if err != nil {
 		return err
@@ -295,6 +292,9 @@ func runTaskList(cmd *cobra.Command, f *cmdutil.Factory, opts *taskOptions) erro
 }
 
 func runTaskCreate(cmd *cobra.Command, f *cmdutil.Factory, opts *taskOptions) error {
+	if err := validateTaskAPIMode(opts.TaskAPI); err != nil {
+		return err
+	}
 	ios, err := f.Streams()
 	if err != nil {
 		return err
@@ -362,6 +362,9 @@ func runTaskCreate(cmd *cobra.Command, f *cmdutil.Factory, opts *taskOptions) er
 }
 
 func runTaskSetState(cmd *cobra.Command, f *cmdutil.Factory, opts *taskOptions, resolve bool) error {
+	if err := validateTaskAPIMode(opts.TaskAPI); err != nil {
+		return err
+	}
 	ios, err := f.Streams()
 	if err != nil {
 		return err

--- a/pkg/cmd/pr/tasks.go
+++ b/pkg/cmd/pr/tasks.go
@@ -16,6 +16,11 @@ import (
 
 const taskRequestTimeout = 10 * time.Second
 
+// errCommentIDOnlyLegacy is returned when --comment-id is supplied in a context
+// where it carries no meaning (Cloud tasks and DC blocker comments are not
+// anchored to a comment).
+var errCommentIDOnlyLegacy = fmt.Errorf("--comment-id only applies to legacy Data Center tasks (--task-api legacy)")
+
 type taskOptions struct {
 	Project   string
 	Repo      string
@@ -302,6 +307,7 @@ func runTaskCreate(cmd *cobra.Command, f *cmdutil.Factory, opts *taskOptions) er
 	if strings.TrimSpace(opts.Text) == "" {
 		return fmt.Errorf("task text is required")
 	}
+	commentIDSet := cmd.Flags().Changed("comment-id")
 	_, ctxCfg, host, err := cmdutil.ResolveContext(f, cmd, cmdutil.FlagValue(cmd, "context"))
 	if err != nil {
 		return err
@@ -333,6 +339,9 @@ func runTaskCreate(cmd *cobra.Command, f *cmdutil.Factory, opts *taskOptions) er
 			}
 			task, err = client.CreateLegacyTask(ctx, projectKey, repoSlug, opts.ID, opts.CommentID, opts.Text)
 		} else {
+			if commentIDSet {
+				return errCommentIDOnlyLegacy
+			}
 			task, err = client.CreateBlockerComment(ctx, projectKey, repoSlug, opts.ID, opts.Text)
 		}
 		if err != nil {
@@ -340,6 +349,9 @@ func runTaskCreate(cmd *cobra.Command, f *cmdutil.Factory, opts *taskOptions) er
 		}
 		created = task.ID
 	case "cloud":
+		if commentIDSet {
+			return errCommentIDOnlyLegacy
+		}
 		workspace, repoSlug, err := cloudContext(opts, ctxCfg.Workspace, ctxCfg.DefaultRepo)
 		if err != nil {
 			return err

--- a/pkg/cmd/pr/tasks.go
+++ b/pkg/cmd/pr/tasks.go
@@ -9,151 +9,209 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/avivsinai/bitbucket-cli/pkg/bbcloud"
+	"github.com/avivsinai/bitbucket-cli/pkg/bbdc"
 	"github.com/avivsinai/bitbucket-cli/pkg/cmdutil"
 )
 
+const taskRequestTimeout = 10 * time.Second
+
 type taskOptions struct {
-	Project string
-	Repo    string
-	ID      int
-	TaskID  int
-	Text    string
+	Project   string
+	Repo      string
+	Workspace string
+	TaskAPI   string
+	ID        int
+	TaskID    int
+	CommentID int
+	Text      string
+}
+
+// taskView is the normalized, host-agnostic shape the CLI prints. Data Center
+// states are OPEN/RESOLVED; Cloud's UNRESOLVED is normalized to OPEN.
+type taskView struct {
+	ID    int    `json:"id"`
+	State string `json:"state"`
+	Text  string `json:"text"`
+}
+
+func dcTaskViews(tasks []bbdc.PullRequestTask) []taskView {
+	views := make([]taskView, 0, len(tasks))
+	for _, t := range tasks {
+		views = append(views, taskView{ID: t.ID, State: t.State, Text: t.Text})
+	}
+	return views
+}
+
+func cloudTaskView(t bbcloud.PullRequestTask) taskView {
+	state := t.State
+	if state == bbcloud.TaskStateUnresolved {
+		state = "OPEN"
+	}
+	return taskView{ID: t.ID, State: state, Text: t.Content.Raw}
 }
 
 func newTaskCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &taskOptions{}
 	cmd := &cobra.Command{
 		Use:   "task",
-		Short: "Manage pull request tasks (DC only)",
-		Long: `List, create, complete, or reopen tasks on a pull request. Tasks track
-action items that must be resolved before merging.
+		Short: "Manage pull request tasks (DC and Cloud)",
+		Long: `List, create, complete, or reopen tasks on a pull request.
 
-Data Center only. Not yet supported on Cloud.`,
+Bitbucket Cloud exposes tasks as a first-class pull request resource. Bitbucket
+Data Center 7.2+ models them as blocker comments; older servers use the legacy
+/tasks API. The --task-api flag selects the Data Center model:
+
+  auto             detect the server version and pick automatically (default)
+  blocker-comments force the Data Center 7.2+ blocker-comments model
+  legacy           force the pre-7.2 /tasks model (create requires --comment-id)
+
+The flag is ignored on Cloud.`,
 		Example: `  # List tasks on a pull request
   bkt pr task list 42
 
-  # Create a new task
+  # Create a task
   bkt pr task create 42 --text "Update the changelog"
 
-  # Mark a task as complete
-  bkt pr task complete 42 99
+  # Create a legacy DC task anchored to a comment
+  bkt pr task create 42 --text "Fix this" --task-api legacy --comment-id 1001
 
-  # Reopen a resolved task
+  # Complete / reopen a task
+  bkt pr task complete 42 99
   bkt pr task reopen 42 99`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if opts.TaskAPI == "" {
+				opts.TaskAPI = taskAPIAuto
+			}
+			return validateTaskAPIMode(opts.TaskAPI)
+		},
 	}
 
-	cmd.AddCommand(newTaskListCmd(f))
-	cmd.AddCommand(newTaskCreateCmd(f))
-	cmd.AddCommand(newTaskCompleteCmd(f))
-	cmd.AddCommand(newTaskReopenCmd(f))
+	cmd.PersistentFlags().StringVar(&opts.TaskAPI, "task-api", taskAPIAuto, "Data Center task model: auto, blocker-comments, or legacy")
+
+	cmd.AddCommand(newTaskListCmd(f, opts))
+	cmd.AddCommand(newTaskCreateCmd(f, opts))
+	cmd.AddCommand(newTaskCompleteCmd(f, opts))
+	cmd.AddCommand(newTaskReopenCmd(f, opts))
 
 	return cmd
 }
 
-func newTaskListCmd(f *cmdutil.Factory) *cobra.Command {
-	opts := &taskOptions{}
+func registerTaskTargetFlags(cmd *cobra.Command, opts *taskOptions) {
+	cmd.Flags().StringVar(&opts.Project, "project", "", "Bitbucket project key override (DC)")
+	cmd.Flags().StringVar(&opts.Repo, "repo", "", "Repository slug override")
+	cmd.Flags().StringVar(&opts.Workspace, "workspace", "", "Bitbucket Cloud workspace override")
+}
+
+func newTaskListCmd(f *cmdutil.Factory, opts *taskOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list <id>",
-		Short: "List tasks for a pull request (DC only)",
-		Long:  `List all tasks on a pull request, showing each task's state (OPEN/RESOLVED), ID, and text. Data Center only.`,
-		Example: `  # List tasks on pull request #42
-  bkt pr task list 42`,
-		Args: cobra.ExactArgs(1),
+		Use:     "list <id>",
+		Short:   "List tasks for a pull request",
+		Example: "  bkt pr task list 42",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id, err := strconv.Atoi(args[0])
+			id, err := parsePRID(args[0])
 			if err != nil {
-				return fmt.Errorf("invalid pull request id %q", args[0])
+				return err
 			}
 			opts.ID = id
 			return runTaskList(cmd, f, opts)
 		},
 	}
-	cmd.Flags().StringVar(&opts.Project, "project", "", "Bitbucket project key override")
-	cmd.Flags().StringVar(&opts.Repo, "repo", "", "Repository slug override")
+	registerTaskTargetFlags(cmd, opts)
 	return cmd
 }
 
-func newTaskCreateCmd(f *cmdutil.Factory) *cobra.Command {
-	opts := &taskOptions{}
+func newTaskCreateCmd(f *cmdutil.Factory, opts *taskOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "create <id>",
-		Short: "Create a task on a pull request (DC only)",
-		Long:  `Create a new task on a pull request with the specified text. Data Center only.`,
-		Example: `  # Create a task
-  bkt pr task create 42 --text "Add unit tests for the new endpoint"`,
-		Args: cobra.ExactArgs(1),
+		Use:     "create <id>",
+		Short:   "Create a task on a pull request",
+		Example: `  bkt pr task create 42 --text "Add unit tests"`,
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id, err := strconv.Atoi(args[0])
+			id, err := parsePRID(args[0])
 			if err != nil {
-				return fmt.Errorf("invalid pull request id %q", args[0])
+				return err
 			}
 			opts.ID = id
 			return runTaskCreate(cmd, f, opts)
 		},
 	}
-
-	cmd.Flags().StringVar(&opts.Project, "project", "", "Bitbucket project key override")
-	cmd.Flags().StringVar(&opts.Repo, "repo", "", "Repository slug override")
+	registerTaskTargetFlags(cmd, opts)
 	cmd.Flags().StringVar(&opts.Text, "text", "", "Task text")
+	cmd.Flags().IntVar(&opts.CommentID, "comment-id", 0, "Comment to anchor the task to (required for --task-api legacy)")
 	_ = cmd.MarkFlagRequired("text")
-
 	return cmd
 }
 
-func newTaskCompleteCmd(f *cmdutil.Factory) *cobra.Command {
-	opts := &taskOptions{}
+func newTaskCompleteCmd(f *cmdutil.Factory, opts *taskOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "complete <id> <task-id>",
-		Short: "Complete a pull request task (DC only)",
-		Long:  `Mark a pull request task as completed (resolved). Data Center only.`,
-		Example: `  # Complete task 99 on pull request #42
-  bkt pr task complete 42 99`,
-		Args: cobra.ExactArgs(2),
+		Use:     "complete <id> <task-id>",
+		Short:   "Complete (resolve) a pull request task",
+		Example: "  bkt pr task complete 42 99",
+		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			prID, err := strconv.Atoi(args[0])
-			if err != nil {
-				return fmt.Errorf("invalid pull request id %q", args[0])
-			}
-			taskID, err := strconv.Atoi(args[1])
-			if err != nil {
-				return fmt.Errorf("invalid task id %q", args[1])
-			}
-			opts.ID = prID
-			opts.TaskID = taskID
-			return runTaskComplete(cmd, f, opts)
+			return runTaskToggle(cmd, f, opts, args, true)
 		},
 	}
-
-	cmd.Flags().StringVar(&opts.Project, "project", "", "Bitbucket project key override")
-	cmd.Flags().StringVar(&opts.Repo, "repo", "", "Repository slug override")
+	registerTaskTargetFlags(cmd, opts)
 	return cmd
 }
 
-func newTaskReopenCmd(f *cmdutil.Factory) *cobra.Command {
-	opts := &taskOptions{}
+func newTaskReopenCmd(f *cmdutil.Factory, opts *taskOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "reopen <id> <task-id>",
-		Short: "Reopen a resolved task (DC only)",
-		Long:  `Reopen a previously completed (resolved) task on a pull request. Data Center only.`,
-		Example: `  # Reopen task 99 on pull request #42
-  bkt pr task reopen 42 99`,
-		Args: cobra.ExactArgs(2),
+		Use:     "reopen <id> <task-id>",
+		Short:   "Reopen a resolved pull request task",
+		Example: "  bkt pr task reopen 42 99",
+		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			prID, err := strconv.Atoi(args[0])
-			if err != nil {
-				return fmt.Errorf("invalid pull request id %q", args[0])
-			}
-			taskID, err := strconv.Atoi(args[1])
-			if err != nil {
-				return fmt.Errorf("invalid task id %q", args[1])
-			}
-			opts.ID = prID
-			opts.TaskID = taskID
-			return runTaskReopen(cmd, f, opts)
+			return runTaskToggle(cmd, f, opts, args, false)
 		},
 	}
-	cmd.Flags().StringVar(&opts.Project, "project", "", "Bitbucket project key override")
-	cmd.Flags().StringVar(&opts.Repo, "repo", "", "Repository slug override")
+	registerTaskTargetFlags(cmd, opts)
 	return cmd
+}
+
+func parsePRID(arg string) (int, error) {
+	id, err := strconv.Atoi(arg)
+	if err != nil {
+		return 0, fmt.Errorf("invalid pull request id %q", arg)
+	}
+	return id, nil
+}
+
+func runTaskToggle(cmd *cobra.Command, f *cmdutil.Factory, opts *taskOptions, args []string, resolve bool) error {
+	prID, err := parsePRID(args[0])
+	if err != nil {
+		return err
+	}
+	taskID, err := strconv.Atoi(args[1])
+	if err != nil {
+		return fmt.Errorf("invalid task id %q", args[1])
+	}
+	opts.ID = prID
+	opts.TaskID = taskID
+	return runTaskSetState(cmd, f, opts, resolve)
+}
+
+// dcContext resolves the project/repo for a Data Center task command.
+func dcContext(opts *taskOptions, ctxProject, ctxRepo string) (projectKey, repoSlug string, err error) {
+	projectKey = cmdutil.FirstNonEmpty(opts.Project, ctxProject)
+	repoSlug = cmdutil.FirstNonEmpty(opts.Repo, ctxRepo)
+	if projectKey == "" || repoSlug == "" {
+		return "", "", fmt.Errorf("context must supply project and repo; use --project/--repo if needed")
+	}
+	return projectKey, repoSlug, nil
+}
+
+// cloudContext resolves the workspace/repo for a Cloud task command.
+func cloudContext(opts *taskOptions, ctxWorkspace, ctxRepo string) (workspace, repoSlug string, err error) {
+	workspace = cmdutil.FirstNonEmpty(opts.Workspace, ctxWorkspace)
+	repoSlug = cmdutil.FirstNonEmpty(opts.Repo, ctxRepo)
+	if workspace == "" || repoSlug == "" {
+		return "", "", fmt.Errorf("context must supply workspace and repo; use --workspace/--repo if needed")
+	}
+	return workspace, repoSlug, nil
 }
 
 func runTaskList(cmd *cobra.Command, f *cmdutil.Factory, opts *taskOptions) error {
@@ -161,39 +219,66 @@ func runTaskList(cmd *cobra.Command, f *cmdutil.Factory, opts *taskOptions) erro
 	if err != nil {
 		return err
 	}
-
 	_, ctxCfg, host, err := cmdutil.ResolveContext(f, cmd, cmdutil.FlagValue(cmd, "context"))
 	if err != nil {
 		return err
 	}
-	if host.Kind != "dc" {
-		return fmt.Errorf("task list currently supports Data Center contexts only")
-	}
 
-	projectKey := cmdutil.FirstNonEmpty(opts.Project, ctxCfg.ProjectKey)
-	repoSlug := cmdutil.FirstNonEmpty(opts.Repo, ctxCfg.DefaultRepo)
-	if projectKey == "" || repoSlug == "" {
-		return fmt.Errorf("context must supply project and repo; use --project/--repo if needed")
-	}
-
-	client, err := cmdutil.NewDCClient(host)
-	if err != nil {
-		return err
-	}
-
-	ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(cmd.Context(), taskRequestTimeout)
 	defer cancel()
 
-	tasks, err := client.ListPullRequestTasks(ctx, projectKey, repoSlug, opts.ID)
-	if err != nil {
-		return err
+	var tasks []taskView
+	payload := map[string]any{}
+
+	switch host.Kind {
+	case "dc":
+		projectKey, repoSlug, err := dcContext(opts, ctxCfg.ProjectKey, ctxCfg.DefaultRepo)
+		if err != nil {
+			return err
+		}
+		client, err := cmdutil.NewDCClient(host)
+		if err != nil {
+			return err
+		}
+		mode, err := resolveDCTaskMode(opts.TaskAPI, func() (string, error) { return client.ServerVersion(ctx) }, false)
+		if err != nil {
+			return err
+		}
+		var dcTasks []bbdc.PullRequestTask
+		if mode == taskAPILegacy {
+			dcTasks, err = client.ListPullRequestTasks(ctx, projectKey, repoSlug, opts.ID)
+		} else {
+			dcTasks, err = client.ListBlockerComments(ctx, projectKey, repoSlug, opts.ID)
+		}
+		if err != nil {
+			return err
+		}
+		tasks = dcTaskViews(dcTasks)
+		payload["project"] = projectKey
+		payload["repo"] = repoSlug
+	case "cloud":
+		workspace, repoSlug, err := cloudContext(opts, ctxCfg.Workspace, ctxCfg.DefaultRepo)
+		if err != nil {
+			return err
+		}
+		client, err := cmdutil.NewCloudClient(host)
+		if err != nil {
+			return err
+		}
+		cloudTasks, err := client.ListPullRequestTasks(ctx, workspace, repoSlug, opts.ID, 0)
+		if err != nil {
+			return err
+		}
+		for _, t := range cloudTasks {
+			tasks = append(tasks, cloudTaskView(t))
+		}
+		payload["workspace"] = workspace
+		payload["repo"] = repoSlug
+	default:
+		return fmt.Errorf("unsupported host kind %q", host.Kind)
 	}
 
-	payload := map[string]any{
-		"project": projectKey,
-		"repo":    repoSlug,
-		"tasks":   tasks,
-	}
+	payload["tasks"] = tasks
 
 	return cmdutil.WriteOutput(cmd, ios.Out, payload, func() error {
 		if len(tasks) == 0 {
@@ -214,91 +299,123 @@ func runTaskCreate(cmd *cobra.Command, f *cmdutil.Factory, opts *taskOptions) er
 	if err != nil {
 		return err
 	}
-
+	if strings.TrimSpace(opts.Text) == "" {
+		return fmt.Errorf("task text is required")
+	}
 	_, ctxCfg, host, err := cmdutil.ResolveContext(f, cmd, cmdutil.FlagValue(cmd, "context"))
 	if err != nil {
 		return err
 	}
-	if host.Kind != "dc" {
-		return fmt.Errorf("task create currently supports Data Center contexts only")
-	}
 
-	projectKey := cmdutil.FirstNonEmpty(opts.Project, ctxCfg.ProjectKey)
-	repoSlug := cmdutil.FirstNonEmpty(opts.Repo, ctxCfg.DefaultRepo)
-	if projectKey == "" || repoSlug == "" {
-		return fmt.Errorf("context must supply project and repo; use --project/--repo if needed")
-	}
-
-	client, err := cmdutil.NewDCClient(host)
-	if err != nil {
-		return err
-	}
-
-	ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(cmd.Context(), taskRequestTimeout)
 	defer cancel()
 
-	task, err := client.CreatePullRequestTask(ctx, projectKey, repoSlug, opts.ID, opts.Text)
-	if err != nil {
-		return err
+	var created int
+
+	switch host.Kind {
+	case "dc":
+		projectKey, repoSlug, err := dcContext(opts, ctxCfg.ProjectKey, ctxCfg.DefaultRepo)
+		if err != nil {
+			return err
+		}
+		client, err := cmdutil.NewDCClient(host)
+		if err != nil {
+			return err
+		}
+		mode, err := resolveDCTaskMode(opts.TaskAPI, func() (string, error) { return client.ServerVersion(ctx) }, true)
+		if err != nil {
+			return err
+		}
+		var task *bbdc.PullRequestTask
+		if mode == taskAPILegacy {
+			if opts.CommentID <= 0 {
+				return fmt.Errorf("legacy Data Center tasks must anchor to a comment; pass --comment-id <id>")
+			}
+			task, err = client.CreateLegacyTask(ctx, projectKey, repoSlug, opts.ID, opts.CommentID, opts.Text)
+		} else {
+			task, err = client.CreateBlockerComment(ctx, projectKey, repoSlug, opts.ID, opts.Text)
+		}
+		if err != nil {
+			return err
+		}
+		created = task.ID
+	case "cloud":
+		workspace, repoSlug, err := cloudContext(opts, ctxCfg.Workspace, ctxCfg.DefaultRepo)
+		if err != nil {
+			return err
+		}
+		client, err := cmdutil.NewCloudClient(host)
+		if err != nil {
+			return err
+		}
+		task, err := client.CreatePullRequestTask(ctx, workspace, repoSlug, opts.ID, opts.Text)
+		if err != nil {
+			return err
+		}
+		created = task.ID
+	default:
+		return fmt.Errorf("unsupported host kind %q", host.Kind)
 	}
 
-	if _, err := fmt.Fprintf(ios.Out, "✓ Created task %d\n", task.ID); err != nil {
-		return err
-	}
-	return nil
+	_, err = fmt.Fprintf(ios.Out, "✓ Created task %d\n", created)
+	return err
 }
 
-func runTaskComplete(cmd *cobra.Command, f *cmdutil.Factory, opts *taskOptions) error {
-	return toggleTaskState(cmd, f, opts, true)
-}
-
-func runTaskReopen(cmd *cobra.Command, f *cmdutil.Factory, opts *taskOptions) error {
-	return toggleTaskState(cmd, f, opts, false)
-}
-
-func toggleTaskState(cmd *cobra.Command, f *cmdutil.Factory, opts *taskOptions, resolve bool) error {
+func runTaskSetState(cmd *cobra.Command, f *cmdutil.Factory, opts *taskOptions, resolve bool) error {
 	ios, err := f.Streams()
 	if err != nil {
 		return err
 	}
-
 	_, ctxCfg, host, err := cmdutil.ResolveContext(f, cmd, cmdutil.FlagValue(cmd, "context"))
 	if err != nil {
 		return err
 	}
-	if host.Kind != "dc" {
-		return fmt.Errorf("task management currently supports Data Center contexts only")
-	}
 
-	projectKey := cmdutil.FirstNonEmpty(opts.Project, ctxCfg.ProjectKey)
-	repoSlug := cmdutil.FirstNonEmpty(opts.Repo, ctxCfg.DefaultRepo)
-	if projectKey == "" || repoSlug == "" {
-		return fmt.Errorf("context must supply project and repo; use --project/--repo if needed")
-	}
-
-	client, err := cmdutil.NewDCClient(host)
-	if err != nil {
-		return err
-	}
-
-	ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(cmd.Context(), taskRequestTimeout)
 	defer cancel()
 
-	if resolve {
-		if err := client.CompletePullRequestTask(ctx, projectKey, repoSlug, opts.ID, opts.TaskID); err != nil {
+	switch host.Kind {
+	case "dc":
+		projectKey, repoSlug, err := dcContext(opts, ctxCfg.ProjectKey, ctxCfg.DefaultRepo)
+		if err != nil {
 			return err
 		}
-		if _, err := fmt.Fprintf(ios.Out, "✓ Completed task %d\n", opts.TaskID); err != nil {
+		client, err := cmdutil.NewDCClient(host)
+		if err != nil {
 			return err
 		}
-		return nil
+		mode, err := resolveDCTaskMode(opts.TaskAPI, func() (string, error) { return client.ServerVersion(ctx) }, true)
+		if err != nil {
+			return err
+		}
+		if mode == taskAPILegacy {
+			_, err = client.SetLegacyTaskState(ctx, opts.TaskID, resolve)
+		} else {
+			_, err = client.SetBlockerCommentState(ctx, projectKey, repoSlug, opts.ID, opts.TaskID, resolve)
+		}
+		if err != nil {
+			return err
+		}
+	case "cloud":
+		workspace, repoSlug, err := cloudContext(opts, ctxCfg.Workspace, ctxCfg.DefaultRepo)
+		if err != nil {
+			return err
+		}
+		client, err := cmdutil.NewCloudClient(host)
+		if err != nil {
+			return err
+		}
+		if _, err := client.SetPullRequestTaskState(ctx, workspace, repoSlug, opts.ID, opts.TaskID, resolve); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported host kind %q", host.Kind)
 	}
 
-	if err := client.ReopenPullRequestTask(ctx, projectKey, repoSlug, opts.ID, opts.TaskID); err != nil {
-		return err
+	verb := "Reopened"
+	if resolve {
+		verb = "Completed"
 	}
-	if _, err := fmt.Fprintf(ios.Out, "✓ Reopened task %d\n", opts.TaskID); err != nil {
-		return err
-	}
-	return nil
+	_, err = fmt.Fprintf(ios.Out, "✓ %s task %d\n", verb, opts.TaskID)
+	return err
 }

--- a/pkg/cmd/pr/tasks_cli_test.go
+++ b/pkg/cmd/pr/tasks_cli_test.go
@@ -68,6 +68,18 @@ func TestPRTaskCreateDCAutoUsesBlockerComments(t *testing.T) {
 	}
 }
 
+// Regression: the task command must not define its own PersistentPreRunE, which
+// would shadow the root hook and skip global output-flag validation.
+func TestPRTaskRespectsRootOutputValidation(t *testing.T) {
+	_, _, err := runCLI(t, dcConfig("http://127.0.0.1:0"), "--json", "--yaml", "pr", "task", "list", "42")
+	if err == nil {
+		t.Fatal("expected --json --yaml to be rejected before reaching the task command")
+	}
+	if !strings.Contains(err.Error(), "json") || !strings.Contains(err.Error(), "yaml") {
+		t.Errorf("error = %v, want a json/yaml conflict error", err)
+	}
+}
+
 // DC legacy create without --comment-id fails fast with a targeted error and
 // never reaches the network.
 func TestPRTaskCreateLegacyRequiresCommentID(t *testing.T) {

--- a/pkg/cmd/pr/tasks_cli_test.go
+++ b/pkg/cmd/pr/tasks_cli_test.go
@@ -80,6 +80,32 @@ func TestPRTaskRespectsRootOutputValidation(t *testing.T) {
 	}
 }
 
+// --comment-id is rejected when it carries no meaning (Cloud, and DC
+// blocker-comments mode) rather than being silently ignored.
+func TestPRTaskCreateRejectsCommentIDOutsideLegacy(t *testing.T) {
+	t.Run("cloud", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Errorf("unexpected request to %s %s", r.Method, r.URL.Path)
+		}))
+		t.Cleanup(srv.Close)
+		_, _, err := runCLI(t, cloudConfig(srv.URL), "pr", "task", "create", "42", "--text", "x", "--comment-id", "7")
+		if err == nil || !strings.Contains(err.Error(), "comment-id") {
+			t.Fatalf("err = %v, want --comment-id rejection", err)
+		}
+	})
+
+	t.Run("dc blocker-comments", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Errorf("unexpected request to %s %s", r.Method, r.URL.Path)
+		}))
+		t.Cleanup(srv.Close)
+		_, _, err := runCLI(t, dcConfig(srv.URL), "pr", "task", "create", "42", "--text", "x", "--task-api", "blocker-comments", "--comment-id", "7")
+		if err == nil || !strings.Contains(err.Error(), "comment-id") {
+			t.Fatalf("err = %v, want --comment-id rejection", err)
+		}
+	})
+}
+
 // DC legacy create without --comment-id fails fast with a targeted error and
 // never reaches the network.
 func TestPRTaskCreateLegacyRequiresCommentID(t *testing.T) {

--- a/pkg/cmd/pr/tasks_cli_test.go
+++ b/pkg/cmd/pr/tasks_cli_test.go
@@ -1,0 +1,87 @@
+package pr_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Cloud: list hits the tasks resource and normalizes UNRESOLVED -> OPEN.
+func TestPRTaskListCloud(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"values": []map[string]any{
+				{"id": 5, "state": "UNRESOLVED", "content": map[string]string{"raw": "do X"}},
+				{"id": 6, "state": "RESOLVED", "content": map[string]string{"raw": "do Y"}},
+			},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	stdout, stderr, err := runCLI(t, cloudConfig(srv.URL), "pr", "task", "list", "42")
+	if err != nil {
+		t.Fatalf("pr task list: %v (stderr=%s)", err, stderr)
+	}
+	if gotPath != "/repositories/myworkspace/my-repo/pullrequests/42/tasks" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if !strings.Contains(stdout, "[OPEN] 5 do X") || !strings.Contains(stdout, "[RESOLVED] 6 do Y") {
+		t.Errorf("unexpected output:\n%s", stdout)
+	}
+}
+
+// DC auto: detects a 7.2+ version and creates via blocker-comments.
+func TestPRTaskCreateDCAutoUsesBlockerComments(t *testing.T) {
+	var versionProbed, createPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/application-properties"):
+			versionProbed = r.URL.Path
+			_ = json.NewEncoder(w).Encode(map[string]any{"version": "8.19.1"})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/blocker-comments"):
+			createPath = r.URL.Path
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 77, "text": "fix it", "state": "OPEN"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	stdout, stderr, err := runCLI(t, dcConfig(srv.URL), "pr", "task", "create", "42", "--text", "fix it")
+	if err != nil {
+		t.Fatalf("pr task create: %v (stderr=%s)", err, stderr)
+	}
+	if versionProbed == "" {
+		t.Error("auto mode did not probe application-properties")
+	}
+	if !strings.HasSuffix(createPath, "/pull-requests/42/blocker-comments") {
+		t.Errorf("create path = %q, want blocker-comments", createPath)
+	}
+	if !strings.Contains(stdout, "Created task 77") {
+		t.Errorf("unexpected output: %s", stdout)
+	}
+}
+
+// DC legacy create without --comment-id fails fast with a targeted error and
+// never reaches the network.
+func TestPRTaskCreateLegacyRequiresCommentID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request to %s %s", r.Method, r.URL.Path)
+		http.Error(w, "should not be called", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, _, err := runCLI(t, dcConfig(srv.URL), "pr", "task", "create", "42", "--text", "x", "--task-api", "legacy")
+	if err == nil {
+		t.Fatal("expected error for legacy create without --comment-id")
+	}
+	if !strings.Contains(err.Error(), "comment-id") {
+		t.Errorf("error = %v, want mention of --comment-id", err)
+	}
+}

--- a/skills/bkt/rules/pr.md
+++ b/skills/bkt/rules/pr.md
@@ -48,7 +48,7 @@ bkt pr <command> [flags]
 | [reopen](#bkt-pr-reopen) | Reopen a declined pull request | `--project`, `--repo`, `--workspace` |
 | [reviewer-group](#bkt-pr-reviewer-group) | Manage default reviewer groups *(DC)* | — |
 | [suggestion](#bkt-pr-suggestion) | Apply or preview a code suggestion *(DC)* | `--preview`, `--project`, `--repo` |
-| [task](#bkt-pr-task) | Manage pull request tasks *(DC)* | — |
+| [task](#bkt-pr-task) | Manage pull request tasks (DC and Cloud) | `--task-api` |
 | [view](#bkt-pr-view) | Show details for a pull request | `--project`, `--repo`, `--web`, `--workspace` |
 
 ## bkt pr approve
@@ -1192,10 +1192,17 @@ bkt pr suggestion <id> <comment-id> <suggestion-id> [flags]
 
 ## bkt pr task
 
-List, create, complete, or reopen tasks on a pull request. Tasks track
-action items that must be resolved before merging.
+List, create, complete, or reopen tasks on a pull request.
 
-Data Center only. Not yet supported on Cloud.
+Bitbucket Cloud exposes tasks as a first-class pull request resource. Bitbucket
+Data Center 7.2+ models them as blocker comments; older servers use the legacy
+/tasks API. The --task-api flag selects the Data Center model:
+
+  auto             detect the server version and pick automatically (default)
+  blocker-comments force the Data Center 7.2+ blocker-comments model
+  legacy           force the pre-7.2 /tasks model (create requires --comment-id)
+
+The flag is ignored on Cloud.
 
 ```
 bkt pr task <command> [flags]
@@ -1207,26 +1214,27 @@ bkt pr task <command> [flags]
 # List tasks on a pull request
   bkt pr task list 42
 
-  # Create a new task
+  # Create a task
   bkt pr task create 42 --text "Update the changelog"
 
-  # Mark a task as complete
-  bkt pr task complete 42 99
+  # Create a legacy DC task anchored to a comment
+  bkt pr task create 42 --text "Fix this" --task-api legacy --comment-id 1001
 
-  # Reopen a resolved task
+  # Complete / reopen a task
+  bkt pr task complete 42 99
   bkt pr task reopen 42 99
 ```
 
 | Subcommand | Description |
 |---|---|
-| complete | Complete a pull request task (DC only) |
-| create | Create a task on a pull request (DC only) |
-| list | List tasks for a pull request (DC only) |
-| reopen | Reopen a resolved task (DC only) |
+| complete | Complete (resolve) a pull request task |
+| create | Create a task on a pull request |
+| list | List tasks for a pull request |
+| reopen | Reopen a resolved pull request task |
 
 ## bkt pr task complete
 
-Mark a pull request task as completed (resolved). Data Center only.
+Complete (resolve) a pull request task
 
 ### Usage
 
@@ -1238,8 +1246,9 @@ bkt pr task complete <id> <task-id> [flags]
 
 | Flag | Short | Description |
 |---|---|---|
-| `--project` |  | Bitbucket project key override |
+| `--project` |  | Bitbucket project key override (DC) |
 | `--repo` |  | Repository slug override |
+| `--workspace` |  | Bitbucket Cloud workspace override |
 
 ### Inherited Flags
 
@@ -1249,19 +1258,19 @@ bkt pr task complete <id> <task-id> [flags]
 | `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
 | `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
+| `--task-api` |  | Data Center task model: auto, blocker-comments, or legacy |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
 
 ### Examples
 
 ```bash
-# Complete task 99 on pull request #42
-  bkt pr task complete 42 99
+bkt pr task complete 42 99
 ```
 
 ## bkt pr task create
 
-Create a new task on a pull request with the specified text. Data Center only.
+Create a task on a pull request
 
 ### Usage
 
@@ -1273,9 +1282,11 @@ bkt pr task create <id> [flags]
 
 | Flag | Short | Description |
 |---|---|---|
-| `--project` |  | Bitbucket project key override |
+| `--comment-id` |  | Comment to anchor the task to (required for --task-api legacy) |
+| `--project` |  | Bitbucket project key override (DC) |
 | `--repo` |  | Repository slug override |
 | `--text` |  | Task text |
+| `--workspace` |  | Bitbucket Cloud workspace override |
 
 ### Inherited Flags
 
@@ -1285,19 +1296,19 @@ bkt pr task create <id> [flags]
 | `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
 | `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
+| `--task-api` |  | Data Center task model: auto, blocker-comments, or legacy |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
 
 ### Examples
 
 ```bash
-# Create a task
-  bkt pr task create 42 --text "Add unit tests for the new endpoint"
+bkt pr task create 42 --text "Add unit tests"
 ```
 
 ## bkt pr task list
 
-List all tasks on a pull request, showing each task's state (OPEN/RESOLVED), ID, and text. Data Center only.
+List tasks for a pull request
 
 ### Usage
 
@@ -1309,8 +1320,9 @@ bkt pr task list <id> [flags]
 
 | Flag | Short | Description |
 |---|---|---|
-| `--project` |  | Bitbucket project key override |
+| `--project` |  | Bitbucket project key override (DC) |
 | `--repo` |  | Repository slug override |
+| `--workspace` |  | Bitbucket Cloud workspace override |
 
 ### Inherited Flags
 
@@ -1320,19 +1332,19 @@ bkt pr task list <id> [flags]
 | `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
 | `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
+| `--task-api` |  | Data Center task model: auto, blocker-comments, or legacy |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
 
 ### Examples
 
 ```bash
-# List tasks on pull request #42
-  bkt pr task list 42
+bkt pr task list 42
 ```
 
 ## bkt pr task reopen
 
-Reopen a previously completed (resolved) task on a pull request. Data Center only.
+Reopen a resolved pull request task
 
 ### Usage
 
@@ -1344,8 +1356,9 @@ bkt pr task reopen <id> <task-id> [flags]
 
 | Flag | Short | Description |
 |---|---|---|
-| `--project` |  | Bitbucket project key override |
+| `--project` |  | Bitbucket project key override (DC) |
 | `--repo` |  | Repository slug override |
+| `--workspace` |  | Bitbucket Cloud workspace override |
 
 ### Inherited Flags
 
@@ -1355,14 +1368,14 @@ bkt pr task reopen <id> <task-id> [flags]
 | `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
 | `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
 | `--json` |  | Output in JSON format when supported |
+| `--task-api` |  | Data Center task model: auto, blocker-comments, or legacy |
 | `--template` |  | Render output using Go templates |
 | `--yaml` |  | Output in YAML format when supported |
 
 ### Examples
 
 ```bash
-# Reopen task 99 on pull request #42
-  bkt pr task reopen 42 99
+bkt pr task reopen 42 99
 ```
 
 ## bkt pr view


### PR DESCRIPTION
## Summary

Reworks `bkt pr task`, which was broken on Data Center (create/complete/reopen hit endpoints that never existed and returned 404, with zero test coverage) and unsupported on Cloud. Fixes #212.

- **Cloud**: new `pkg/bbcloud/tasks.go` using the first-class `/pullrequests/{id}/tasks` resource — `list`, `create`, `complete`, `reopen`.
- **Data Center**: dispatch via a new `--task-api auto|blocker-comments|legacy` flag.
  - `auto` (default) detects the server version via `/application-properties`: **≥ 7.2** uses blocker comments (the non-deprecated model), older servers use the legacy top-level `/tasks` API.
  - Blocker-comment state changes use the required optimistic-locking flow (GET version → PUT `{version, state}`).
  - Legacy task creation requires `--comment-id` (legacy tasks must anchor to a comment); a missing id fails fast with a targeted error.
  - Mutating ops fail closed if the version can't be detected; reads fall back to blocker comments.
- Removes the old broken/deprecated DC task methods.
- Normalized, host-agnostic output (`id`/`state`/`text`; Cloud `UNRESOLVED` → `OPEN`).

## Testing

- `go build ./...`
- `go vet ./...`
- `go test ./...` (green)
- New tests: Cloud client (list/create/state + validation), DC client (blocker-comments pagination, GET-then-PUT version flow, legacy anchor/state/delete), `--task-api` mode/version resolution (22 cases), and end-to-end CLI dispatch (Cloud list, DC auto→blocker-comments, legacy `--comment-id` guard, root output-flag validation regression).
- Live DC/Cloud smoke not yet run here — one item to confirm against a real DC instance: the blocker-comment state PUT body is `{version, state}` only.

## Notes

Built as a paired effort: DC client by codex (`8a0c7e8`), Cloud client + CLI + mode resolution by Claude. Cross-reviewed; one blocking issue (a `PersistentPreRunE` shadowing root output validation) was found in review and fixed (`c209f4c`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)