### PR TITLE
Feat/pr comment thread resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented here. The format follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Added
+- `bkt pr comments resolve`, `bkt pr comments reopen`, and
+  `bkt pr comments delete` now manage pull request comment threads/comments on
+  Bitbucket Cloud and Data Center. Resolve/reopen require the top-level thread
+  comment ID and support structured output.
+
+### Fixed
+- `bkt pr comments --state deleted` can now list deleted pull request comments
+  returned by Bitbucket Cloud, making deletion verification explicit.
+- `bkt pr comments delete` now includes the current comment version required by
+  Bitbucket Data Center delete-comment requests.
 
 ## [0.27.1] - 2026-05-29
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -301,9 +301,15 @@ bkt pr checks 42                              # Show build/CI status
 bkt pr checks 42 --wait                       # Wait for builds to complete
 bkt pr checks 42 --wait --timeout 5m          # Wait with timeout
 bkt pr checks 42 --wait --max-interval 1m     # Custom backoff cap
+bkt pr comments 42 --details                  # Review PR comments and thread IDs
+bkt pr comments resolve 42 1001               # Resolve a top-level comment thread
+bkt pr comments reopen 42 1001                # Reopen a resolved comment thread
+bkt pr comments delete 42 1001                # Delete a PR comment
 ```
 
 The CLI wraps Bitbucket pull-request endpoints for creation, listing, review, and merge operations. The `checks` command displays build status with color-coded output (green for success, red for failure, yellow for in-progress) and supports polling until all builds complete. Polling uses exponential backoff with jitter to avoid overwhelming the API during long builds.
+For comment thread state changes, pass the top-level thread comment ID; replies
+cannot be resolved or reopened directly.
 
 ### 5. Issue tracking (Bitbucket Cloud only)
 

--- a/internal/docgen/generate.go
+++ b/internal/docgen/generate.go
@@ -255,7 +255,7 @@ func writeGroupFile(w io.Writer, binName string, cmd *cobra.Command, emitHeader 
 
 	// Usage
 	if cmd.HasSubCommands() {
-		fmt.Fprintf(w, "```\n%s <command> [flags]\n```\n\n", fullName)
+		writeCommandGroupUsage(w, binName, cmd, fullName)
 	} else {
 		useLine := formatUseLine(binName, cmd)
 		fmt.Fprintf(w, "%s Usage\n\n```\n%s\n```\n\n", heading(h1+1), useLine)
@@ -266,6 +266,12 @@ func writeGroupFile(w io.Writer, binName string, cmd *cobra.Command, emitHeader 
 		writeFlagsAtDepth(w, cmd, h1+2)
 		writeExamplesAtDepth(w, cmd, h1+2)
 		return
+	}
+
+	// Runnable group command — show the parent command's own flags in addition
+	// to the subcommand table.
+	if cmd.Runnable() {
+		writeFlagsAtDepth(w, cmd, h1+2)
 	}
 
 	// Group command — show examples before subcommand table if present
@@ -319,7 +325,11 @@ func writeSubcommandSection(w io.Writer, parentPath string, sub *cobra.Command) 
 	// and recurse into each child instead of showing usage/flags for the parent.
 	nested := visibleSubcommands(sub)
 	if len(nested) > 0 {
-		fmt.Fprintf(w, "```\n%s <command> [flags]\n```\n\n", subFull)
+		writeCommandGroupUsage(w, parentPath, sub, subFull)
+
+		if sub.Runnable() {
+			writeFlags(w, sub)
+		}
 
 		writeExamples(w, sub)
 
@@ -342,6 +352,16 @@ func writeSubcommandSection(w io.Writer, parentPath string, sub *cobra.Command) 
 
 	writeFlags(w, sub)
 	writeExamples(w, sub)
+}
+
+func writeCommandGroupUsage(w io.Writer, parentPath string, cmd *cobra.Command, fullName string) {
+	fmt.Fprintln(w, "```")
+	if cmd.Runnable() {
+		fmt.Fprintln(w, formatUseLine(parentPath, cmd))
+	}
+	fmt.Fprintf(w, "%s <command> [flags]\n", fullName)
+	fmt.Fprintln(w, "```")
+	fmt.Fprintln(w)
 }
 
 func writeFlags(w io.Writer, cmd *cobra.Command) {

--- a/internal/docgen/generate_test.go
+++ b/internal/docgen/generate_test.go
@@ -71,6 +71,24 @@ func newTestTree() *cobra.Command {
 	prTaskCreate.Flags().String("text", "", "Task text")
 	prTask.AddCommand(prTaskList, prTaskCreate)
 
+	// Runnable subcommand with its own children (pr comments -> resolve/reopen)
+	prComments := &cobra.Command{
+		Use:   "comments <id>",
+		Short: "List comments on a pull request",
+		Example: `  # List unresolved comments
+  bkt pr comments 42 --state unresolved
+
+  # Resolve a comment thread
+  bkt pr comments resolve 42 1001`,
+		Run: func(cmd *cobra.Command, args []string) {},
+	}
+	prComments.Flags().String("state", "all", "Filter by state")
+	prComments.Flags().Bool("details", false, "Show full comment details")
+	prComments.AddCommand(
+		&cobra.Command{Use: "resolve <id> <comment-id>", Short: "Resolve a comment thread"},
+		&cobra.Command{Use: "reopen <id> <comment-id>", Short: "Reopen a comment thread"},
+	)
+
 	// DC-only subcommand
 	prReaction := &cobra.Command{
 		Use:   "reaction",
@@ -85,7 +103,7 @@ func newTestTree() *cobra.Command {
 		Long:  "Show pipeline status for a pull request.",
 	}
 
-	pr.AddCommand(prList, prCreate, prTask, prReaction, prPipeline)
+	pr.AddCommand(prList, prCreate, prTask, prComments, prReaction, prPipeline)
 
 	// Root persistent flags (inherited by all commands)
 	root.PersistentFlags().StringP("context", "c", "", "Active context name")
@@ -299,6 +317,34 @@ func TestNestedSubcommands(t *testing.T) {
 	// Nested child flags should appear
 	if !strings.Contains(got, "`--text`") {
 		t.Error("missing --text flag from nested task create")
+	}
+}
+
+func TestRunnableSubcommandWithChildren(t *testing.T) {
+	root := newTestTree()
+	pr, _, _ := root.Find([]string{"pr"})
+
+	var buf strings.Builder
+	writeGroupFile(&buf, "bkt", pr, true)
+	got := buf.String()
+
+	if !strings.Contains(got, "## bkt pr comments") {
+		t.Fatal("missing comments section")
+	}
+	if !strings.Contains(got, "bkt pr comments <id> [flags]\nbkt pr comments <command> [flags]") {
+		t.Error("runnable command with children should show both parent and child usage forms")
+	}
+	if !strings.Contains(got, "`--state`") {
+		t.Error("missing parent runnable command flag --state")
+	}
+	if !strings.Contains(got, "`--details`") {
+		t.Error("missing parent runnable command flag --details")
+	}
+	if !strings.Contains(got, "bkt pr comments 42 --state unresolved") {
+		t.Error("missing parent runnable command examples")
+	}
+	if !strings.Contains(got, "## bkt pr comments resolve") {
+		t.Error("missing nested resolve section")
 	}
 }
 

--- a/pkg/bbcloud/commits_test.go
+++ b/pkg/bbcloud/commits_test.go
@@ -62,7 +62,7 @@ func TestCommitDiffPath(t *testing.T) {
 	}
 }
 
-func TestCommitDiffHandlesHTTPError(t *testing.T) {
+func TestCommitDiffHandlesErrorResponse(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		_, _ = w.Write([]byte("Repository not found"))

--- a/pkg/bbcloud/pullrequests.go
+++ b/pkg/bbcloud/pullrequests.go
@@ -677,6 +677,31 @@ func (c *Client) GetPullRequestComment(ctx context.Context, workspace, repoSlug 
 	return &comment, nil
 }
 
+// DeletePullRequestComment deletes a pull request comment.
+func (c *Client) DeletePullRequestComment(ctx context.Context, workspace, repoSlug string, prID, commentID int) error {
+	if workspace == "" || repoSlug == "" {
+		return fmt.Errorf("workspace and repository slug are required")
+	}
+	if prID <= 0 {
+		return fmt.Errorf("pull request id must be positive")
+	}
+	if commentID <= 0 {
+		return fmt.Errorf("comment id must be positive")
+	}
+
+	path := fmt.Sprintf("/repositories/%s/%s/pullrequests/%d/comments/%d",
+		url.PathEscape(workspace),
+		url.PathEscape(repoSlug),
+		prID,
+		commentID,
+	)
+	req, err := c.http.NewRequest(ctx, "DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+	return c.http.Do(req, nil)
+}
+
 // SetPullRequestCommentThreadResolved resolves or reopens a top-level pull
 // request comment thread. Resolve returns Bitbucket Cloud's resolution object
 // when provided; reopen returns nil on success.

--- a/pkg/bbcloud/pullrequests.go
+++ b/pkg/bbcloud/pullrequests.go
@@ -572,6 +572,7 @@ type PullRequestComment struct {
 	User       *Account `json:"user"`
 	CreatedOn  string   `json:"created_on"`
 	UpdatedOn  string   `json:"updated_on"`
+	Deleted    bool     `json:"deleted"`
 	Resolution *struct {
 		User      *Account `json:"user"`
 		CreatedOn string   `json:"created_on"`
@@ -585,6 +586,10 @@ type PullRequestComment struct {
 		To   *int   `json:"to"`
 	} `json:"inline,omitempty"`
 }
+
+// PullRequestCommentResolution preserves Bitbucket Cloud's resolution response
+// for a resolve operation.
+type PullRequestCommentResolution map[string]any
 
 type pullRequestCommentListPage struct {
 	Values []PullRequestComment `json:"values"`
@@ -640,6 +645,78 @@ func (c *Client) ListPullRequestComments(ctx context.Context, workspace, repoSlu
 	}
 
 	return comments, nil
+}
+
+// GetPullRequestComment retrieves a single pull request comment.
+func (c *Client) GetPullRequestComment(ctx context.Context, workspace, repoSlug string, prID, commentID int) (*PullRequestComment, error) {
+	if workspace == "" || repoSlug == "" {
+		return nil, fmt.Errorf("workspace and repository slug are required")
+	}
+	if prID <= 0 {
+		return nil, fmt.Errorf("pull request id must be positive")
+	}
+	if commentID <= 0 {
+		return nil, fmt.Errorf("comment id must be positive")
+	}
+
+	path := fmt.Sprintf("/repositories/%s/%s/pullrequests/%d/comments/%d",
+		url.PathEscape(workspace),
+		url.PathEscape(repoSlug),
+		prID,
+		commentID,
+	)
+	req, err := c.http.NewRequest(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var comment PullRequestComment
+	if err := c.http.Do(req, &comment); err != nil {
+		return nil, err
+	}
+	return &comment, nil
+}
+
+// SetPullRequestCommentThreadResolved resolves or reopens a top-level pull
+// request comment thread. Resolve returns Bitbucket Cloud's resolution object
+// when provided; reopen returns nil on success.
+func (c *Client) SetPullRequestCommentThreadResolved(ctx context.Context, workspace, repoSlug string, prID, commentID int, resolved bool) (*PullRequestCommentResolution, error) {
+	if workspace == "" || repoSlug == "" {
+		return nil, fmt.Errorf("workspace and repository slug are required")
+	}
+	if prID <= 0 {
+		return nil, fmt.Errorf("pull request id must be positive")
+	}
+	if commentID <= 0 {
+		return nil, fmt.Errorf("comment id must be positive")
+	}
+
+	path := fmt.Sprintf("/repositories/%s/%s/pullrequests/%d/comments/%d/resolve",
+		url.PathEscape(workspace),
+		url.PathEscape(repoSlug),
+		prID,
+		commentID,
+	)
+
+	method := "DELETE"
+	if resolved {
+		method = "POST"
+	}
+
+	req, err := c.http.NewRequest(ctx, method, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if !resolved {
+		return nil, c.http.Do(req, nil)
+	}
+
+	var resolution PullRequestCommentResolution
+	if err := c.http.Do(req, &resolution); err != nil {
+		return nil, err
+	}
+	return &resolution, nil
 }
 
 // ApprovePullRequest approves the given pull request.

--- a/pkg/bbcloud/pullrequests_test.go
+++ b/pkg/bbcloud/pullrequests_test.go
@@ -1028,6 +1028,15 @@ func TestListPullRequestComments(t *testing.T) {
 					"updated_on": "2024-01-11T10:00:00.000000+00:00",
 					"resolution": resolution,
 				},
+				{
+					"id":      3,
+					"deleted": true,
+					"content": map[string]string{"raw": ""},
+					"user": map[string]any{
+						"display_name": "Deleted User",
+						"nickname":     "deleted",
+					},
+				},
 			},
 		})
 	}))
@@ -1042,8 +1051,8 @@ func TestListPullRequestComments(t *testing.T) {
 	if gotPath != "/repositories/myworkspace/my-repo/pullrequests/42/comments" {
 		t.Errorf("path = %q, want /repositories/myworkspace/my-repo/pullrequests/42/comments", gotPath)
 	}
-	if len(comments) != 2 {
-		t.Fatalf("expected 2 comments, got %d", len(comments))
+	if len(comments) != 3 {
+		t.Fatalf("expected 3 comments, got %d", len(comments))
 	}
 	if comments[0].ID != 1 {
 		t.Errorf("comments[0].ID = %d, want 1", comments[0].ID)
@@ -1062,6 +1071,37 @@ func TestListPullRequestComments(t *testing.T) {
 	}
 	if comments[1].Resolution == nil {
 		t.Fatal("comments[1].Resolution should not be nil")
+	}
+	if !comments[2].Deleted {
+		t.Fatal("comments[2].Deleted = false, want true")
+	}
+}
+
+func TestGetPullRequestComment(t *testing.T) {
+	var gotMethod, gotPath string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":      9,
+			"deleted": true,
+			"content": map[string]string{"raw": ""},
+		})
+	}))
+
+	comment, err := client.GetPullRequestComment(context.Background(), "ws", "repo", 42, 9)
+	if err != nil {
+		t.Fatalf("GetPullRequestComment: %v", err)
+	}
+	if gotMethod != http.MethodGet {
+		t.Errorf("method = %s, want GET", gotMethod)
+	}
+	if gotPath != "/repositories/ws/repo/pullrequests/42/comments/9" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if comment.ID != 9 || !comment.Deleted {
+		t.Fatalf("comment = %+v, want id=9 deleted=true", comment)
 	}
 }
 
@@ -1125,6 +1165,99 @@ func TestListPullRequestCommentsValidation(t *testing.T) {
 			_, err := client.ListPullRequestComments(context.Background(), tt.workspace, tt.repo, 1, 0)
 			if err == nil {
 				t.Error("expected error")
+			}
+		})
+	}
+}
+
+func TestSetPullRequestCommentThreadResolved(t *testing.T) {
+	tests := []struct {
+		name       string
+		resolved   bool
+		wantMethod string
+		status     int
+		body       map[string]any
+	}{
+		{
+			name:       "resolve",
+			resolved:   true,
+			wantMethod: http.MethodPost,
+			status:     http.StatusOK,
+			body: map[string]any{
+				"user":       map[string]string{"display_name": "Alice"},
+				"created_on": "2026-01-01T00:00:00+00:00",
+			},
+		},
+		{
+			name:       "reopen",
+			resolved:   false,
+			wantMethod: http.MethodDelete,
+			status:     http.StatusNoContent,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotMethod, gotPath string
+			client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotMethod = r.Method
+				gotPath = r.URL.Path
+				if gotPath != "/repositories/ws/repo/pullrequests/42/comments/9/resolve" {
+					http.NotFound(w, r)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.status)
+				if tt.body != nil {
+					_ = json.NewEncoder(w).Encode(tt.body)
+				}
+			}))
+
+			resolution, err := client.SetPullRequestCommentThreadResolved(context.Background(), "ws", "repo", 42, 9, tt.resolved)
+			if err != nil {
+				t.Fatalf("SetPullRequestCommentThreadResolved: %v", err)
+			}
+			if gotMethod != tt.wantMethod {
+				t.Errorf("method = %s, want %s", gotMethod, tt.wantMethod)
+			}
+			if gotPath != "/repositories/ws/repo/pullrequests/42/comments/9/resolve" {
+				t.Errorf("path = %q", gotPath)
+			}
+			if tt.resolved {
+				if resolution == nil || (*resolution)["created_on"] == "" {
+					t.Fatalf("resolution = %#v, want decoded resolution", resolution)
+				}
+			} else if resolution != nil {
+				t.Fatalf("resolution = %#v, want nil", resolution)
+			}
+		})
+	}
+}
+
+func TestSetPullRequestCommentThreadResolvedErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		want   string
+	}{
+		{"forbidden", http.StatusForbidden, `{"error":{"message":"Comment is not a top-level comment"}}`, "403 Forbidden: Comment is not a top-level comment"},
+		{"not found", http.StatusNotFound, `{"error":{"message":"Not found"}}`, "404 Not Found: Not found"},
+		{"conflict", http.StatusConflict, `{"error":{"message":"Already resolved"}}`, "409 Conflict: Already resolved"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+
+			_, err := client.SetPullRequestCommentThreadResolved(context.Background(), "ws", "repo", 42, 9, true)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if err.Error() != tt.want {
+				t.Fatalf("error = %q, want %q", err.Error(), tt.want)
 			}
 		})
 	}

--- a/pkg/bbcloud/pullrequests_test.go
+++ b/pkg/bbcloud/pullrequests_test.go
@@ -1105,6 +1105,54 @@ func TestGetPullRequestComment(t *testing.T) {
 	}
 }
 
+func TestDeletePullRequestComment(t *testing.T) {
+	var gotMethod, gotPath string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	if err := client.DeletePullRequestComment(context.Background(), "ws", "repo", 42, 9); err != nil {
+		t.Fatalf("DeletePullRequestComment: %v", err)
+	}
+	if gotMethod != http.MethodDelete {
+		t.Errorf("method = %s, want DELETE", gotMethod)
+	}
+	if gotPath != "/repositories/ws/repo/pullrequests/42/comments/9" {
+		t.Errorf("path = %q", gotPath)
+	}
+}
+
+func TestDeletePullRequestCommentErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		want   string
+	}{
+		{"forbidden", http.StatusForbidden, `{"error":{"message":"Forbidden"}}`, "403 Forbidden: Forbidden"},
+		{"not found", http.StatusNotFound, `{"error":{"message":"Comment not found"}}`, "404 Not Found: Comment not found"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+
+			err := client.DeletePullRequestComment(context.Background(), "ws", "repo", 42, 9)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if err.Error() != tt.want {
+				t.Fatalf("error = %q, want %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
 func TestListPullRequestCommentsPaginates(t *testing.T) {
 	var hits int32
 	var serverURL string

--- a/pkg/bbdc/commits_test.go
+++ b/pkg/bbdc/commits_test.go
@@ -78,7 +78,7 @@ func TestCommitDiffValidation(t *testing.T) {
 	}
 }
 
-func TestCommitDiffHandlesHTTPError(t *testing.T) {
+func TestCommitDiffHandlesErrorResponse(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		_, _ = w.Write([]byte("Repository not found"))

--- a/pkg/bbdc/pullrequests.go
+++ b/pkg/bbdc/pullrequests.go
@@ -158,6 +158,31 @@ func (c *Client) SetPullRequestCommentThreadResolved(ctx context.Context, projec
 	return &updated, nil
 }
 
+// DeletePullRequestComment deletes a pull request comment.
+func (c *Client) DeletePullRequestComment(ctx context.Context, projectKey, repoSlug string, prID, commentID int) error {
+	if projectKey == "" || repoSlug == "" {
+		return fmt.Errorf("project key and repository slug are required")
+	}
+	if prID <= 0 {
+		return fmt.Errorf("pull request id must be positive")
+	}
+	if commentID <= 0 {
+		return fmt.Errorf("comment id must be positive")
+	}
+
+	path := fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/comments/%d",
+		url.PathEscape(projectKey),
+		url.PathEscape(repoSlug),
+		prID,
+		commentID,
+	)
+	req, err := c.http.NewRequest(ctx, "DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+	return c.http.Do(req, nil)
+}
+
 // flattenComments walks a comment tree depth-first, returning a flat slice
 // with Depth set on each node.
 func flattenComments(c PullRequestComment, depth int) []PullRequestComment {

--- a/pkg/bbdc/pullrequests.go
+++ b/pkg/bbdc/pullrequests.go
@@ -28,13 +28,14 @@ type PullRequestParticipant struct {
 
 // PullRequestComment represents a PR comment.
 type PullRequestComment struct {
-	ID             int    `json:"id"`
-	Version        int    `json:"version"`
-	Text           string `json:"text"`
-	Severity       string `json:"severity"` // "NORMAL" or "BLOCKER" (task)
-	State          string `json:"state"`    // "OPEN" or "RESOLVED"
-	Author         User   `json:"author"`
-	ThreadResolved bool   `json:"threadResolved"`
+	ID             int            `json:"id"`
+	Version        int            `json:"version"`
+	Text           string         `json:"text"`
+	Severity       string         `json:"severity"` // "NORMAL" or "BLOCKER" (task)
+	State          string         `json:"state"`    // "OPEN" or "RESOLVED"
+	Properties     map[string]any `json:"properties,omitempty"`
+	Author         User           `json:"author"`
+	ThreadResolved bool           `json:"threadResolved"`
 	Anchor         *struct {
 		Path     string `json:"path"`
 		Line     int    `json:"line"`
@@ -132,9 +133,21 @@ func (c *Client) SetPullRequestCommentThreadResolved(ctx context.Context, projec
 		return current, nil
 	}
 
+	properties := current.Properties
+	if properties == nil {
+		properties = map[string]any{}
+	}
 	body := map[string]any{
+		"id":             current.ID,
 		"version":        current.Version,
+		"text":           current.Text,
+		"severity":       current.Severity,
+		"state":          current.State,
+		"properties":     properties,
 		"threadResolved": resolved,
+	}
+	if current.Anchor != nil {
+		body["anchor"] = current.Anchor
 	}
 	path := fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/comments/%d",
 		url.PathEscape(projectKey),

--- a/pkg/bbdc/pullrequests.go
+++ b/pkg/bbdc/pullrequests.go
@@ -2,6 +2,7 @@ package bbdc
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -28,22 +29,91 @@ type PullRequestParticipant struct {
 
 // PullRequestComment represents a PR comment.
 type PullRequestComment struct {
-	ID             int            `json:"id"`
-	Version        int            `json:"version"`
-	Text           string         `json:"text"`
-	Severity       string         `json:"severity"` // "NORMAL" or "BLOCKER" (task)
-	State          string         `json:"state"`    // "OPEN" or "RESOLVED"
-	Properties     map[string]any `json:"properties,omitempty"`
-	Author         User           `json:"author"`
-	ThreadResolved bool           `json:"threadResolved"`
-	Anchor         *struct {
-		Path     string `json:"path"`
-		Line     int    `json:"line"`
-		LineType string `json:"lineType"`
-		FileType string `json:"fileType"`
-	} `json:"anchor,omitempty"`
-	Comments []PullRequestComment `json:"comments,omitempty"`
-	Depth    int                  `json:"-"` // nesting depth, set during flattening
+	ID             int                       `json:"id"`
+	Version        int                       `json:"version"`
+	Text           string                    `json:"text"`
+	Severity       string                    `json:"severity"` // "NORMAL" or "BLOCKER" (task)
+	State          string                    `json:"state"`    // "OPEN" or "RESOLVED"
+	Properties     map[string]any            `json:"properties,omitempty"`
+	Author         User                      `json:"author"`
+	ThreadResolved bool                      `json:"threadResolved"`
+	Anchor         *PullRequestCommentAnchor `json:"anchor,omitempty"`
+	Comments       []PullRequestComment      `json:"comments,omitempty"`
+	Depth          int                       `json:"-"` // nesting depth, set during flattening
+	raw            map[string]any
+}
+
+type PullRequestCommentAnchor struct {
+	Path     string `json:"path"`
+	Line     int    `json:"line"`
+	LineType string `json:"lineType"`
+	FileType string `json:"fileType"`
+}
+
+func (a *PullRequestCommentAnchor) UnmarshalJSON(data []byte) error {
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if value, ok := raw["path"]; ok {
+		a.Path = commentAnchorPath(value)
+	}
+	if value, ok := raw["line"].(float64); ok {
+		a.Line = int(value)
+	}
+	if value, ok := raw["lineType"].(string); ok {
+		a.LineType = value
+	}
+	if value, ok := raw["fileType"].(string); ok {
+		a.FileType = value
+	}
+	return nil
+}
+
+func commentAnchorPath(value any) string {
+	switch path := value.(type) {
+	case string:
+		return path
+	case map[string]any:
+		if parent, _ := path["parent"].(string); parent != "" {
+			if name, _ := path["name"].(string); name != "" {
+				return strings.TrimSuffix(parent, "/") + "/" + name
+			}
+			return parent
+		}
+		if components, ok := path["components"].([]any); ok {
+			parts := make([]string, 0, len(components))
+			for _, component := range components {
+				if s, ok := component.(string); ok && s != "" {
+					parts = append(parts, s)
+				}
+			}
+			if len(parts) > 0 {
+				return strings.Join(parts, "/")
+			}
+		}
+		if name, _ := path["name"].(string); name != "" {
+			return name
+		}
+	}
+	return ""
+}
+
+// UnmarshalJSON keeps the typed fields used by callers while preserving the
+// mutable comment fields needed by Bitbucket's update-comment endpoint.
+func (c *PullRequestComment) UnmarshalJSON(data []byte) error {
+	type alias PullRequestComment
+	var parsed alias
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return err
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*c = PullRequestComment(parsed)
+	c.raw = raw
+	return nil
 }
 
 // pullRequestActivity represents a single entry from the PR activities endpoint.
@@ -116,15 +186,9 @@ func (c *Client) SetPullRequestCommentThreadResolved(ctx context.Context, projec
 		return nil, err
 	}
 
-	var current *PullRequestComment
-	for i := range comments {
-		if comments[i].ID == commentID {
-			current = &comments[i]
-			break
-		}
-	}
-	if current == nil {
-		return nil, fmt.Errorf("pull request comment %d not found", commentID)
+	current, err := findPullRequestComment(comments, commentID)
+	if err != nil {
+		return nil, err
 	}
 	if current.Depth > 0 {
 		return nil, ErrPullRequestCommentNotTopLevel
@@ -133,22 +197,7 @@ func (c *Client) SetPullRequestCommentThreadResolved(ctx context.Context, projec
 		return current, nil
 	}
 
-	properties := current.Properties
-	if properties == nil {
-		properties = map[string]any{}
-	}
-	body := map[string]any{
-		"id":             current.ID,
-		"version":        current.Version,
-		"text":           current.Text,
-		"severity":       current.Severity,
-		"state":          current.State,
-		"properties":     properties,
-		"threadResolved": resolved,
-	}
-	if current.Anchor != nil {
-		body["anchor"] = current.Anchor
-	}
+	body := current.updatePayload(resolved)
 	path := fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/comments/%d",
 		url.PathEscape(projectKey),
 		url.PathEscape(repoSlug),
@@ -171,6 +220,48 @@ func (c *Client) SetPullRequestCommentThreadResolved(ctx context.Context, projec
 	return &updated, nil
 }
 
+func (c PullRequestComment) updatePayload(resolved bool) map[string]any {
+	body := map[string]any{}
+	for _, key := range []string{"anchor", "comments", "id", "properties", "severity", "state", "text", "version"} {
+		if value, ok := c.raw[key]; ok {
+			body[key] = value
+		}
+	}
+	if _, ok := body["id"]; !ok {
+		body["id"] = c.ID
+	}
+	if _, ok := body["version"]; !ok {
+		body["version"] = c.Version
+	}
+	if _, ok := body["text"]; !ok {
+		body["text"] = c.Text
+	}
+	if _, ok := body["severity"]; !ok {
+		body["severity"] = c.Severity
+	}
+	if _, ok := body["state"]; !ok {
+		body["state"] = c.State
+	}
+	if _, ok := body["properties"]; !ok {
+		if c.Properties != nil {
+			body["properties"] = c.Properties
+		} else {
+			body["properties"] = map[string]any{}
+		}
+	}
+	body["threadResolved"] = resolved
+	return body
+}
+
+func findPullRequestComment(comments []PullRequestComment, commentID int) (*PullRequestComment, error) {
+	for i := range comments {
+		if comments[i].ID == commentID {
+			return &comments[i], nil
+		}
+	}
+	return nil, fmt.Errorf("pull request comment %d not found", commentID)
+}
+
 // DeletePullRequestComment deletes a pull request comment.
 func (c *Client) DeletePullRequestComment(ctx context.Context, projectKey, repoSlug string, prID, commentID int) error {
 	if projectKey == "" || repoSlug == "" {
@@ -183,11 +274,23 @@ func (c *Client) DeletePullRequestComment(ctx context.Context, projectKey, repoS
 		return fmt.Errorf("comment id must be positive")
 	}
 
-	path := fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/comments/%d",
+	comments, err := c.ListPullRequestComments(ctx, projectKey, repoSlug, prID)
+	if err != nil {
+		return err
+	}
+	current, err := findPullRequestComment(comments, commentID)
+	if err != nil {
+		return err
+	}
+
+	query := url.Values{}
+	query.Set("version", fmt.Sprint(current.Version))
+	path := fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/comments/%d?%s",
 		url.PathEscape(projectKey),
 		url.PathEscape(repoSlug),
 		prID,
 		commentID,
+		query.Encode(),
 	)
 	req, err := c.http.NewRequest(ctx, "DELETE", path, nil)
 	if err != nil {

--- a/pkg/bbdc/pullrequests.go
+++ b/pkg/bbdc/pullrequests.go
@@ -2,11 +2,16 @@ package bbdc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
 	"strings"
 )
+
+// ErrPullRequestCommentNotTopLevel is returned when a thread-level operation is
+// attempted on a reply instead of the thread's top-level comment.
+var ErrPullRequestCommentNotTopLevel = errors.New("only top-level pull request comment threads can be changed")
 
 // PullRequestReviewer represents a reviewer assignment.
 type PullRequestReviewer struct {
@@ -24,6 +29,7 @@ type PullRequestParticipant struct {
 // PullRequestComment represents a PR comment.
 type PullRequestComment struct {
 	ID             int    `json:"id"`
+	Version        int    `json:"version"`
 	Text           string `json:"text"`
 	Severity       string `json:"severity"` // "NORMAL" or "BLOCKER" (task)
 	State          string `json:"state"`    // "OPEN" or "RESOLVED"
@@ -89,6 +95,67 @@ func (c *Client) ListPullRequestComments(ctx context.Context, projectKey, repoSl
 	}
 
 	return all, nil
+}
+
+// SetPullRequestCommentThreadResolved resolves or reopens a top-level pull
+// request comment thread.
+func (c *Client) SetPullRequestCommentThreadResolved(ctx context.Context, projectKey, repoSlug string, prID, commentID int, resolved bool) (*PullRequestComment, error) {
+	if projectKey == "" || repoSlug == "" {
+		return nil, fmt.Errorf("project key and repository slug are required")
+	}
+	if prID <= 0 {
+		return nil, fmt.Errorf("pull request id must be positive")
+	}
+	if commentID <= 0 {
+		return nil, fmt.Errorf("comment id must be positive")
+	}
+
+	comments, err := c.ListPullRequestComments(ctx, projectKey, repoSlug, prID)
+	if err != nil {
+		return nil, err
+	}
+
+	var current *PullRequestComment
+	for i := range comments {
+		if comments[i].ID == commentID {
+			current = &comments[i]
+			break
+		}
+	}
+	if current == nil {
+		return nil, fmt.Errorf("pull request comment %d not found", commentID)
+	}
+	if current.Depth > 0 {
+		return nil, ErrPullRequestCommentNotTopLevel
+	}
+	if current.ThreadResolved == resolved {
+		return current, nil
+	}
+
+	body := map[string]any{
+		"version":        current.Version,
+		"threadResolved": resolved,
+	}
+	path := fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/comments/%d",
+		url.PathEscape(projectKey),
+		url.PathEscape(repoSlug),
+		prID,
+		commentID,
+	)
+	req, err := c.http.NewRequest(ctx, "PUT", path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var updated PullRequestComment
+	if err := c.http.Do(req, &updated); err != nil {
+		return nil, err
+	}
+	if updated.ID == 0 {
+		updated = *current
+		updated.ThreadResolved = resolved
+	}
+	return &updated, nil
 }
 
 // flattenComments walks a comment tree depth-first, returning a flat slice

--- a/pkg/bbdc/pullrequests_test.go
+++ b/pkg/bbdc/pullrequests_test.go
@@ -570,6 +570,25 @@ func TestSetPullRequestCommentThreadResolved(t *testing.T) {
 	}
 }
 
+func TestDeletePullRequestComment(t *testing.T) {
+	var gotMethod, gotPath string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	if err := client.DeletePullRequestComment(context.Background(), "PROJ", "repo", 42, 9); err != nil {
+		t.Fatalf("DeletePullRequestComment: %v", err)
+	}
+	if gotMethod != http.MethodDelete {
+		t.Errorf("method = %s, want DELETE", gotMethod)
+	}
+	if gotPath != "/rest/api/1.0/projects/PROJ/repos/repo/pull-requests/42/comments/9" {
+		t.Errorf("path = %q", gotPath)
+	}
+}
+
 func TestSetPullRequestCommentThreadResolvedAlreadyResolvedSkipsPUT(t *testing.T) {
 	var putCalled bool
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/bbdc/pullrequests_test.go
+++ b/pkg/bbdc/pullrequests_test.go
@@ -537,11 +537,22 @@ func TestSetPullRequestCommentThreadResolved(t *testing.T) {
 							"state":          "OPEN",
 							"properties":     map[string]any{"keep": "me"},
 							"threadResolved": false,
+							"author":         map[string]any{"displayName": "Reviewer"},
+							"permittedOperations": map[string]any{
+								"editable": true,
+							},
 							"anchor": map[string]any{
-								"path":     "src/main.go",
+								"path": map[string]any{
+									"components": []string{"src", "main.go"},
+									"name":       "main.go",
+									"parent":     "src",
+								},
 								"line":     10,
 								"lineType": "ADDED",
 								"fileType": "TO",
+							},
+							"comments": []map[string]any{
+								{"id": 10, "version": 1, "text": "reply"},
 							},
 						},
 					},
@@ -588,8 +599,19 @@ func TestSetPullRequestCommentThreadResolved(t *testing.T) {
 		t.Errorf("properties = %#v, want keep=me", gotBody["properties"])
 	}
 	anchor, ok := gotBody["anchor"].(map[string]any)
-	if !ok || anchor["path"] != "src/main.go" || anchor["line"] != float64(10) {
-		t.Errorf("anchor = %#v, want src/main.go:10", gotBody["anchor"])
+	path, _ := anchor["path"].(map[string]any)
+	if !ok || path["parent"] != "src" || anchor["line"] != float64(10) {
+		t.Errorf("anchor = %#v, want raw src/main.go anchor", gotBody["anchor"])
+	}
+	replies, ok := gotBody["comments"].([]any)
+	if !ok || len(replies) != 1 {
+		t.Errorf("comments = %#v, want preserved replies", gotBody["comments"])
+	}
+	if _, ok := gotBody["author"]; ok {
+		t.Errorf("author should not be sent in update body: %#v", gotBody["author"])
+	}
+	if _, ok := gotBody["permittedOperations"]; ok {
+		t.Errorf("permittedOperations should not be sent in update body: %#v", gotBody["permittedOperations"])
 	}
 	if gotBody["threadResolved"] != true {
 		t.Errorf("threadResolved = %v, want true", gotBody["threadResolved"])
@@ -600,11 +622,32 @@ func TestSetPullRequestCommentThreadResolved(t *testing.T) {
 }
 
 func TestDeletePullRequestComment(t *testing.T) {
-	var gotMethod, gotPath string
+	var gotMethod, gotPath, gotQuery string
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotMethod = r.Method
-		gotPath = r.URL.Path
-		w.WriteHeader(http.StatusNoContent)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pull-requests/42/activities"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"isLastPage": true,
+				"values": []map[string]any{
+					{
+						"action": "COMMENTED",
+						"comment": map[string]any{
+							"id":      9,
+							"version": 3,
+							"text":    "root",
+						},
+					},
+				},
+			})
+		case r.Method == http.MethodDelete:
+			gotMethod = r.Method
+			gotPath = r.URL.Path
+			gotQuery = r.URL.RawQuery
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
 	}))
 
 	if err := client.DeletePullRequestComment(context.Background(), "PROJ", "repo", 42, 9); err != nil {
@@ -615,6 +658,9 @@ func TestDeletePullRequestComment(t *testing.T) {
 	}
 	if gotPath != "/rest/api/1.0/projects/PROJ/repos/repo/pull-requests/42/comments/9" {
 		t.Errorf("path = %q", gotPath)
+	}
+	if gotQuery != "version=3" {
+		t.Errorf("query = %q, want version=3", gotQuery)
 	}
 }
 

--- a/pkg/bbdc/pullrequests_test.go
+++ b/pkg/bbdc/pullrequests_test.go
@@ -3,6 +3,7 @@ package bbdc_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -513,6 +514,122 @@ func TestListPullRequestCommentsFlattensReplies(t *testing.T) {
 		if c.Depth != wantDepths[i] {
 			t.Errorf("comments[%d].Depth = %d, want %d", i, c.Depth, wantDepths[i])
 		}
+	}
+}
+
+func TestSetPullRequestCommentThreadResolved(t *testing.T) {
+	var gotPutPath string
+	var gotBody map[string]any
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pull-requests/42/activities"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"isLastPage": true,
+				"values": []map[string]any{
+					{
+						"action": "COMMENTED",
+						"comment": map[string]any{
+							"id":             9,
+							"version":        3,
+							"text":           "root",
+							"threadResolved": false,
+						},
+					},
+				},
+			})
+		case r.Method == http.MethodPut && r.URL.Path == "/rest/api/1.0/projects/PROJ/repos/repo/pull-requests/42/comments/9":
+			gotPutPath = r.URL.Path
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":             9,
+				"version":        4,
+				"text":           "root",
+				"threadResolved": true,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	comment, err := client.SetPullRequestCommentThreadResolved(context.Background(), "PROJ", "repo", 42, 9, true)
+	if err != nil {
+		t.Fatalf("SetPullRequestCommentThreadResolved: %v", err)
+	}
+	if gotPutPath == "" {
+		t.Fatal("expected PUT request")
+	}
+	if gotBody["version"] != float64(3) {
+		t.Errorf("version = %v, want 3", gotBody["version"])
+	}
+	if gotBody["threadResolved"] != true {
+		t.Errorf("threadResolved = %v, want true", gotBody["threadResolved"])
+	}
+	if !comment.ThreadResolved {
+		t.Errorf("updated comment ThreadResolved = false, want true")
+	}
+}
+
+func TestSetPullRequestCommentThreadResolvedAlreadyResolvedSkipsPUT(t *testing.T) {
+	var putCalled bool
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			putCalled = true
+			t.Fatalf("unexpected PUT to %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"isLastPage": true,
+			"values": []map[string]any{
+				{
+					"action": "COMMENTED",
+					"comment": map[string]any{
+						"id":             9,
+						"version":        3,
+						"text":           "root",
+						"threadResolved": true,
+					},
+				},
+			},
+		})
+	}))
+
+	comment, err := client.SetPullRequestCommentThreadResolved(context.Background(), "PROJ", "repo", 42, 9, true)
+	if err != nil {
+		t.Fatalf("SetPullRequestCommentThreadResolved: %v", err)
+	}
+	if putCalled {
+		t.Fatal("PUT should not be called")
+	}
+	if !comment.ThreadResolved {
+		t.Fatal("comment should remain resolved")
+	}
+}
+
+func TestSetPullRequestCommentThreadResolvedRejectsReply(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"isLastPage": true,
+			"values": []map[string]any{
+				{
+					"action": "COMMENTED",
+					"comment": map[string]any{
+						"id":      1,
+						"version": 1,
+						"text":    "root",
+						"comments": []map[string]any{
+							{"id": 2, "version": 1, "text": "reply"},
+						},
+					},
+				},
+			},
+		})
+	}))
+
+	_, err := client.SetPullRequestCommentThreadResolved(context.Background(), "PROJ", "repo", 42, 2, true)
+	if !errors.Is(err, bbdc.ErrPullRequestCommentNotTopLevel) {
+		t.Fatalf("error = %v, want ErrPullRequestCommentNotTopLevel", err)
 	}
 }
 

--- a/pkg/bbdc/pullrequests_test.go
+++ b/pkg/bbdc/pullrequests_test.go
@@ -533,7 +533,16 @@ func TestSetPullRequestCommentThreadResolved(t *testing.T) {
 							"id":             9,
 							"version":        3,
 							"text":           "root",
+							"severity":       "NORMAL",
+							"state":          "OPEN",
+							"properties":     map[string]any{"keep": "me"},
 							"threadResolved": false,
+							"anchor": map[string]any{
+								"path":     "src/main.go",
+								"line":     10,
+								"lineType": "ADDED",
+								"fileType": "TO",
+							},
 						},
 					},
 				},
@@ -561,6 +570,26 @@ func TestSetPullRequestCommentThreadResolved(t *testing.T) {
 	}
 	if gotBody["version"] != float64(3) {
 		t.Errorf("version = %v, want 3", gotBody["version"])
+	}
+	if gotBody["id"] != float64(9) {
+		t.Errorf("id = %v, want 9", gotBody["id"])
+	}
+	if gotBody["text"] != "root" {
+		t.Errorf("text = %v, want root", gotBody["text"])
+	}
+	if gotBody["severity"] != "NORMAL" {
+		t.Errorf("severity = %v, want NORMAL", gotBody["severity"])
+	}
+	if gotBody["state"] != "OPEN" {
+		t.Errorf("state = %v, want OPEN", gotBody["state"])
+	}
+	props, ok := gotBody["properties"].(map[string]any)
+	if !ok || props["keep"] != "me" {
+		t.Errorf("properties = %#v, want keep=me", gotBody["properties"])
+	}
+	anchor, ok := gotBody["anchor"].(map[string]any)
+	if !ok || anchor["path"] != "src/main.go" || anchor["line"] != float64(10) {
+		t.Errorf("anchor = %#v, want src/main.go:10", gotBody["anchor"])
 	}
 	if gotBody["threadResolved"] != true {
 		t.Errorf("threadResolved = %v, want true", gotBody["threadResolved"])

--- a/pkg/cmd/pr/comments.go
+++ b/pkg/cmd/pr/comments.go
@@ -2,6 +2,7 @@ package pr
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/avivsinai/bitbucket-cli/pkg/bbcloud"
+	"github.com/avivsinai/bitbucket-cli/pkg/bbdc"
 	"github.com/avivsinai/bitbucket-cli/pkg/cmdutil"
 )
 
@@ -16,8 +18,15 @@ type commentsOptions struct {
 	Workspace string
 	Project   string
 	Repo      string
-	State     string // "all", "resolved", "unresolved"
+	State     string // "all", "resolved", "unresolved", "deleted"
 	Details   bool
+}
+
+type commentThreadStateResult struct {
+	PullRequest int                                   `json:"pull_request" yaml:"pull_request"`
+	CommentID   int                                   `json:"comment_id" yaml:"comment_id"`
+	Resolved    bool                                  `json:"resolved" yaml:"resolved"`
+	Resolution  *bbcloud.PullRequestCommentResolution `json:"resolution,omitempty" yaml:"resolution,omitempty"`
 }
 
 func newCommentsCmd(f *cmdutil.Factory) *cobra.Command {
@@ -26,7 +35,7 @@ func newCommentsCmd(f *cmdutil.Factory) *cobra.Command {
 		Use:   "comments <id>",
 		Short: "List comments on a pull request",
 		Long: `List all comments on a pull request. On Cloud, use --state to filter by
-resolution status (resolved or unresolved). The --state flag is not supported
+resolution status (resolved, unresolved, or deleted). The --state flag is not supported
 on Data Center because the DC API does not expose resolution status.
 
 Works on both Data Center and Cloud.`,
@@ -37,7 +46,16 @@ Works on both Data Center and Cloud.`,
   bkt pr comments 42 --state unresolved
 
   # List resolved comments (Cloud only)
-  bkt pr comments 42 --state resolved`,
+  bkt pr comments 42 --state resolved
+
+  # List deleted comments (Cloud only)
+  bkt pr comments 42 --state deleted
+
+  # Resolve a comment thread
+  bkt pr comments resolve 42 1001
+
+  # Reopen a resolved comment thread
+  bkt pr comments reopen 42 1001`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := strconv.Atoi(args[0])
@@ -51,10 +69,69 @@ Works on both Data Center and Cloud.`,
 	cmd.Flags().StringVar(&opts.Workspace, "workspace", "", "Bitbucket Cloud workspace override")
 	cmd.Flags().StringVar(&opts.Project, "project", "", "Bitbucket project key override")
 	cmd.Flags().StringVar(&opts.Repo, "repo", "", "Repository slug override")
-	cmd.Flags().StringVar(&opts.State, "state", "all", "Filter by state: all, resolved, unresolved (Cloud only)")
+	cmd.Flags().StringVar(&opts.State, "state", "all", "Filter by state: all, resolved, unresolved, deleted (Cloud only)")
 	cmd.Flags().BoolVar(&opts.Details, "details", false, "Show full comment details (file, resolved, task status)")
 
+	cmd.AddCommand(newCommentsResolveCmd(f))
+	cmd.AddCommand(newCommentsReopenCmd(f))
+
 	return cmd
+}
+
+func newCommentsResolveCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &commentsOptions{}
+	cmd := &cobra.Command{
+		Use:     "resolve <id> <comment-id>",
+		Short:   "Resolve a pull request comment thread",
+		Example: "  bkt pr comments resolve 42 1001",
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			prID, commentID, err := parseCommentThreadArgs(args)
+			if err != nil {
+				return err
+			}
+			return runCommentThreadSetState(cmd, f, opts, prID, commentID, true)
+		},
+	}
+	registerCommentsTargetFlags(cmd, opts)
+	return cmd
+}
+
+func newCommentsReopenCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &commentsOptions{}
+	cmd := &cobra.Command{
+		Use:     "reopen <id> <comment-id>",
+		Short:   "Reopen a resolved pull request comment thread",
+		Example: "  bkt pr comments reopen 42 1001",
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			prID, commentID, err := parseCommentThreadArgs(args)
+			if err != nil {
+				return err
+			}
+			return runCommentThreadSetState(cmd, f, opts, prID, commentID, false)
+		},
+	}
+	registerCommentsTargetFlags(cmd, opts)
+	return cmd
+}
+
+func registerCommentsTargetFlags(cmd *cobra.Command, opts *commentsOptions) {
+	cmd.Flags().StringVar(&opts.Workspace, "workspace", "", "Bitbucket Cloud workspace override")
+	cmd.Flags().StringVar(&opts.Project, "project", "", "Bitbucket project key override")
+	cmd.Flags().StringVar(&opts.Repo, "repo", "", "Repository slug override")
+}
+
+func parseCommentThreadArgs(args []string) (int, int, error) {
+	prID, err := strconv.Atoi(args[0])
+	if err != nil || prID <= 0 {
+		return 0, 0, fmt.Errorf("invalid pull request id %q", args[0])
+	}
+	commentID, err := strconv.Atoi(args[1])
+	if err != nil || commentID <= 0 {
+		return 0, 0, fmt.Errorf("invalid comment id %q", args[1])
+	}
+	return prID, commentID, nil
 }
 
 func runComments(cmd *cobra.Command, f *cmdutil.Factory, id int, opts *commentsOptions) error {
@@ -70,8 +147,8 @@ func runComments(cmd *cobra.Command, f *cmdutil.Factory, id int, opts *commentsO
 	}
 
 	state := strings.ToLower(strings.TrimSpace(opts.State))
-	if state != "all" && state != "resolved" && state != "unresolved" {
-		return fmt.Errorf("invalid --state value %q: must be all, resolved, or unresolved", opts.State)
+	if state != "all" && state != "resolved" && state != "unresolved" && state != "deleted" {
+		return fmt.Errorf("invalid --state value %q: must be all, resolved, unresolved, or deleted", opts.State)
 	}
 
 	switch host.Kind {
@@ -205,10 +282,16 @@ func runComments(cmd *cobra.Command, f *cmdutil.Factory, id int, opts *commentsO
 			return err
 		}
 
-		// Client-side filtering for resolved/unresolved
+		// Client-side filtering for resolved/unresolved/deleted.
 		if state != "all" {
 			filtered := make([]bbcloud.PullRequestComment, 0, len(comments))
 			for _, c := range comments {
+				if c.Deleted {
+					if state == "deleted" {
+						filtered = append(filtered, c)
+					}
+					continue
+				}
 				switch state {
 				case "resolved":
 					if c.Resolution != nil {
@@ -243,6 +326,12 @@ func runComments(cmd *cobra.Command, f *cmdutil.Factory, id int, opts *commentsO
 					}
 				}
 				if !opts.Details {
+					if c.Deleted {
+						if _, err := fmt.Fprintf(ios.Out, "%d\t%s\t[deleted]\n", c.ID, author); err != nil {
+							return err
+						}
+						continue
+					}
 					text := truncate(c.Content.Raw, 80)
 					if _, err := fmt.Fprintf(ios.Out, "%d\t%s\t%s\n", c.ID, author, text); err != nil {
 						return err
@@ -251,6 +340,12 @@ func runComments(cmd *cobra.Command, f *cmdutil.Factory, id int, opts *commentsO
 				}
 				if _, err := fmt.Fprintf(ios.Out, "--- Comment #%d by %s ---\n", c.ID, author); err != nil {
 					return err
+				}
+				if c.Deleted {
+					if _, err := fmt.Fprintf(ios.Out, "Deleted: yes\n\n"); err != nil {
+						return err
+					}
+					continue
 				}
 				if c.Inline != nil {
 					line := ""
@@ -280,6 +375,135 @@ func runComments(cmd *cobra.Command, f *cmdutil.Factory, id int, opts *commentsO
 	default:
 		return fmt.Errorf("unsupported host kind %q", host.Kind)
 	}
+}
+
+func runCommentThreadSetState(cmd *cobra.Command, f *cmdutil.Factory, opts *commentsOptions, prID, commentID int, resolved bool) error {
+	ios, err := f.Streams()
+	if err != nil {
+		return err
+	}
+
+	_, ctxCfg, host, err := cmdutil.ResolveContext(f, cmd, cmdutil.FlagValue(cmd, "context"))
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), timeoutWrite)
+	defer cancel()
+
+	result := commentThreadStateResult{
+		PullRequest: prID,
+		CommentID:   commentID,
+		Resolved:    resolved,
+	}
+	already := false
+
+	switch host.Kind {
+	case "dc":
+		projectKey := cmdutil.FirstNonEmpty(opts.Project, ctxCfg.ProjectKey)
+		repoSlug := cmdutil.FirstNonEmpty(opts.Repo, ctxCfg.DefaultRepo)
+		if projectKey == "" || repoSlug == "" {
+			return fmt.Errorf("context must supply project and repo; use --project/--repo if needed")
+		}
+		client, err := cmdutil.NewDCClient(host)
+		if err != nil {
+			return err
+		}
+		if _, err := client.SetPullRequestCommentThreadResolved(ctx, projectKey, repoSlug, prID, commentID, resolved); err != nil {
+			if errors.Is(err, bbdc.ErrPullRequestCommentNotTopLevel) {
+				return topLevelCommentThreadError(resolved)
+			}
+			return err
+		}
+	case "cloud":
+		workspace := cmdutil.FirstNonEmpty(opts.Workspace, ctxCfg.Workspace)
+		repoSlug := cmdutil.FirstNonEmpty(opts.Repo, ctxCfg.DefaultRepo)
+		if workspace == "" || repoSlug == "" {
+			return fmt.Errorf("context must supply workspace and repo; use --workspace/--repo if needed")
+		}
+		client, err := cmdutil.NewCloudClient(host)
+		if err != nil {
+			return err
+		}
+		mapped, isAlready, err := inspectCommentThreadCloudState(ctx, client, workspace, repoSlug, prID, commentID, resolved)
+		if err != nil {
+			return err
+		}
+		if mapped != nil {
+			return mapped
+		}
+		if isAlready {
+			already = true
+			break
+		}
+		resolution, err := client.SetPullRequestCommentThreadResolved(ctx, workspace, repoSlug, prID, commentID, resolved)
+		if err != nil {
+			mapped, isAlready, inspectErr := inspectCommentThreadCloudState(ctx, client, workspace, repoSlug, prID, commentID, resolved)
+			if inspectErr == nil {
+				if mapped != nil {
+					return mapped
+				}
+				if isAlready {
+					already = true
+					break
+				}
+			}
+			return err
+		}
+		result.Resolution = resolution
+	default:
+		return fmt.Errorf("unsupported host kind %q", host.Kind)
+	}
+
+	return cmdutil.WriteOutput(cmd, ios.Out, result, func() error {
+		if already {
+			state := "resolved"
+			if !resolved {
+				state = "open"
+			}
+			_, err := fmt.Fprintf(ios.Out, "✓ Comment thread %d on pull request #%d is already %s\n", commentID, prID, state)
+			return err
+		}
+		verb := "Reopened"
+		if resolved {
+			verb = "Resolved"
+		}
+		_, err := fmt.Fprintf(ios.Out, "✓ %s comment thread %d on pull request #%d\n", verb, commentID, prID)
+		return err
+	})
+}
+
+func inspectCommentThreadCloudState(ctx context.Context, client *bbcloud.Client, workspace, repoSlug string, prID, commentID int, resolved bool) (error, bool, error) {
+	comment, err := client.GetPullRequestComment(ctx, workspace, repoSlug, prID, commentID)
+	if err != nil {
+		return nil, false, err
+	}
+	if comment.Deleted {
+		return deletedCommentThreadError(commentID, resolved), false, nil
+	}
+	if comment.Parent != nil {
+		return topLevelCommentThreadError(resolved), false, nil
+	}
+	if resolved == (comment.Resolution != nil) {
+		return nil, true, nil
+	}
+	return nil, false, nil
+}
+
+func deletedCommentThreadError(commentID int, resolved bool) error {
+	action := "resolved"
+	if !resolved {
+		action = "reopened"
+	}
+	return fmt.Errorf("Pull request comment %d has been deleted and cannot be %s.", commentID, action)
+}
+
+func topLevelCommentThreadError(resolved bool) error {
+	action := "resolved"
+	if !resolved {
+		action = "reopened"
+	}
+	return fmt.Errorf("Only top-level pull request comment threads can be %s.", action)
 }
 
 // truncate shortens s to at most maxLen runes, appending "..." if truncated.

--- a/pkg/cmd/pr/comments.go
+++ b/pkg/cmd/pr/comments.go
@@ -44,7 +44,11 @@ func newCommentsCmd(f *cmdutil.Factory) *cobra.Command {
 resolution status (resolved, unresolved, or deleted). The --state flag is not supported
 on Data Center because the DC API does not expose resolution status.
 
-Works on both Data Center and Cloud.`,
+Works on both Data Center and Cloud.
+
+Resolve and reopen subcommands require the top-level thread comment ID, not a
+reply ID. Use --details when listing comments to inspect thread structure before
+changing thread state.`,
 		Example: `  # List all comments
   bkt pr comments 42
 
@@ -91,10 +95,19 @@ Works on both Data Center and Cloud.`,
 func newCommentsResolveCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &commentsOptions{}
 	cmd := &cobra.Command{
-		Use:     "resolve <id> <comment-id>",
-		Short:   "Resolve a pull request comment thread",
-		Example: "  bkt pr comments resolve 42 1001",
-		Args:    cobra.ExactArgs(2),
+		Use:   "resolve <id> <comment-id>",
+		Short: "Resolve a pull request comment thread",
+		Long: `Resolve a pull request comment thread on Bitbucket Cloud or Data Center.
+
+The comment-id must be the top-level comment for the thread. Replies cannot be
+resolved directly; pass the parent comment ID instead. Deleted comments cannot
+be resolved.`,
+		Example: `  # Resolve thread 1001 on pull request 42
+  bkt pr comments resolve 42 1001
+
+  # Resolve a thread in a specific repository
+  bkt pr comments resolve 42 1001 --repo platform-api`,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			prID, commentID, err := parseCommentThreadArgs(args)
 			if err != nil {
@@ -110,10 +123,19 @@ func newCommentsResolveCmd(f *cmdutil.Factory) *cobra.Command {
 func newCommentsReopenCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &commentsOptions{}
 	cmd := &cobra.Command{
-		Use:     "reopen <id> <comment-id>",
-		Short:   "Reopen a resolved pull request comment thread",
-		Example: "  bkt pr comments reopen 42 1001",
-		Args:    cobra.ExactArgs(2),
+		Use:   "reopen <id> <comment-id>",
+		Short: "Reopen a resolved pull request comment thread",
+		Long: `Reopen a resolved pull request comment thread on Bitbucket Cloud or Data Center.
+
+The comment-id must be the top-level comment for the thread. Replies cannot be
+reopened directly; pass the parent comment ID instead. Deleted comments cannot
+be reopened.`,
+		Example: `  # Reopen thread 1001 on pull request 42
+  bkt pr comments reopen 42 1001
+
+  # Reopen a thread in a specific repository
+  bkt pr comments reopen 42 1001 --repo platform-api`,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			prID, commentID, err := parseCommentThreadArgs(args)
 			if err != nil {
@@ -132,8 +154,18 @@ func newCommentsDeleteCmd(f *cmdutil.Factory) *cobra.Command {
 		Use:     "delete <id> <comment-id>",
 		Aliases: []string{"rm"},
 		Short:   "Delete a pull request comment",
-		Example: "  bkt pr comments delete 42 1001",
-		Args:    cobra.ExactArgs(2),
+		Long: `Delete a pull request comment on Bitbucket Cloud or Data Center.
+
+Use bkt pr comments <id> or bkt pr comments <id> --details to find the comment
+ID before deleting it. On Bitbucket Cloud, deleted comments can still be listed
+with --state deleted when the API returns them. On Data Center, bkt fetches the
+current comment version before deleting because the API requires it.`,
+		Example: `  # Delete comment 1001 from pull request 42
+  bkt pr comments delete 42 1001
+
+  # Delete a comment in a specific repository
+  bkt pr comments delete 42 1001 --repo platform-api`,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			prID, commentID, err := parseCommentThreadArgs(args)
 			if err != nil {

--- a/pkg/cmd/pr/comments.go
+++ b/pkg/cmd/pr/comments.go
@@ -581,7 +581,7 @@ func deletedCommentThreadError(commentID int, resolved bool) error {
 	if !resolved {
 		action = "reopened"
 	}
-	return fmt.Errorf("Pull request comment %d has been deleted and cannot be %s.", commentID, action)
+	return fmt.Errorf("pull request comment %d has been deleted and cannot be %s", commentID, action)
 }
 
 func topLevelCommentThreadError(resolved bool) error {
@@ -589,7 +589,7 @@ func topLevelCommentThreadError(resolved bool) error {
 	if !resolved {
 		action = "reopened"
 	}
-	return fmt.Errorf("Only top-level pull request comment threads can be %s.", action)
+	return fmt.Errorf("only top-level pull request comment threads can be %s", action)
 }
 
 // truncate shortens s to at most maxLen runes, appending "..." if truncated.

--- a/pkg/cmd/pr/comments.go
+++ b/pkg/cmd/pr/comments.go
@@ -29,6 +29,12 @@ type commentThreadStateResult struct {
 	Resolution  *bbcloud.PullRequestCommentResolution `json:"resolution,omitempty" yaml:"resolution,omitempty"`
 }
 
+type commentDeleteResult struct {
+	PullRequest int  `json:"pull_request" yaml:"pull_request"`
+	CommentID   int  `json:"comment_id" yaml:"comment_id"`
+	Deleted     bool `json:"deleted" yaml:"deleted"`
+}
+
 func newCommentsCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &commentsOptions{}
 	cmd := &cobra.Command{
@@ -50,6 +56,9 @@ Works on both Data Center and Cloud.`,
 
   # List deleted comments (Cloud only)
   bkt pr comments 42 --state deleted
+
+  # Delete a comment
+  bkt pr comments delete 42 1001
 
   # Resolve a comment thread
   bkt pr comments resolve 42 1001
@@ -74,6 +83,7 @@ Works on both Data Center and Cloud.`,
 
 	cmd.AddCommand(newCommentsResolveCmd(f))
 	cmd.AddCommand(newCommentsReopenCmd(f))
+	cmd.AddCommand(newCommentsDeleteCmd(f))
 
 	return cmd
 }
@@ -110,6 +120,26 @@ func newCommentsReopenCmd(f *cmdutil.Factory) *cobra.Command {
 				return err
 			}
 			return runCommentThreadSetState(cmd, f, opts, prID, commentID, false)
+		},
+	}
+	registerCommentsTargetFlags(cmd, opts)
+	return cmd
+}
+
+func newCommentsDeleteCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &commentsOptions{}
+	cmd := &cobra.Command{
+		Use:     "delete <id> <comment-id>",
+		Aliases: []string{"rm"},
+		Short:   "Delete a pull request comment",
+		Example: "  bkt pr comments delete 42 1001",
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			prID, commentID, err := parseCommentThreadArgs(args)
+			if err != nil {
+				return err
+			}
+			return runCommentDelete(cmd, f, opts, prID, commentID)
 		},
 	}
 	registerCommentsTargetFlags(cmd, opts)
@@ -469,6 +499,62 @@ func runCommentThreadSetState(cmd *cobra.Command, f *cmdutil.Factory, opts *comm
 			verb = "Resolved"
 		}
 		_, err := fmt.Fprintf(ios.Out, "✓ %s comment thread %d on pull request #%d\n", verb, commentID, prID)
+		return err
+	})
+}
+
+func runCommentDelete(cmd *cobra.Command, f *cmdutil.Factory, opts *commentsOptions, prID, commentID int) error {
+	ios, err := f.Streams()
+	if err != nil {
+		return err
+	}
+
+	_, ctxCfg, host, err := cmdutil.ResolveContext(f, cmd, cmdutil.FlagValue(cmd, "context"))
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), timeoutWrite)
+	defer cancel()
+
+	switch host.Kind {
+	case "dc":
+		projectKey := cmdutil.FirstNonEmpty(opts.Project, ctxCfg.ProjectKey)
+		repoSlug := cmdutil.FirstNonEmpty(opts.Repo, ctxCfg.DefaultRepo)
+		if projectKey == "" || repoSlug == "" {
+			return fmt.Errorf("context must supply project and repo; use --project/--repo if needed")
+		}
+		client, err := cmdutil.NewDCClient(host)
+		if err != nil {
+			return err
+		}
+		if err := client.DeletePullRequestComment(ctx, projectKey, repoSlug, prID, commentID); err != nil {
+			return err
+		}
+	case "cloud":
+		workspace := cmdutil.FirstNonEmpty(opts.Workspace, ctxCfg.Workspace)
+		repoSlug := cmdutil.FirstNonEmpty(opts.Repo, ctxCfg.DefaultRepo)
+		if workspace == "" || repoSlug == "" {
+			return fmt.Errorf("context must supply workspace and repo; use --workspace/--repo if needed")
+		}
+		client, err := cmdutil.NewCloudClient(host)
+		if err != nil {
+			return err
+		}
+		if err := client.DeletePullRequestComment(ctx, workspace, repoSlug, prID, commentID); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported host kind %q", host.Kind)
+	}
+
+	result := commentDeleteResult{
+		PullRequest: prID,
+		CommentID:   commentID,
+		Deleted:     true,
+	}
+	return cmdutil.WriteOutput(cmd, ios.Out, result, func() error {
+		_, err := fmt.Fprintf(ios.Out, "✓ Deleted comment %d on pull request #%d\n", commentID, prID)
 		return err
 	})
 }

--- a/pkg/cmd/pr/comments_test.go
+++ b/pkg/cmd/pr/comments_test.go
@@ -569,11 +569,32 @@ func TestCommentsThreadResolveDC(t *testing.T) {
 }
 
 func TestCommentsDeleteDC(t *testing.T) {
-	var gotMethod, gotPath string
+	var gotMethod, gotPath, gotQuery string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotMethod = r.Method
-		gotPath = r.URL.Path
-		w.WriteHeader(http.StatusNoContent)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pull-requests/42/activities"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"isLastPage": true,
+				"values": []map[string]any{
+					{
+						"action": "COMMENTED",
+						"comment": map[string]any{
+							"id":      9,
+							"version": 3,
+							"text":    "root",
+						},
+					},
+				},
+			})
+		case r.Method == http.MethodDelete:
+			gotMethod = r.Method
+			gotPath = r.URL.Path
+			gotQuery = r.URL.RawQuery
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
 	}))
 	t.Cleanup(srv.Close)
 
@@ -586,6 +607,9 @@ func TestCommentsDeleteDC(t *testing.T) {
 	}
 	if gotPath != "/rest/api/1.0/projects/PROJ/repos/my-repo/pull-requests/42/comments/9" {
 		t.Errorf("path = %q", gotPath)
+	}
+	if gotQuery != "version=3" {
+		t.Errorf("query = %q, want version=3", gotQuery)
 	}
 	if !strings.Contains(stdout, "Deleted comment 9 on pull request #42") {
 		t.Errorf("unexpected output: %s", stdout)

--- a/pkg/cmd/pr/comments_test.go
+++ b/pkg/cmd/pr/comments_test.go
@@ -389,7 +389,7 @@ func TestCommentsThreadResolveCloud(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error")
 		}
-		if !strings.Contains(err.Error(), "Only top-level pull request comment threads can be resolved.") {
+		if !strings.Contains(err.Error(), "only top-level pull request comment threads can be resolved") {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
@@ -413,7 +413,7 @@ func TestCommentsThreadResolveCloud(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error")
 		}
-		if !strings.Contains(err.Error(), "Pull request comment 10 has been deleted and cannot be resolved.") {
+		if !strings.Contains(err.Error(), "pull request comment 10 has been deleted and cannot be resolved") {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})

--- a/pkg/cmd/pr/comments_test.go
+++ b/pkg/cmd/pr/comments_test.go
@@ -524,6 +524,9 @@ func TestCommentsThreadResolveDC(t *testing.T) {
 							"id":             9,
 							"version":        3,
 							"text":           "root",
+							"severity":       "NORMAL",
+							"state":          "OPEN",
+							"properties":     map[string]any{"keep": "me"},
 							"threadResolved": false,
 						},
 					},
@@ -551,8 +554,14 @@ func TestCommentsThreadResolveDC(t *testing.T) {
 	if gotPutPath != "/rest/api/1.0/projects/PROJ/repos/my-repo/pull-requests/42/comments/9" {
 		t.Errorf("PUT path = %q", gotPutPath)
 	}
-	if gotBody["version"] != float64(3) || gotBody["threadResolved"] != true {
-		t.Errorf("body = %#v, want version=3 threadResolved=true", gotBody)
+	if gotBody["version"] != float64(3) || gotBody["id"] != float64(9) ||
+		gotBody["text"] != "root" || gotBody["severity"] != "NORMAL" ||
+		gotBody["state"] != "OPEN" || gotBody["threadResolved"] != true {
+		t.Errorf("body = %#v, want full comment payload with threadResolved=true", gotBody)
+	}
+	props, ok := gotBody["properties"].(map[string]any)
+	if !ok || props["keep"] != "me" {
+		t.Errorf("properties = %#v, want keep=me", gotBody["properties"])
 	}
 	if !strings.Contains(stdout, "Resolved comment thread 9 on pull request #42") {
 		t.Errorf("unexpected output: %s", stdout)

--- a/pkg/cmd/pr/comments_test.go
+++ b/pkg/cmd/pr/comments_test.go
@@ -48,6 +48,26 @@ func TestCommentsCommandValidation(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
+
+	t.Run("invalid resolve comment ID", func(t *testing.T) {
+		_, _, err := runCLI(t, cfg, "pr", "comments", "resolve", "42", "abc")
+		if err == nil {
+			t.Fatal("expected error for invalid comment ID")
+		}
+		if !strings.Contains(err.Error(), "invalid comment id") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("help includes resolve and reopen examples", func(t *testing.T) {
+		stdout, _, err := runCLI(t, cfg, "pr", "comments", "--help")
+		if err != nil {
+			t.Fatalf("help: %v", err)
+		}
+		if !strings.Contains(stdout, "bkt pr comments resolve 42 1001") || !strings.Contains(stdout, "bkt pr comments reopen 42 1001") {
+			t.Errorf("help missing resolve/reopen examples:\n%s", stdout)
+		}
+	})
 }
 
 func TestCommentsDC(t *testing.T) {
@@ -142,6 +162,12 @@ func TestCommentsCloud(t *testing.T) {
 				"created_on": "2025-01-01T00:00:00+00:00",
 			},
 		},
+		{
+			"id":      3,
+			"deleted": true,
+			"content": map[string]string{"raw": ""},
+			"user":    map[string]string{"display_name": "Deleted User", "nickname": "deleted"},
+		},
 	}
 
 	t.Run("state all", func(t *testing.T) {
@@ -157,6 +183,9 @@ func TestCommentsCloud(t *testing.T) {
 		}
 		if !strings.Contains(stdout, "Resolved comment") {
 			t.Errorf("expected resolved comment in output, got: %s", stdout)
+		}
+		if !strings.Contains(stdout, "3\tDeleted User\t[deleted]") {
+			t.Errorf("expected deleted marker in output, got: %s", stdout)
 		}
 	})
 
@@ -174,6 +203,9 @@ func TestCommentsCloud(t *testing.T) {
 		if strings.Contains(stdout, "Unresolved comment") {
 			t.Errorf("should not contain unresolved comment, got: %s", stdout)
 		}
+		if strings.Contains(stdout, "[deleted]") {
+			t.Errorf("should not contain deleted comment, got: %s", stdout)
+		}
 	})
 
 	t.Run("state unresolved", func(t *testing.T) {
@@ -190,6 +222,47 @@ func TestCommentsCloud(t *testing.T) {
 		if strings.Contains(stdout, "Resolved comment") {
 			t.Errorf("should not contain resolved comment, got: %s", stdout)
 		}
+		if strings.Contains(stdout, "[deleted]") {
+			t.Errorf("should not contain deleted comment, got: %s", stdout)
+		}
+	})
+
+	t.Run("state deleted", func(t *testing.T) {
+		srv := makeServer(allComments)
+		t.Cleanup(srv.Close)
+
+		stdout, stderr, err := runCLI(t, cloudConfig(srv.URL), "pr", "comments", "42", "--state", "deleted")
+		if err != nil {
+			t.Fatalf("unexpected error: %v (stderr=%s)", err, stderr)
+		}
+		if !strings.Contains(stdout, "3\tDeleted User\t[deleted]") {
+			t.Errorf("expected deleted comment in output, got: %s", stdout)
+		}
+		if strings.Contains(stdout, "Unresolved comment") || strings.Contains(stdout, "Resolved comment") {
+			t.Errorf("should only contain deleted comments, got: %s", stdout)
+		}
+	})
+
+	t.Run("deleted json output", func(t *testing.T) {
+		srv := makeServer(allComments)
+		t.Cleanup(srv.Close)
+
+		stdout, stderr, err := runCLI(t, cloudConfig(srv.URL), "--json", "pr", "comments", "42", "--state", "deleted")
+		if err != nil {
+			t.Fatalf("unexpected error: %v (stderr=%s)", err, stderr)
+		}
+		var payload struct {
+			Comments []struct {
+				ID      int  `json:"id"`
+				Deleted bool `json:"deleted"`
+			} `json:"comments"`
+		}
+		if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+			t.Fatalf("output is not JSON: %v\n%s", err, stdout)
+		}
+		if len(payload.Comments) != 1 || payload.Comments[0].ID != 3 || !payload.Comments[0].Deleted {
+			t.Errorf("comments = %+v, want only deleted comment 3", payload.Comments)
+		}
 	})
 
 	t.Run("default state is all", func(t *testing.T) {
@@ -200,10 +273,224 @@ func TestCommentsCloud(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v (stderr=%s)", err, stderr)
 		}
-		if !strings.Contains(stdout, "Unresolved comment") || !strings.Contains(stdout, "Resolved comment") {
-			t.Errorf("expected both comments in output (default state=all), got: %s", stdout)
+		if !strings.Contains(stdout, "Unresolved comment") || !strings.Contains(stdout, "Resolved comment") || !strings.Contains(stdout, "[deleted]") {
+			t.Errorf("expected all comments in output (default state=all), got: %s", stdout)
 		}
 	})
+}
+
+func TestCommentsThreadResolveCloud(t *testing.T) {
+	t.Run("resolve human output", func(t *testing.T) {
+		var gotMethod, gotPath string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch {
+			case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/comments/9"):
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"id":      9,
+					"content": map[string]string{"raw": "Needs a tweak"},
+				})
+			case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/comments/9/resolve"):
+				gotMethod = r.Method
+				gotPath = r.URL.Path
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"user":       map[string]string{"display_name": "Alice"},
+					"created_on": "2026-01-01T00:00:00+00:00",
+				})
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		t.Cleanup(srv.Close)
+
+		stdout, stderr, err := runCLI(t, cloudConfig(srv.URL), "pr", "comments", "resolve", "42", "9")
+		if err != nil {
+			t.Fatalf("resolve: %v (stderr=%s)", err, stderr)
+		}
+		if gotMethod != http.MethodPost {
+			t.Errorf("method = %s, want POST", gotMethod)
+		}
+		if gotPath != "/repositories/myworkspace/my-repo/pullrequests/42/comments/9/resolve" {
+			t.Errorf("path = %q", gotPath)
+		}
+		if !strings.Contains(stdout, "Resolved comment thread 9 on pull request #42") {
+			t.Errorf("unexpected output: %s", stdout)
+		}
+	})
+
+	t.Run("reopen json output", func(t *testing.T) {
+		var gotMethod string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch {
+			case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/comments/9"):
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"id":         9,
+					"content":    map[string]string{"raw": "Needs a tweak"},
+					"resolution": map[string]string{"created_on": "2026-01-01T00:00:00+00:00"},
+				})
+			case r.Method == http.MethodDelete && strings.HasSuffix(r.URL.Path, "/comments/9/resolve"):
+				gotMethod = r.Method
+				w.WriteHeader(http.StatusNoContent)
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		t.Cleanup(srv.Close)
+
+		stdout, stderr, err := runCLI(t, cloudConfig(srv.URL), "--json", "pr", "comments", "reopen", "42", "9")
+		if err != nil {
+			t.Fatalf("reopen --json: %v (stderr=%s)", err, stderr)
+		}
+		if gotMethod != http.MethodDelete {
+			t.Errorf("method = %s, want DELETE", gotMethod)
+		}
+		var payload struct {
+			PullRequest int  `json:"pull_request"`
+			CommentID   int  `json:"comment_id"`
+			Resolved    bool `json:"resolved"`
+		}
+		if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+			t.Fatalf("output is not JSON: %v\n%s", err, stdout)
+		}
+		if payload.PullRequest != 42 || payload.CommentID != 9 || payload.Resolved {
+			t.Errorf("payload = %+v, want pr=42 comment=9 resolved=false", payload)
+		}
+	})
+
+	t.Run("reply maps to top-level error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/comments/10") {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"id":      10,
+					"parent":  map[string]int{"id": 9},
+					"content": map[string]string{"raw": "A reply"},
+				})
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		t.Cleanup(srv.Close)
+
+		_, _, err := runCLI(t, cloudConfig(srv.URL), "pr", "comments", "resolve", "42", "10")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "Only top-level pull request comment threads can be resolved.") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("deleted comment maps to deleted error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/comments/10") {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"id":      10,
+					"deleted": true,
+					"content": map[string]string{"raw": ""},
+				})
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		t.Cleanup(srv.Close)
+
+		_, _, err := runCLI(t, cloudConfig(srv.URL), "pr", "comments", "resolve", "42", "10")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "Pull request comment 10 has been deleted and cannot be resolved.") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("conflict is idempotent success", func(t *testing.T) {
+		getCount := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch {
+			case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/comments/9"):
+				getCount++
+				comment := map[string]any{
+					"id":      9,
+					"content": map[string]string{"raw": "Needs a tweak"},
+				}
+				if getCount > 1 {
+					comment["resolution"] = map[string]string{"created_on": "2026-01-01T00:00:00+00:00"}
+				}
+				_ = json.NewEncoder(w).Encode(comment)
+			case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/comments/9/resolve"):
+				w.WriteHeader(http.StatusConflict)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"error": map[string]string{"message": "Already resolved"},
+				})
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		t.Cleanup(srv.Close)
+
+		stdout, stderr, err := runCLI(t, cloudConfig(srv.URL), "pr", "comments", "resolve", "42", "9")
+		if err != nil {
+			t.Fatalf("resolve conflict: %v (stderr=%s)", err, stderr)
+		}
+		if !strings.Contains(stdout, "already resolved") {
+			t.Errorf("unexpected output: %s", stdout)
+		}
+	})
+}
+
+func TestCommentsThreadResolveDC(t *testing.T) {
+	var gotBody map[string]any
+	var gotPutPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pull-requests/42/activities"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"isLastPage": true,
+				"values": []map[string]any{
+					{
+						"action": "COMMENTED",
+						"comment": map[string]any{
+							"id":             9,
+							"version":        3,
+							"text":           "root",
+							"threadResolved": false,
+						},
+					},
+				},
+			})
+		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/pull-requests/42/comments/9"):
+			gotPutPath = r.URL.Path
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":             9,
+				"version":        4,
+				"text":           "root",
+				"threadResolved": true,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	stdout, stderr, err := runCLI(t, dcConfig(srv.URL), "pr", "comments", "resolve", "42", "9")
+	if err != nil {
+		t.Fatalf("dc resolve: %v (stderr=%s)", err, stderr)
+	}
+	if gotPutPath != "/rest/api/1.0/projects/PROJ/repos/my-repo/pull-requests/42/comments/9" {
+		t.Errorf("PUT path = %q", gotPutPath)
+	}
+	if gotBody["version"] != float64(3) || gotBody["threadResolved"] != true {
+		t.Errorf("body = %#v, want version=3 threadResolved=true", gotBody)
+	}
+	if !strings.Contains(stdout, "Resolved comment thread 9 on pull request #42") {
+		t.Errorf("unexpected output: %s", stdout)
+	}
 }
 
 func TestCommentsEmpty(t *testing.T) {

--- a/pkg/cmd/pr/comments_test.go
+++ b/pkg/cmd/pr/comments_test.go
@@ -59,13 +59,25 @@ func TestCommentsCommandValidation(t *testing.T) {
 		}
 	})
 
-	t.Run("help includes resolve and reopen examples", func(t *testing.T) {
+	t.Run("invalid delete comment ID", func(t *testing.T) {
+		_, _, err := runCLI(t, cfg, "pr", "comments", "delete", "42", "abc")
+		if err == nil {
+			t.Fatal("expected error for invalid comment ID")
+		}
+		if !strings.Contains(err.Error(), "invalid comment id") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("help includes thread action examples", func(t *testing.T) {
 		stdout, _, err := runCLI(t, cfg, "pr", "comments", "--help")
 		if err != nil {
 			t.Fatalf("help: %v", err)
 		}
-		if !strings.Contains(stdout, "bkt pr comments resolve 42 1001") || !strings.Contains(stdout, "bkt pr comments reopen 42 1001") {
-			t.Errorf("help missing resolve/reopen examples:\n%s", stdout)
+		if !strings.Contains(stdout, "bkt pr comments delete 42 1001") ||
+			!strings.Contains(stdout, "bkt pr comments resolve 42 1001") ||
+			!strings.Contains(stdout, "bkt pr comments reopen 42 1001") {
+			t.Errorf("help missing thread action examples:\n%s", stdout)
 		}
 	})
 }
@@ -442,6 +454,60 @@ func TestCommentsThreadResolveCloud(t *testing.T) {
 	})
 }
 
+func TestCommentsDeleteCloud(t *testing.T) {
+	t.Run("delete human output", func(t *testing.T) {
+		var gotMethod, gotPath string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotMethod = r.Method
+			gotPath = r.URL.Path
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		t.Cleanup(srv.Close)
+
+		stdout, stderr, err := runCLI(t, cloudConfig(srv.URL), "pr", "comments", "delete", "42", "9")
+		if err != nil {
+			t.Fatalf("delete: %v (stderr=%s)", err, stderr)
+		}
+		if gotMethod != http.MethodDelete {
+			t.Errorf("method = %s, want DELETE", gotMethod)
+		}
+		if gotPath != "/repositories/myworkspace/my-repo/pullrequests/42/comments/9" {
+			t.Errorf("path = %q", gotPath)
+		}
+		if !strings.Contains(stdout, "Deleted comment 9 on pull request #42") {
+			t.Errorf("unexpected output: %s", stdout)
+		}
+	})
+
+	t.Run("delete json output", func(t *testing.T) {
+		var gotMethod string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotMethod = r.Method
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		t.Cleanup(srv.Close)
+
+		stdout, stderr, err := runCLI(t, cloudConfig(srv.URL), "--json", "pr", "comments", "delete", "42", "9")
+		if err != nil {
+			t.Fatalf("delete --json: %v (stderr=%s)", err, stderr)
+		}
+		if gotMethod != http.MethodDelete {
+			t.Errorf("method = %s, want DELETE", gotMethod)
+		}
+		var payload struct {
+			PullRequest int  `json:"pull_request"`
+			CommentID   int  `json:"comment_id"`
+			Deleted     bool `json:"deleted"`
+		}
+		if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+			t.Fatalf("output is not JSON: %v\n%s", err, stdout)
+		}
+		if payload.PullRequest != 42 || payload.CommentID != 9 || !payload.Deleted {
+			t.Errorf("payload = %+v, want pr=42 comment=9 deleted=true", payload)
+		}
+	})
+}
+
 func TestCommentsThreadResolveDC(t *testing.T) {
 	var gotBody map[string]any
 	var gotPutPath string
@@ -489,6 +555,30 @@ func TestCommentsThreadResolveDC(t *testing.T) {
 		t.Errorf("body = %#v, want version=3 threadResolved=true", gotBody)
 	}
 	if !strings.Contains(stdout, "Resolved comment thread 9 on pull request #42") {
+		t.Errorf("unexpected output: %s", stdout)
+	}
+}
+
+func TestCommentsDeleteDC(t *testing.T) {
+	var gotMethod, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	stdout, stderr, err := runCLI(t, dcConfig(srv.URL), "pr", "comments", "delete", "42", "9")
+	if err != nil {
+		t.Fatalf("delete: %v (stderr=%s)", err, stderr)
+	}
+	if gotMethod != http.MethodDelete {
+		t.Errorf("method = %s, want DELETE", gotMethod)
+	}
+	if gotPath != "/rest/api/1.0/projects/PROJ/repos/my-repo/pull-requests/42/comments/9" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if !strings.Contains(stdout, "Deleted comment 9 on pull request #42") {
 		t.Errorf("unexpected output: %s", stdout)
 	}
 }

--- a/skills/bkt/rules/pr.md
+++ b/skills/bkt/rules/pr.md
@@ -419,6 +419,10 @@ on Data Center because the DC API does not expose resolution status.
 
 Works on both Data Center and Cloud.
 
+Resolve and reopen subcommands require the top-level thread comment ID, not a
+reply ID. Use --details when listing comments to inspect thread structure before
+changing thread state.
+
 ```
 bkt pr comments <id> [flags]
 bkt pr comments <command> [flags]
@@ -478,7 +482,12 @@ bkt pr comments <command> [flags]
 
 ## bkt pr comments delete
 
-Delete a pull request comment
+Delete a pull request comment on Bitbucket Cloud or Data Center.
+
+Use bkt pr comments <id> or bkt pr comments <id> --details to find the comment
+ID before deleting it. On Bitbucket Cloud, deleted comments can still be listed
+with --state deleted when the API returns them. On Data Center, bkt fetches the
+current comment version before deleting because the API requires it.
 
 **Alias:** `rm`
 
@@ -510,12 +519,20 @@ bkt pr comments delete <id> <comment-id> [flags]
 ### Examples
 
 ```bash
-bkt pr comments delete 42 1001
+# Delete comment 1001 from pull request 42
+  bkt pr comments delete 42 1001
+
+  # Delete a comment in a specific repository
+  bkt pr comments delete 42 1001 --repo platform-api
 ```
 
 ## bkt pr comments reopen
 
-Reopen a resolved pull request comment thread
+Reopen a resolved pull request comment thread on Bitbucket Cloud or Data Center.
+
+The comment-id must be the top-level comment for the thread. Replies cannot be
+reopened directly; pass the parent comment ID instead. Deleted comments cannot
+be reopened.
 
 ### Usage
 
@@ -545,12 +562,20 @@ bkt pr comments reopen <id> <comment-id> [flags]
 ### Examples
 
 ```bash
-bkt pr comments reopen 42 1001
+# Reopen thread 1001 on pull request 42
+  bkt pr comments reopen 42 1001
+
+  # Reopen a thread in a specific repository
+  bkt pr comments reopen 42 1001 --repo platform-api
 ```
 
 ## bkt pr comments resolve
 
-Resolve a pull request comment thread
+Resolve a pull request comment thread on Bitbucket Cloud or Data Center.
+
+The comment-id must be the top-level comment for the thread. Replies cannot be
+resolved directly; pass the parent comment ID instead. Deleted comments cannot
+be resolved.
 
 ### Usage
 
@@ -580,7 +605,11 @@ bkt pr comments resolve <id> <comment-id> [flags]
 ### Examples
 
 ```bash
-bkt pr comments resolve 42 1001
+# Resolve thread 1001 on pull request 42
+  bkt pr comments resolve 42 1001
+
+  # Resolve a thread in a specific repository
+  bkt pr comments resolve 42 1001 --repo platform-api
 ```
 
 ## bkt pr create

--- a/skills/bkt/rules/pr.md
+++ b/skills/bkt/rules/pr.md
@@ -460,6 +460,9 @@ bkt pr comments <command> [flags]
   # List deleted comments (Cloud only)
   bkt pr comments 42 --state deleted
 
+  # Delete a comment
+  bkt pr comments delete 42 1001
+
   # Resolve a comment thread
   bkt pr comments resolve 42 1001
 
@@ -469,8 +472,46 @@ bkt pr comments <command> [flags]
 
 | Subcommand | Description |
 |---|---|
+| delete | Delete a pull request comment |
 | reopen | Reopen a resolved pull request comment thread |
 | resolve | Resolve a pull request comment thread |
+
+## bkt pr comments delete
+
+Delete a pull request comment
+
+**Alias:** `rm`
+
+### Usage
+
+```
+bkt pr comments delete <id> <comment-id> [flags]
+```
+
+### Flags
+
+| Flag | Short | Description |
+|---|---|---|
+| `--project` |  | Bitbucket project key override |
+| `--repo` |  | Repository slug override |
+| `--workspace` |  | Bitbucket Cloud workspace override |
+
+### Inherited Flags
+
+| Flag | Short | Description |
+|---|---|---|
+| `--context` | `-c` | Active Bitbucket context name |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
+| `--json` |  | Output in JSON format when supported |
+| `--template` |  | Render output using Go templates |
+| `--yaml` |  | Output in YAML format when supported |
+
+### Examples
+
+```bash
+bkt pr comments delete 42 1001
+```
 
 ## bkt pr comments reopen
 

--- a/skills/bkt/rules/pr.md
+++ b/skills/bkt/rules/pr.md
@@ -414,15 +414,14 @@ bkt pr comment <id> --text <message> [flags]
 ## bkt pr comments
 
 List all comments on a pull request. On Cloud, use --state to filter by
-resolution status (resolved or unresolved). The --state flag is not supported
+resolution status (resolved, unresolved, or deleted). The --state flag is not supported
 on Data Center because the DC API does not expose resolution status.
 
 Works on both Data Center and Cloud.
 
-### Usage
-
 ```
 bkt pr comments <id> [flags]
+bkt pr comments <command> [flags]
 ```
 
 ### Flags
@@ -432,7 +431,7 @@ bkt pr comments <id> [flags]
 | `--details` |  | Show full comment details (file, resolved, task status) |
 | `--project` |  | Bitbucket project key override |
 | `--repo` |  | Repository slug override |
-| `--state` |  | Filter by state: all, resolved, unresolved (Cloud only) |
+| `--state` |  | Filter by state: all, resolved, unresolved, deleted (Cloud only) |
 | `--workspace` |  | Bitbucket Cloud workspace override |
 
 ### Inherited Flags
@@ -457,6 +456,90 @@ bkt pr comments <id> [flags]
 
   # List resolved comments (Cloud only)
   bkt pr comments 42 --state resolved
+
+  # List deleted comments (Cloud only)
+  bkt pr comments 42 --state deleted
+
+  # Resolve a comment thread
+  bkt pr comments resolve 42 1001
+
+  # Reopen a resolved comment thread
+  bkt pr comments reopen 42 1001
+```
+
+| Subcommand | Description |
+|---|---|
+| reopen | Reopen a resolved pull request comment thread |
+| resolve | Resolve a pull request comment thread |
+
+## bkt pr comments reopen
+
+Reopen a resolved pull request comment thread
+
+### Usage
+
+```
+bkt pr comments reopen <id> <comment-id> [flags]
+```
+
+### Flags
+
+| Flag | Short | Description |
+|---|---|---|
+| `--project` |  | Bitbucket project key override |
+| `--repo` |  | Repository slug override |
+| `--workspace` |  | Bitbucket Cloud workspace override |
+
+### Inherited Flags
+
+| Flag | Short | Description |
+|---|---|---|
+| `--context` | `-c` | Active Bitbucket context name |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
+| `--json` |  | Output in JSON format when supported |
+| `--template` |  | Render output using Go templates |
+| `--yaml` |  | Output in YAML format when supported |
+
+### Examples
+
+```bash
+bkt pr comments reopen 42 1001
+```
+
+## bkt pr comments resolve
+
+Resolve a pull request comment thread
+
+### Usage
+
+```
+bkt pr comments resolve <id> <comment-id> [flags]
+```
+
+### Flags
+
+| Flag | Short | Description |
+|---|---|---|
+| `--project` |  | Bitbucket project key override |
+| `--repo` |  | Repository slug override |
+| `--workspace` |  | Bitbucket Cloud workspace override |
+
+### Inherited Flags
+
+| Flag | Short | Description |
+|---|---|---|
+| `--context` | `-c` | Active Bitbucket context name |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
+| `--json` |  | Output in JSON format when supported |
+| `--template` |  | Render output using Go templates |
+| `--yaml` |  | Output in YAML format when supported |
+
+### Examples
+
+```bash
+bkt pr comments resolve 42 1001
 ```
 
 ## bkt pr create


### PR DESCRIPTION
  Adds  PR comment thread commands:

  - bkt pr comments resolve <pr-id> <comment-id>
  - bkt pr comments reopen <pr-id> <comment-id>
  - bkt pr comments delete <pr-id> <comment-id>

  This removes the need to use raw Bitbucket API calls for resolving, reopening, or deleting pull request comment threads/comments. The commands support existing repo/context override flags and structured
  output.

  Also updates generated skill docs so runnable commands with subcommands, like bkt pr comments, still document the parent list usage and flags.

  ## Testing

  - [x] make fmt
  - [x] make test
  - [x] make build
  - [x] Other: make check-generated-skill

  ## Screenshots / recordings

  Manual CLI verification against my Bitbucket Cloud private repo:

  ✓ Commented on pull request #361
  ✓ Resolved comment thread 804341720 on pull request #361

  Verified --state resolved, --state unresolved, and --state deleted behavior, including deleted comment visibility.

  ## Checklist

  - [x] Adds or updates documentation
  - [ ] Updates CHANGELOG.md
  - [ ] Signed commits (git commit -s)

  ## Notes for reviewers

I like when my review bot's can left PR review comments, another bots can read it and try to fix it.

  comment-id for resolve/reopen must be the top-level thread comment. Replies and deleted comments are handled with clearer user-facing errors where possible.