### PR TITLE
test(pr): cover pr task reopen path (DC OPEN, Cloud UNRESOLVED)

### DIFF
--- a/pkg/bbdc/tasks_test.go
+++ b/pkg/bbdc/tasks_test.go
@@ -206,6 +206,56 @@ func TestSetPullRequestTaskStateFetchesVersionBeforePUT(t *testing.T) {
 	}
 }
 
+func TestSetPullRequestTaskStateReopensWithOpenState(t *testing.T) {
+	var hits int32
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&hits, 1)
+		switch count {
+		case 1:
+			if r.Method != http.MethodGet {
+				t.Fatalf("method = %s, want GET", r.Method)
+			}
+			if r.URL.Path != "/rest/api/1.0/projects/PROJ/repos/repo/pull-requests/42/blocker-comments/99" {
+				t.Fatalf("path = %q, want blocker-comments get path", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 99, "version": 7, "text": "fix docs", "state": "RESOLVED"})
+		case 2:
+			if r.Method != http.MethodPut {
+				t.Fatalf("method = %s, want PUT", r.Method)
+			}
+			if r.URL.Path != "/rest/api/1.0/projects/PROJ/repos/repo/pull-requests/42/blocker-comments/99" {
+				t.Fatalf("path = %q, want blocker-comments put path", r.URL.Path)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if int(body["version"].(float64)) != 7 || body["state"] != "OPEN" {
+				t.Fatalf("body = %#v, want version=7 state=OPEN", body)
+			}
+			if _, ok := body["text"]; ok {
+				t.Fatalf("body should not update text: %#v", body)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 99, "version": 8, "state": "OPEN"})
+		default:
+			t.Fatalf("unexpected request %d", count)
+		}
+	}))
+
+	task, err := client.SetPullRequestTaskState(context.Background(), "PROJ", "repo", 42, 99, false)
+	if err != nil {
+		t.Fatalf("SetPullRequestTaskState: %v", err)
+	}
+	if task.ID != 99 || task.State != "OPEN" {
+		t.Fatalf("task = %+v, want id=99 state=OPEN", task)
+	}
+	if hits != 2 {
+		t.Fatalf("hits = %d, want 2", hits)
+	}
+}
+
 func TestSetPullRequestTaskStateWrapsPUTFailure(t *testing.T) {
 	var hits int32
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/cmd/pr/tasks_cli_test.go
+++ b/pkg/cmd/pr/tasks_cli_test.go
@@ -154,6 +154,57 @@ func TestPRTaskCompleteCloud(t *testing.T) {
 	}
 }
 
+// DC: reopen fetches the version then PUTs state=OPEN (the resolve=false path).
+func TestPRTaskReopenDC(t *testing.T) {
+	var putBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 99, "version": 4, "state": "RESOLVED"})
+		case http.MethodPut:
+			_ = json.NewDecoder(r.Body).Decode(&putBody)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 99, "version": 5, "state": "OPEN"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	stdout, stderr, err := runCLI(t, dcConfig(srv.URL), "pr", "task", "reopen", "42", "99")
+	if err != nil {
+		t.Fatalf("pr task reopen: %v (stderr=%s)", err, stderr)
+	}
+	if putBody["state"] != "OPEN" {
+		t.Errorf("PUT body = %#v, want state=OPEN", putBody)
+	}
+	if !strings.Contains(stdout, "Reopened task 99") {
+		t.Errorf("unexpected output: %s", stdout)
+	}
+}
+
+// Cloud: reopen PUTs state=UNRESOLVED to the task resource.
+func TestPRTaskReopenCloud(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 9, "state": "UNRESOLVED", "content": map[string]string{"raw": "x"}})
+	}))
+	t.Cleanup(srv.Close)
+
+	stdout, stderr, err := runCLI(t, cloudConfig(srv.URL), "pr", "task", "reopen", "42", "9")
+	if err != nil {
+		t.Fatalf("pr task reopen: %v (stderr=%s)", err, stderr)
+	}
+	if gotBody["state"] != "UNRESOLVED" {
+		t.Errorf("body = %#v, want state=UNRESOLVED", gotBody)
+	}
+	if !strings.Contains(stdout, "Reopened task 9") {
+		t.Errorf("unexpected output: %s", stdout)
+	}
+}
+
 // --json is honored on create and complete, not just list (the whole command
 // family must emit the structured shape for automation).
 func TestPRTaskJSONOutput(t *testing.T) {


### PR DESCRIPTION
Closes the last test gap from the ChatGPT-Pro review of #214: the `reopen`
(`resolve=false`) path was only covered implicitly via the shared `complete`
code path.

- `pkg/bbdc/tasks_test.go`: `SetPullRequestTaskState(resolved=false)` does GET
  for version then PUT `{version, state:"OPEN"}` (no `text`), returns state OPEN.
- `pkg/cmd/pr/tasks_cli_test.go`: `bkt pr task reopen` on Data Center (PUT
  `state:OPEN`) and Cloud (PUT `state:UNRESOLVED`), asserting body + output.

Tests-only; no production code change.

## Testing
- `go test ./...`, `go vet ./...` — green
- `go test ./pkg/bbdc ./pkg/cmd/pr -run Reopen`

Paired with codex (bbdc test); CLI tests by Claude. Cross-reviewed both ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)