### PR TITLE
chore(release): v0.27.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.26.7",
+  "version": "0.27.0",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.26.7",
+  "version": "0.27.0",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented here. The format follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
+## [0.27.0] - 2026-05-29
 ### Added
 - `bkt pr task` now works on Bitbucket Cloud, using its first-class pull request
   tasks API (`list`, `create`, `complete`, `reopen`).
@@ -16,6 +18,7 @@ All notable changes to this project will be documented here. The format follows
   against an older server surfaces a clear hint. On Data Center, tasks and
   `bkt pr comments --details` overlap by design, since tasks are blocker
   comments there.
+
 
 ## [0.26.7] - 2026-05-27
 ### Fixed
@@ -525,7 +528,8 @@ All notable changes to this project will be documented here. The format follows
 ## [0.1.0] - 2025-10-26
 - Initial public release of `bkt`.
 
-[Unreleased]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.7...HEAD
+[Unreleased]: https://github.com/avivsinai/bitbucket-cli/compare/v0.27.0...HEAD
+[0.27.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.7...v0.27.0
 [0.26.7]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.6...v0.26.7
 [0.26.6]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.5...v0.26.6
 [0.26.5]: https://github.com/avivsinai/bitbucket-cli/compare/v0.26.4...v0.26.5

--- a/skills/bkt/SKILL.md
+++ b/skills/bkt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bkt
-version: 0.26.7
+version: 0.27.0
 description: Bitbucket CLI for Data Center and Cloud. Use when users need to manage repositories, pull requests, branches, issues, webhooks, or pipelines in Bitbucket. Triggers include "bitbucket", "bkt", "pull request", "PR", "repo list", "branch create", "Bitbucket Data Center", "Bitbucket Cloud", "keyring timeout".
 metadata:
   short-description: Bitbucket CLI for repos, PRs, branches


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.27.0`
- aligns skill/plugin metadata to `0.27.0`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.27.0`, publishes the release, and publishes skills in the same workflow run