### PR TITLE
fix: address project review correctness gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented here. The format follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- `bkt branch create --from` on Bitbucket Data Center no longer wraps commit
+  hashes in `refs/heads/`, so creating a branch from a commit hash works.
+- `bkt variable set` and `bkt variable delete` on Bitbucket Cloud now reject
+  invalid variable and deployment-environment UUIDs locally instead of calling
+  malformed API endpoints.
+- `bkt pipeline view` and `bkt pipeline logs` now paginate pipeline steps, so
+  pipelines with many steps are complete and the default log step is the true
+  final step.
+- `bkt pr merge` on Bitbucket Cloud now gives async merge tasks enough time to
+  finish and reports an actionable "may still be running" message with task and
+  pull request IDs if polling times out.
+- `bkt pr list --mine` on Bitbucket Cloud now filters by the authenticated
+  user's stable identity (UUID or account ID) instead of an email-shaped
+  username, fixing empty results for API-token logins.
+- `bkt repo create` now rejects host-specific flags that do not apply, such as
+  `--forkable`, `--default-branch`, `--scm`, and `--project` on Cloud or
+  `--workspace` and `--cloud-project` on Data Center, instead of silently
+  ignoring them.
 
 ## [0.28.0] - 2026-05-30
 ### Added

--- a/README.md
+++ b/README.md
@@ -285,11 +285,13 @@ bkt repo list --limit 20
 bkt repo list --workspace myteam --limit 10   # Cloud workspace override
 bkt repo view platform-api
 bkt repo create data-pipeline --description "Data ingestion" --project DATA
+bkt repo create frontend-app --workspace myteam --cloud-project WEB
 bkt repo browse --project DATA --repo platform-api
 bkt repo clone platform-api --project DATA --ssh
 ```
 
 `repo list`/`repo view` automatically target the right REST API for your active context: Data Center uses `/rest/api/1.0/projects/{projectKey}/repos`, while Cloud uses `/2.0/repositories/{workspace}`.
+For `repo create`, `--project`, `--forkable`, `--default-branch`, and `--scm` are Data Center flags; `--workspace` and `--cloud-project` are Cloud flags. Host-specific create flags are rejected when they would otherwise be ignored.
 
 ### 4. Pull request workflows
 

--- a/pkg/bbcloud/client.go
+++ b/pkg/bbcloud/client.go
@@ -562,23 +562,48 @@ func (c *Client) ListPipelineSteps(ctx context.Context, workspace, repoSlug, pip
 		return nil, err
 	}
 
-	path := fmt.Sprintf("/repositories/%s/%s/pipelines/%s/steps/",
+	path := fmt.Sprintf("/repositories/%s/%s/pipelines/%s/steps/?pagelen=100",
 		url.PathEscape(workspace),
 		url.PathEscape(repoSlug),
 		url.PathEscape(normalizedPipelineUUID),
 	)
-	req, err := c.http.NewRequest(ctx, "GET", path, nil)
-	if err != nil {
-		return nil, err
+
+	var steps []PipelineStep
+	for path != "" {
+		req, err := c.http.NewRequest(ctx, "GET", path, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var resp struct {
+			Values []PipelineStep `json:"values"`
+			Next   string         `json:"next"`
+		}
+		if err := c.http.Do(req, &resp); err != nil {
+			return nil, err
+		}
+
+		steps = append(steps, resp.Values...)
+
+		if resp.Next == "" {
+			break
+		}
+		nextURL, err := url.Parse(resp.Next)
+		if err != nil {
+			return nil, fmt.Errorf("parse pipeline steps next URL %q: %w", resp.Next, err)
+		}
+		if nextURL.IsAbs() {
+			if uri := nextURL.RequestURI(); uri != "" {
+				path = uri
+			} else {
+				path = nextURL.String()
+			}
+		} else {
+			path = nextURL.String()
+		}
 	}
 
-	var resp struct {
-		Values []PipelineStep `json:"values"`
-	}
-	if err := c.http.Do(req, &resp); err != nil {
-		return nil, err
-	}
-	return resp.Values, nil
+	return steps, nil
 }
 
 // PipelineLog represents a step log chunk.

--- a/pkg/bbcloud/client_test.go
+++ b/pkg/bbcloud/client_test.go
@@ -922,6 +922,86 @@ func TestListPipelineStepsNormalizesUUID(t *testing.T) {
 	}
 }
 
+func TestListPipelineStepsPaginates(t *testing.T) {
+	const pipelineUUID = "{550e8400-e29b-41d4-a716-446655440000}"
+	var hits int32
+	var serverURL string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&hits, 1)
+		if !strings.Contains(r.URL.Path, pipelineUUID) {
+			t.Fatalf("expected normalized pipeline UUID in path, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+
+		switch count {
+		case 1:
+			if r.URL.Query().Get("pagelen") != "100" {
+				t.Fatalf("expected pagelen=100 on first request, got %q", r.URL.Query().Get("pagelen"))
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values": []map[string]any{
+					{"uuid": "{11111111-1111-4111-8111-111111111111}", "name": "Build"},
+				},
+				"next": serverURL + "/repositories/work/repo/pipelines/%7B550e8400-e29b-41d4-a716-446655440000%7D/steps/?pagelen=100&page=2",
+			})
+		case 2:
+			if r.URL.Query().Get("page") != "2" {
+				t.Fatalf("expected page=2 on second request, got %q", r.URL.Query().Get("page"))
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values": []map[string]any{
+					{"uuid": "{22222222-2222-4222-8222-222222222222}", "name": "Deploy"},
+				},
+			})
+		default:
+			t.Fatalf("unexpected extra request %d", count)
+		}
+	}))
+	serverURL = server.URL
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{BaseURL: server.URL})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	steps, err := client.ListPipelineSteps(context.Background(), "work", "repo", pipelineUUID)
+	if err != nil {
+		t.Fatalf("ListPipelineSteps: %v", err)
+	}
+	if len(steps) != 2 {
+		t.Fatalf("expected 2 steps, got %d", len(steps))
+	}
+	if steps[0].Name != "Build" || steps[1].Name != "Deploy" {
+		t.Fatalf("unexpected steps: %+v", steps)
+	}
+	if hits != 2 {
+		t.Fatalf("expected 2 requests, got %d", hits)
+	}
+}
+
+func TestListPipelineStepsRejectsInvalidNextURL(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"values": []map[string]any{
+				{"uuid": "{11111111-1111-4111-8111-111111111111}", "name": "Build"},
+			},
+			"next": "%",
+		})
+	})
+
+	client := newTestClient(t, handler)
+	_, err := client.ListPipelineSteps(context.Background(), "work", "repo", "{550e8400-e29b-41d4-a716-446655440000}")
+	if err == nil {
+		t.Fatal("expected invalid next URL error")
+	}
+	if !strings.Contains(err.Error(), "parse pipeline steps next URL") {
+		t.Fatalf("error = %q, want pipeline steps next URL context", err)
+	}
+}
+
 func TestGetPipelineLogsNormalizesUUIDs(t *testing.T) {
 	const pipelineUUID = "{550e8400-e29b-41d4-a716-446655440000}"
 	const stepUUID = "{123e4567-e89b-12d3-a456-426614174000}"

--- a/pkg/bbcloud/pullrequests.go
+++ b/pkg/bbcloud/pullrequests.go
@@ -95,7 +95,7 @@ func (c *Client) ListPullRequests(ctx context.Context, workspace, repoSlug strin
 		params = append(params, "state="+url.QueryEscape(strings.ToUpper(state)))
 	}
 	if mine := strings.TrimSpace(opts.Mine); mine != "" {
-		params = append(params, "q="+url.QueryEscape(bbqlEquals("author.username", mine)))
+		params = append(params, "q="+url.QueryEscape(bbqlEquals(authorFilterField(mine), mine)))
 	}
 
 	path := fmt.Sprintf("/repositories/%s/%s/pullrequests?%s",
@@ -134,6 +134,17 @@ func (c *Client) ListPullRequests(ctx context.Context, workspace, repoSlug strin
 	}
 
 	return prs, nil
+}
+
+func authorFilterField(identity string) string {
+	switch {
+	case LooksLikeUUID(identity):
+		return "author.uuid"
+	case LooksLikeAccountID(identity):
+		return "author.account_id"
+	default:
+		return "author.username"
+	}
 }
 
 // GetPullRequest fetches a pull request by ID.
@@ -538,7 +549,7 @@ func (c *Client) pollMergeTask(ctx context.Context, workspace, repoSlug string, 
 	for attempt := 0; attempt < maxMergePollAttempts; attempt++ {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("merge task timed out: %w", ctx.Err())
+			return fmt.Errorf("merge task %s for pull request #%d may still be running; polling timed out: %w", taskID, prID, ctx.Err())
 		case <-time.After(c.mergePollInterval):
 		}
 
@@ -549,18 +560,21 @@ func (c *Client) pollMergeTask(ctx context.Context, workspace, repoSlug string, 
 
 		var status mergeTaskStatus
 		if err := c.http.Do(req, &status); err != nil {
-			return fmt.Errorf("polling merge task: %w", err)
+			if ctx.Err() != nil {
+				return fmt.Errorf("merge task %s for pull request #%d may still be running; polling timed out: %w", taskID, prID, ctx.Err())
+			}
+			return fmt.Errorf("polling merge task %s for pull request #%d: %w", taskID, prID, err)
 		}
 
 		if status.Status == "SUCCESS" {
 			return nil
 		}
 		if status.Status != "PENDING" {
-			return fmt.Errorf("merge task failed with status: %s", status.Status)
+			return fmt.Errorf("merge task %s for pull request #%d failed with status: %s", taskID, prID, status.Status)
 		}
 	}
 
-	return fmt.Errorf("merge task %s did not complete after %d poll attempts", taskID, maxMergePollAttempts)
+	return fmt.Errorf("merge task %s for pull request #%d may still be running; did not complete after %d poll attempts", taskID, prID, maxMergePollAttempts)
 }
 
 // PullRequestComment models a comment on a Bitbucket Cloud pull request.

--- a/pkg/bbcloud/pullrequests_test.go
+++ b/pkg/bbcloud/pullrequests_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/avivsinai/bitbucket-cli/pkg/bbcloud"
+	"github.com/avivsinai/bitbucket-cli/pkg/httpx"
 )
 
 func newTestClient(t *testing.T, handler http.Handler) *bbcloud.Client {
@@ -153,6 +154,32 @@ func TestListPullRequestsRespectsLimit(t *testing.T) {
 	}
 	if len(prs) != 2 {
 		t.Errorf("expected 2 PRs, got %d", len(prs))
+	}
+}
+
+func TestListPullRequestsMineFiltersByAuthorUUID(t *testing.T) {
+	var gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query().Get("q")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"values": []map[string]any{}})
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := bbcloud.New(bbcloud.Options{BaseURL: server.URL, Username: "email@example.com", Token: "t"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.ListPullRequests(context.Background(), "ws", "repo", bbcloud.PullRequestListOptions{
+		Mine: "{550e8400-e29b-41d4-a716-446655440000}",
+	})
+	if err != nil {
+		t.Fatalf("ListPullRequests: %v", err)
+	}
+
+	if gotQuery != `author.uuid = "{550e8400-e29b-41d4-a716-446655440000}"` {
+		t.Fatalf("q = %q, want author.uuid filter", gotQuery)
 	}
 }
 
@@ -719,6 +746,67 @@ func TestMergePullRequest202AsyncPolling(t *testing.T) {
 	}
 }
 
+func TestMergePullRequest202AsyncDeadlineErrorIsActionable(t *testing.T) {
+	statusStarted := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/merge") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"task_id": "slow-123",
+			})
+			return
+		}
+		if strings.Contains(r.URL.Path, "/task-status/") {
+			close(statusStarted)
+			<-r.Context().Done()
+			return
+		}
+		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := bbcloud.New(bbcloud.Options{
+		BaseURL:           server.URL,
+		Username:          "user",
+		Token:             "token",
+		Retry:             httpx.RetryPolicy{MaxAttempts: 1},
+		MergePollInterval: time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- client.MergePullRequest(ctx, "ws", "repo", 1, "", "squash", false)
+	}()
+
+	select {
+	case <-statusStarted:
+	case <-time.After(time.Second):
+		t.Fatal("merge task status request did not start")
+	}
+
+	select {
+	case err = <-errCh:
+	case <-time.After(time.Second):
+		t.Fatal("MergePullRequest did not return after context deadline")
+	}
+	if err == nil {
+		t.Fatal("expected merge timeout error")
+	}
+	for _, want := range []string{"merge task slow-123", "pull request #1", "may still be running", context.DeadlineExceeded.Error()} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want substring %q", err, want)
+		}
+	}
+}
+
 func TestMergePullRequest202AsyncFailure(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/merge") {
@@ -742,7 +830,7 @@ func TestMergePullRequest202AsyncFailure(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for failed merge task")
 	}
-	if !strings.Contains(err.Error(), "merge task failed") {
+	if !strings.Contains(err.Error(), "merge task abc-456") || !strings.Contains(err.Error(), "failed with status: FAILED") {
 		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/pkg/bbcloud/variables.go
+++ b/pkg/bbcloud/variables.go
@@ -132,6 +132,10 @@ func (c *Client) UpdateRepositoryVariable(ctx context.Context, workspace, repoSl
 	if input.Key == "" {
 		return nil, fmt.Errorf("variable key is required")
 	}
+	normalizedVariableUUID, err := normalizeUUIDArg("variable UUID", variableUUID)
+	if err != nil {
+		return nil, err
+	}
 
 	body := map[string]any{
 		"key":     input.Key,
@@ -142,7 +146,7 @@ func (c *Client) UpdateRepositoryVariable(ctx context.Context, workspace, repoSl
 	path := fmt.Sprintf("/repositories/%s/%s/pipelines_config/variables/%s",
 		url.PathEscape(workspace),
 		url.PathEscape(repoSlug),
-		url.PathEscape(NormalizeUUID(variableUUID)),
+		url.PathEscape(normalizedVariableUUID),
 	)
 
 	req, err := c.http.NewRequest(ctx, "PUT", path, body)
@@ -165,11 +169,15 @@ func (c *Client) DeleteRepositoryVariable(ctx context.Context, workspace, repoSl
 	if variableUUID == "" {
 		return fmt.Errorf("variable UUID is required")
 	}
+	normalizedVariableUUID, err := normalizeUUIDArg("variable UUID", variableUUID)
+	if err != nil {
+		return err
+	}
 
 	path := fmt.Sprintf("/repositories/%s/%s/pipelines_config/variables/%s",
 		url.PathEscape(workspace),
 		url.PathEscape(repoSlug),
-		url.PathEscape(NormalizeUUID(variableUUID)),
+		url.PathEscape(normalizedVariableUUID),
 	)
 
 	req, err := c.http.NewRequest(ctx, "DELETE", path, nil)
@@ -287,6 +295,10 @@ func (c *Client) UpdateWorkspaceVariable(ctx context.Context, workspace, variabl
 	if input.Key == "" {
 		return nil, fmt.Errorf("variable key is required")
 	}
+	normalizedVariableUUID, err := normalizeUUIDArg("variable UUID", variableUUID)
+	if err != nil {
+		return nil, err
+	}
 
 	body := map[string]any{
 		"key":     input.Key,
@@ -296,7 +308,7 @@ func (c *Client) UpdateWorkspaceVariable(ctx context.Context, workspace, variabl
 
 	path := fmt.Sprintf("/workspaces/%s/pipelines-config/variables/%s",
 		url.PathEscape(workspace),
-		url.PathEscape(NormalizeUUID(variableUUID)),
+		url.PathEscape(normalizedVariableUUID),
 	)
 
 	req, err := c.http.NewRequest(ctx, "PUT", path, body)
@@ -319,10 +331,14 @@ func (c *Client) DeleteWorkspaceVariable(ctx context.Context, workspace, variabl
 	if variableUUID == "" {
 		return fmt.Errorf("variable UUID is required")
 	}
+	normalizedVariableUUID, err := normalizeUUIDArg("variable UUID", variableUUID)
+	if err != nil {
+		return err
+	}
 
 	path := fmt.Sprintf("/workspaces/%s/pipelines-config/variables/%s",
 		url.PathEscape(workspace),
-		url.PathEscape(NormalizeUUID(variableUUID)),
+		url.PathEscape(normalizedVariableUUID),
 	)
 
 	req, err := c.http.NewRequest(ctx, "DELETE", path, nil)
@@ -397,6 +413,10 @@ func (c *Client) ListDeploymentVariables(ctx context.Context, workspace, repoSlu
 	if environmentUUID == "" {
 		return nil, fmt.Errorf("environment UUID is required")
 	}
+	normalizedEnvironmentUUID, err := normalizeUUIDArg("environment UUID", environmentUUID)
+	if err != nil {
+		return nil, err
+	}
 
 	pageLen := opts.Limit
 	if pageLen <= 0 || pageLen > 100 {
@@ -406,7 +426,7 @@ func (c *Client) ListDeploymentVariables(ctx context.Context, workspace, repoSlu
 	path := fmt.Sprintf("/repositories/%s/%s/deployments_config/environments/%s/variables?pagelen=%d",
 		url.PathEscape(workspace),
 		url.PathEscape(repoSlug),
-		url.PathEscape(NormalizeUUID(environmentUUID)),
+		url.PathEscape(normalizedEnvironmentUUID),
 		pageLen,
 	)
 
@@ -461,6 +481,10 @@ func (c *Client) CreateDeploymentVariable(ctx context.Context, workspace, repoSl
 	if input.Key == "" {
 		return nil, fmt.Errorf("variable key is required")
 	}
+	normalizedEnvironmentUUID, err := normalizeUUIDArg("environment UUID", environmentUUID)
+	if err != nil {
+		return nil, err
+	}
 
 	body := map[string]any{
 		"key":     input.Key,
@@ -471,7 +495,7 @@ func (c *Client) CreateDeploymentVariable(ctx context.Context, workspace, repoSl
 	path := fmt.Sprintf("/repositories/%s/%s/deployments_config/environments/%s/variables",
 		url.PathEscape(workspace),
 		url.PathEscape(repoSlug),
-		url.PathEscape(NormalizeUUID(environmentUUID)),
+		url.PathEscape(normalizedEnvironmentUUID),
 	)
 
 	req, err := c.http.NewRequest(ctx, "POST", path, body)
@@ -507,6 +531,14 @@ func (c *Client) UpdateDeploymentVariable(ctx context.Context, workspace, repoSl
 	if input.Key == "" {
 		return nil, fmt.Errorf("variable key is required")
 	}
+	normalizedEnvironmentUUID, err := normalizeUUIDArg("environment UUID", environmentUUID)
+	if err != nil {
+		return nil, err
+	}
+	normalizedVariableUUID, err := normalizeUUIDArg("variable UUID", variableUUID)
+	if err != nil {
+		return nil, err
+	}
 
 	body := map[string]any{
 		"key":     input.Key,
@@ -517,8 +549,8 @@ func (c *Client) UpdateDeploymentVariable(ctx context.Context, workspace, repoSl
 	path := fmt.Sprintf("/repositories/%s/%s/deployments_config/environments/%s/variables/%s",
 		url.PathEscape(workspace),
 		url.PathEscape(repoSlug),
-		url.PathEscape(NormalizeUUID(environmentUUID)),
-		url.PathEscape(NormalizeUUID(variableUUID)),
+		url.PathEscape(normalizedEnvironmentUUID),
+		url.PathEscape(normalizedVariableUUID),
 	)
 
 	req, err := c.http.NewRequest(ctx, "PUT", path, body)
@@ -544,12 +576,20 @@ func (c *Client) DeleteDeploymentVariable(ctx context.Context, workspace, repoSl
 	if variableUUID == "" {
 		return fmt.Errorf("variable UUID is required")
 	}
+	normalizedEnvironmentUUID, err := normalizeUUIDArg("environment UUID", environmentUUID)
+	if err != nil {
+		return err
+	}
+	normalizedVariableUUID, err := normalizeUUIDArg("variable UUID", variableUUID)
+	if err != nil {
+		return err
+	}
 
 	path := fmt.Sprintf("/repositories/%s/%s/deployments_config/environments/%s/variables/%s",
 		url.PathEscape(workspace),
 		url.PathEscape(repoSlug),
-		url.PathEscape(NormalizeUUID(environmentUUID)),
-		url.PathEscape(NormalizeUUID(variableUUID)),
+		url.PathEscape(normalizedEnvironmentUUID),
+		url.PathEscape(normalizedVariableUUID),
 	)
 
 	req, err := c.http.NewRequest(ctx, "DELETE", path, nil)

--- a/pkg/bbcloud/variables_test.go
+++ b/pkg/bbcloud/variables_test.go
@@ -419,7 +419,7 @@ func TestListDeploymentVariables(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	variables, err := client.ListDeploymentVariables(ctx, "ws", "repo", "{env-uuid}", VariableListOptions{})
+	variables, err := client.ListDeploymentVariables(ctx, "ws", "repo", "{550e8400-e29b-41d4-a716-446655440000}", VariableListOptions{})
 	if err != nil {
 		t.Fatalf("ListDeploymentVariables: %v", err)
 	}
@@ -429,5 +429,126 @@ func TestListDeploymentVariables(t *testing.T) {
 	}
 	if variables[0].Key != "DEPLOY_VAR" {
 		t.Errorf("expected key DEPLOY_VAR, got %s", variables[0].Key)
+	}
+}
+
+func TestVariableUUIDValidationRejectsMalformedUUIDsBeforeRequest(t *testing.T) {
+	var hits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(PipelineVariable{UUID: "{123e4567-e89b-12d3-a456-426614174000}", Key: "VAR"})
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{BaseURL: server.URL})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+	validEnvironmentUUID := "{550e8400-e29b-41d4-a716-446655440000}"
+	validVariableUUID := "{123e4567-e89b-12d3-a456-426614174000}"
+	tests := []struct {
+		name string
+		call func() error
+		want string
+	}{
+		{
+			name: "update repository variable",
+			call: func() error {
+				_, err := client.UpdateRepositoryVariable(ctx, "ws", "repo", "not-a-uuid", UpdateRepositoryVariableInput{Key: "VAR"})
+				return err
+			},
+			want: "variable UUID must be a canonical UUID",
+		},
+		{
+			name: "delete repository variable",
+			call: func() error {
+				return client.DeleteRepositoryVariable(ctx, "ws", "repo", "not-a-uuid")
+			},
+			want: "variable UUID must be a canonical UUID",
+		},
+		{
+			name: "update workspace variable",
+			call: func() error {
+				_, err := client.UpdateWorkspaceVariable(ctx, "ws", "not-a-uuid", UpdateWorkspaceVariableInput{Key: "VAR"})
+				return err
+			},
+			want: "variable UUID must be a canonical UUID",
+		},
+		{
+			name: "delete workspace variable",
+			call: func() error {
+				return client.DeleteWorkspaceVariable(ctx, "ws", "not-a-uuid")
+			},
+			want: "variable UUID must be a canonical UUID",
+		},
+		{
+			name: "list deployment variables",
+			call: func() error {
+				_, err := client.ListDeploymentVariables(ctx, "ws", "repo", "not-a-uuid", VariableListOptions{})
+				return err
+			},
+			want: "environment UUID must be a canonical UUID",
+		},
+		{
+			name: "create deployment variable",
+			call: func() error {
+				_, err := client.CreateDeploymentVariable(ctx, "ws", "repo", "not-a-uuid", CreateDeploymentVariableInput{Key: "VAR"})
+				return err
+			},
+			want: "environment UUID must be a canonical UUID",
+		},
+		{
+			name: "update deployment variable environment",
+			call: func() error {
+				_, err := client.UpdateDeploymentVariable(ctx, "ws", "repo", "not-a-uuid", validVariableUUID, UpdateDeploymentVariableInput{Key: "VAR"})
+				return err
+			},
+			want: "environment UUID must be a canonical UUID",
+		},
+		{
+			name: "update deployment variable",
+			call: func() error {
+				_, err := client.UpdateDeploymentVariable(ctx, "ws", "repo", validEnvironmentUUID, "not-a-uuid", UpdateDeploymentVariableInput{Key: "VAR"})
+				return err
+			},
+			want: "variable UUID must be a canonical UUID",
+		},
+		{
+			name: "delete deployment variable environment",
+			call: func() error {
+				return client.DeleteDeploymentVariable(ctx, "ws", "repo", "not-a-uuid", validVariableUUID)
+			},
+			want: "environment UUID must be a canonical UUID",
+		},
+		{
+			name: "delete deployment variable",
+			call: func() error {
+				return client.DeleteDeploymentVariable(ctx, "ws", "repo", validEnvironmentUUID, "not-a-uuid")
+			},
+			want: "variable UUID must be a canonical UUID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hits = 0
+			err := tt.call()
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %q, want substring %q", err, tt.want)
+			}
+			if hits != 0 {
+				t.Fatalf("expected local validation to avoid HTTP requests, got %d", hits)
+			}
+		})
 	}
 }

--- a/pkg/bbdc/branches.go
+++ b/pkg/bbdc/branches.go
@@ -89,7 +89,7 @@ func (c *Client) CreateBranch(ctx context.Context, projectKey, repoSlug string, 
 
 	body := map[string]any{
 		"name":       ensureRef(in.Name),
-		"startPoint": ensureRef(in.StartPoint),
+		"startPoint": normalizeStartPoint(in.StartPoint),
 	}
 	if in.Message != "" {
 		body["message"] = in.Message
@@ -158,6 +158,26 @@ func ensureRef(ref string) string {
 		return ref
 	}
 	return "refs/heads/" + ref
+}
+
+func normalizeStartPoint(startPoint string) string {
+	if strings.HasPrefix(startPoint, "refs/") || isCommitSHA(startPoint) {
+		return startPoint
+	}
+	return ensureRef(startPoint)
+}
+
+func isCommitSHA(value string) bool {
+	if len(value) < 7 || len(value) > 40 {
+		return false
+	}
+	for _, ch := range value {
+		if (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F') {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func valueOrPositive(value, fallback int) int {

--- a/pkg/bbdc/branches_test.go
+++ b/pkg/bbdc/branches_test.go
@@ -1,0 +1,75 @@
+package bbdc_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/avivsinai/bitbucket-cli/pkg/bbdc"
+)
+
+func TestCreateBranchStartPointNormalization(t *testing.T) {
+	tests := []struct {
+		name           string
+		startPoint     string
+		wantStartPoint string
+	}{
+		{
+			name:           "commit sha",
+			startPoint:     "0123456789abcdef0123456789abcdef01234567",
+			wantStartPoint: "0123456789abcdef0123456789abcdef01234567",
+		},
+		{
+			name:           "branch name",
+			startPoint:     "main",
+			wantStartPoint: "refs/heads/main",
+		},
+		{
+			name:           "non-branch ref",
+			startPoint:     "refs/changes/123",
+			wantStartPoint: "refs/changes/123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotBody map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Fatalf("method = %s, want POST", r.Method)
+				}
+				if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+					t.Fatalf("decode body: %v", err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"id":        "refs/heads/feature",
+					"displayId": "feature",
+				})
+			}))
+			t.Cleanup(server.Close)
+
+			client, err := bbdc.New(bbdc.Options{BaseURL: server.URL})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+
+			_, err = client.CreateBranch(context.Background(), "PROJ", "repo", bbdc.CreateBranchInput{
+				Name:       "feature",
+				StartPoint: tt.startPoint,
+			})
+			if err != nil {
+				t.Fatalf("CreateBranch: %v", err)
+			}
+
+			if got := gotBody["name"]; got != "refs/heads/feature" {
+				t.Errorf("name = %v, want refs/heads/feature", got)
+			}
+			if got := gotBody["startPoint"]; got != tt.wantStartPoint {
+				t.Errorf("startPoint = %v, want %s", got, tt.wantStartPoint)
+			}
+		})
+	}
+}

--- a/pkg/cmd/pipeline/pipeline.go
+++ b/pkg/cmd/pipeline/pipeline.go
@@ -373,10 +373,11 @@ func runPipelineLogs(cmd *cobra.Command, f *cmdutil.Factory, opts *logsOptions) 
 		if err != nil {
 			return err
 		}
-		if len(steps) == 0 {
+		var ok bool
+		stepID, ok = defaultPipelineLogStepID(steps)
+		if !ok {
 			return fmt.Errorf("pipeline #%d has no steps yet", pipeline.BuildNumber)
 		}
-		stepID = steps[len(steps)-1].UUID
 	}
 
 	logs, err := client.GetPipelineLogs(ctx, workspace, repo, pipeline.UUID, stepID)
@@ -388,6 +389,13 @@ func runPipelineLogs(cmd *cobra.Command, f *cmdutil.Factory, opts *logsOptions) 
 		return err
 	}
 	return nil
+}
+
+func defaultPipelineLogStepID(steps []bbcloud.PipelineStep) (string, bool) {
+	if len(steps) == 0 {
+		return "", false
+	}
+	return steps[len(steps)-1].UUID, true
 }
 
 func resolveCloudRepo(cmd *cobra.Command, f *cmdutil.Factory, workspaceOverride, repoOverride string) (string, string, *config.Host, error) {

--- a/pkg/cmd/pipeline/pipeline_test.go
+++ b/pkg/cmd/pipeline/pipeline_test.go
@@ -1,0 +1,32 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/avivsinai/bitbucket-cli/pkg/bbcloud"
+)
+
+func TestDefaultPipelineLogStepIDUsesLastReturnedStep(t *testing.T) {
+	steps := []bbcloud.PipelineStep{
+		{UUID: "{11111111-1111-4111-8111-111111111111}", Name: "Build"},
+		{UUID: "{22222222-2222-4222-8222-222222222222}", Name: "Deploy"},
+	}
+
+	got, ok := defaultPipelineLogStepID(steps)
+	if !ok {
+		t.Fatal("expected a default step")
+	}
+	if got != "{22222222-2222-4222-8222-222222222222}" {
+		t.Fatalf("default step = %q, want deploy step", got)
+	}
+}
+
+func TestDefaultPipelineLogStepIDEmpty(t *testing.T) {
+	got, ok := defaultPipelineLogStepID(nil)
+	if ok {
+		t.Fatal("expected no default step")
+	}
+	if got != "" {
+		t.Fatalf("default step = %q, want empty string", got)
+	}
+}

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -29,9 +29,10 @@ import (
 
 const (
 	// Standard timeouts for API calls.
-	timeoutRead      = 15 * time.Second
-	timeoutWrite     = 10 * time.Second
-	prListTimeLayout = "2006-01-02 15:04"
+	timeoutRead       = 15 * time.Second
+	timeoutWrite      = 10 * time.Second
+	cloudMergeTimeout = 6 * time.Minute
+	prListTimeLayout  = "2006-01-02 15:04"
 )
 
 // Sentinel errors for checks command
@@ -242,8 +243,15 @@ func runList(cmd *cobra.Command, f *cmdutil.Factory, opts *listOptions) error {
 		defer cancel()
 
 		mine := ""
-		if opts.Mine && host.Username != "" {
-			mine = host.Username
+		if opts.Mine {
+			currentUser, err := client.CurrentUser(ctx)
+			if err != nil {
+				return fmt.Errorf("resolve current Bitbucket Cloud user for --mine: %w", err)
+			}
+			mine, err = cloudRepositoryMineIdentity(*currentUser)
+			if err != nil {
+				return err
+			}
 		}
 
 		prs, err := client.ListPullRequests(ctx, workspace, repoSlug, bbcloud.PullRequestListOptions{
@@ -345,7 +353,7 @@ func runListDashboardDC(cmd *cobra.Command, f *cmdutil.Factory, ios *iostreams.I
 
 // runListWorkspaceCloud lists pull requests for the authenticated user across all repositories (Cloud).
 func runListWorkspaceCloud(cmd *cobra.Command, f *cmdutil.Factory, ios *iostreams.IOStreams, host *config.Host, workspace string, opts *listOptions) error {
-	client, err := cmdutil.NewCloudClient(host)
+	client, err := f.CloudClient(host)
 	if err != nil {
 		return err
 	}
@@ -359,17 +367,9 @@ func runListWorkspaceCloud(cmd *cobra.Command, f *cmdutil.Factory, ios *iostream
 		return fmt.Errorf("failed to get current user: %w", err)
 	}
 
-	// Determine username for API call. Username may be empty for newer Bitbucket
-	// accounts, so fall back to AccountID, then configured host username.
-	username := currentUser.Username
-	if username == "" {
-		username = currentUser.AccountID
-	}
-	if username == "" && host.Username != "" && !strings.Contains(host.Username, "@") {
-		username = host.Username
-	}
-	if username == "" {
-		return fmt.Errorf("could not determine username; Bitbucket Cloud account may lack username field")
+	username, err := cloudWorkspaceMineIdentity(*currentUser, host)
+	if err != nil {
+		return err
 	}
 
 	prs, err := client.ListWorkspacePullRequests(ctx, workspace, username, bbcloud.WorkspacePullRequestsOptions{
@@ -415,6 +415,31 @@ func runListWorkspaceCloud(cmd *cobra.Command, f *cmdutil.Factory, ios *iostream
 		}
 		return nil
 	})
+}
+
+func cloudRepositoryMineIdentity(user bbcloud.User) (string, error) {
+	if normalized := bbcloud.NormalizeUUID(user.UUID); normalized != "" {
+		return normalized, nil
+	}
+	if accountID := strings.TrimSpace(user.AccountID); accountID != "" {
+		return accountID, nil
+	}
+	return "", fmt.Errorf("could not determine stable Bitbucket Cloud user identity for --mine; /user returned no UUID or account ID")
+}
+
+func cloudWorkspaceMineIdentity(user bbcloud.User, host *config.Host) (string, error) {
+	if username := strings.TrimSpace(user.Username); username != "" {
+		return username, nil
+	}
+	if accountID := strings.TrimSpace(user.AccountID); accountID != "" {
+		return accountID, nil
+	}
+	if host != nil {
+		if username := strings.TrimSpace(host.Username); username != "" && !strings.Contains(username, "@") {
+			return username, nil
+		}
+	}
+	return "", fmt.Errorf("could not determine username; Bitbucket Cloud account may lack username field")
 }
 
 func formatPRListUnixMilli(unixMilli int64) string {
@@ -2437,12 +2462,12 @@ func runMerge(cmd *cobra.Command, f *cmdutil.Factory, id int, opts *mergeOptions
 			return fmt.Errorf("context must supply workspace and repo; use --workspace/--repo if needed")
 		}
 
-		client, err := cmdutil.NewCloudClient(host)
+		client, err := f.CloudClient(host)
 		if err != nil {
 			return err
 		}
 
-		ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
+		ctx, cancel := context.WithTimeout(cmd.Context(), cloudMergeTimeout)
 		defer cancel()
 
 		if err := client.MergePullRequest(ctx, workspace, repoSlug, id, opts.Message, opts.Strategy, opts.CloseSource); err != nil {

--- a/pkg/cmd/pr/pr_test.go
+++ b/pkg/cmd/pr/pr_test.go
@@ -671,8 +671,8 @@ func TestListRepositoryCloudMineUsesCurrentUserUUID(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
-		switch {
-		case r.URL.Path == "/user":
+		switch r.URL.Path {
+		case "/user":
 			sawCurrentUser = true
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"uuid":        userUUID,
@@ -680,7 +680,7 @@ func TestListRepositoryCloudMineUsesCurrentUserUUID(t *testing.T) {
 				"account_id":  "557058:12345678-1234-1234-1234-123456789abc",
 				"displayName": "Actual User",
 			})
-		case r.URL.Path == "/repositories/workspace/repo1/pullrequests":
+		case "/repositories/workspace/repo1/pullrequests":
 			gotQuery = r.URL.Query().Get("q")
 			_ = json.NewEncoder(w).Encode(map[string]any{"values": []map[string]any{}})
 		default:

--- a/pkg/cmd/pr/pr_test.go
+++ b/pkg/cmd/pr/pr_test.go
@@ -652,6 +652,96 @@ func TestListRepositoryCloudIncludesCreationTimestamp(t *testing.T) {
 	}
 }
 
+func TestListRepositoryCloudMineUsesCurrentUserUUID(t *testing.T) {
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(origWd)
+	})
+
+	const userUUID = "{550e8400-e29b-41d4-a716-446655440000}"
+	var gotQuery string
+	var sawCurrentUser bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.URL.Path == "/user":
+			sawCurrentUser = true
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"uuid":        userUUID,
+				"username":    "actual-user",
+				"account_id":  "557058:12345678-1234-1234-1234-123456789abc",
+				"displayName": "Actual User",
+			})
+		case r.URL.Path == "/repositories/workspace/repo1/pullrequests":
+			gotQuery = r.URL.Query().Get("q")
+			_ = json.NewEncoder(w).Encode(map[string]any{"values": []map[string]any{}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ActiveContext: "default",
+		Contexts: map[string]*config.Context{
+			"default": {
+				Host:        "cloud",
+				Workspace:   "workspace",
+				DefaultRepo: "repo1",
+			},
+		},
+		Hosts: map[string]*config.Host{
+			"cloud": {
+				Kind:     "cloud",
+				BaseURL:  server.URL,
+				Username: "email@example.com",
+				Token:    "test-token",
+			},
+		},
+	}
+
+	stdout := &strings.Builder{}
+	stderr := &strings.Builder{}
+	f := &cmdutil.Factory{
+		AppVersion:     "test",
+		ExecutableName: "bkt",
+		IOStreams:      &iostreams.IOStreams{Out: stdout, ErrOut: stderr},
+		Config:         func() (*config.Config, error) { return cfg, nil },
+	}
+
+	cmd := newListCmd(f)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--mine"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !sawCurrentUser {
+		t.Fatal("expected --mine to resolve the current user before listing repository PRs")
+	}
+	if gotQuery != `author.uuid = "`+userUUID+`"` {
+		t.Fatalf("q = %q, want author.uuid query", gotQuery)
+	}
+}
+
+func TestCloudMergeTimeoutCoversAsyncPollBudget(t *testing.T) {
+	if cloudMergeTimeout < 5*time.Minute {
+		t.Fatalf("cloudMergeTimeout = %s, want at least 5m for async Cloud merge polling", cloudMergeTimeout)
+	}
+	if cloudMergeTimeout <= timeoutRead {
+		t.Fatalf("cloudMergeTimeout = %s, must exceed read timeout %s", cloudMergeTimeout, timeoutRead)
+	}
+}
+
 // failingWriter returns an error on every Write. It exercises the error-return
 // branches after the per-PR Fprintf calls in the list rendering paths.
 type failingWriter struct{}

--- a/pkg/cmd/repo/repo.go
+++ b/pkg/cmd/repo/repo.go
@@ -668,10 +668,15 @@ func newCreateCmd(f *cmdutil.Factory) *cobra.Command {
 		Long: `Create a new repository in a Bitbucket project (Data Center) or workspace (Cloud).
 
 On Data Center, the repository is created under the specified project with optional
-flags for visibility, forking policy, and default branch. On Cloud, the repository
-is created in the specified workspace; use --cloud-project to assign it to a
-Bitbucket Cloud project. Repositories are private by default on Cloud; pass
---public to make them public.`,
+flags for visibility, forking policy, SCM, and default branch. On Cloud, the
+repository is created in the specified workspace; use --cloud-project to assign
+it to a Bitbucket Cloud project. Repositories are private by default on Cloud;
+pass --public to make them public.
+
+Host-specific flags are validated before any API request. Data Center accepts
+--project, --forkable, --default-branch, and --scm. Cloud accepts --workspace
+and --cloud-project. Passing a flag that only applies to the other host kind
+returns an error instead of silently ignoring it.`,
 		Example: `  # Create a repository in the active context
   bkt repo create my-new-service
 
@@ -690,14 +695,14 @@ Bitbucket Cloud project. Repositories are private by default on Cloud; pass
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.Project, "project", "", "Bitbucket project key override")
-	cmd.Flags().StringVar(&opts.Workspace, "workspace", "", "Bitbucket workspace override (Cloud)")
+	cmd.Flags().StringVar(&opts.Project, "project", "", "Bitbucket Data Center project key override")
+	cmd.Flags().StringVar(&opts.Workspace, "workspace", "", "Bitbucket Cloud workspace override")
 	cmd.Flags().StringVar(&opts.CloudProject, "cloud-project", "", "Bitbucket Cloud project key")
 	cmd.Flags().StringVar(&opts.Description, "description", "", "Repository description")
 	cmd.Flags().BoolVar(&opts.Public, "public", false, "Create repository as public")
-	cmd.Flags().BoolVar(&opts.Forkable, "forkable", false, "Allow forking of the repository")
-	cmd.Flags().StringVar(&opts.DefaultBranch, "default-branch", "", "Default branch to set after creation")
-	cmd.Flags().StringVar(&opts.SCM, "scm", "git", "SCM type (git)")
+	cmd.Flags().BoolVar(&opts.Forkable, "forkable", false, "Allow forking of the Data Center repository")
+	cmd.Flags().StringVar(&opts.DefaultBranch, "default-branch", "", "Data Center default branch to set after creation")
+	cmd.Flags().StringVar(&opts.SCM, "scm", "git", "Data Center SCM type (git)")
 
 	return cmd
 }
@@ -716,6 +721,10 @@ func runCreate(cmd *cobra.Command, f *cmdutil.Factory, slug string, opts createO
 
 	switch host.Kind {
 	case "dc":
+		if err := rejectRepoCreateNoOpFlags(cmd, host.Kind); err != nil {
+			return err
+		}
+
 		projectKey := strings.TrimSpace(opts.Project)
 		if projectKey == "" {
 			projectKey = ctxCfg.ProjectKey
@@ -762,6 +771,10 @@ func runCreate(cmd *cobra.Command, f *cmdutil.Factory, slug string, opts createO
 		return nil
 
 	case "cloud":
+		if err := rejectRepoCreateNoOpFlags(cmd, host.Kind); err != nil {
+			return err
+		}
+
 		workspace := strings.TrimSpace(opts.Workspace)
 		if workspace == "" {
 			workspace = ctxCfg.Workspace
@@ -804,6 +817,32 @@ func runCreate(cmd *cobra.Command, f *cmdutil.Factory, slug string, opts createO
 	default:
 		return fmt.Errorf("unsupported host kind %q", host.Kind)
 	}
+}
+
+func rejectRepoCreateNoOpFlags(cmd *cobra.Command, hostKind string) error {
+	switch hostKind {
+	case "dc":
+		if cmd.Flags().Changed("workspace") {
+			return fmt.Errorf("--workspace is not supported for Data Center repo create; use --project")
+		}
+		if cmd.Flags().Changed("cloud-project") {
+			return fmt.Errorf("--cloud-project is not supported for Data Center repo create; use --project")
+		}
+	case "cloud":
+		if cmd.Flags().Changed("project") {
+			return fmt.Errorf("--project is not supported for Cloud repo create; use --cloud-project")
+		}
+		if cmd.Flags().Changed("forkable") {
+			return fmt.Errorf("--forkable is not supported for Cloud repo create")
+		}
+		if cmd.Flags().Changed("default-branch") {
+			return fmt.Errorf("--default-branch is not supported for Cloud repo create; set the default branch after creating the repository")
+		}
+		if cmd.Flags().Changed("scm") {
+			return fmt.Errorf("--scm is not supported for Cloud repo create; Bitbucket Cloud repositories use git")
+		}
+	}
+	return nil
 }
 
 func newCloneCmd(f *cmdutil.Factory) *cobra.Command {

--- a/pkg/cmd/repo/repo_test.go
+++ b/pkg/cmd/repo/repo_test.go
@@ -1,6 +1,10 @@
 package repo
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -122,5 +126,118 @@ func TestBrowseWithoutRepoDefaults(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "repository required") {
 		t.Fatalf("expected error to mention repository requirement, got %q", err.Error())
+	}
+}
+
+func TestRepoCreateRejectsHostNoOpFlags(t *testing.T) {
+	tests := []struct {
+		name          string
+		hostKind      string
+		args          []string
+		errorContains string
+	}{
+		{
+			name:          "cloud rejects project",
+			hostKind:      "cloud",
+			args:          []string{"service", "--project", "DATA"},
+			errorContains: "--project is not supported for Cloud repo create",
+		},
+		{
+			name:          "cloud rejects forkable",
+			hostKind:      "cloud",
+			args:          []string{"service", "--forkable"},
+			errorContains: "--forkable is not supported for Cloud repo create",
+		},
+		{
+			name:          "cloud rejects default branch",
+			hostKind:      "cloud",
+			args:          []string{"service", "--default-branch", "main"},
+			errorContains: "--default-branch is not supported for Cloud repo create",
+		},
+		{
+			name:          "cloud rejects explicit scm",
+			hostKind:      "cloud",
+			args:          []string{"service", "--scm", "git"},
+			errorContains: "--scm is not supported for Cloud repo create",
+		},
+		{
+			name:          "data center rejects workspace",
+			hostKind:      "dc",
+			args:          []string{"service", "--workspace", "team"},
+			errorContains: "--workspace is not supported for Data Center repo create",
+		},
+		{
+			name:          "data center rejects cloud project",
+			hostKind:      "dc",
+			args:          []string{"service", "--cloud-project", "WEB"},
+			errorContains: "--cloud-project is not supported for Data Center repo create",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var hits int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				hits++
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"slug": "service",
+					"name": "service",
+					"project": map[string]any{
+						"key": "PROJ",
+					},
+				})
+			}))
+			t.Cleanup(server.Close)
+
+			cfg := &config.Config{
+				ActiveContext: "default",
+				Contexts: map[string]*config.Context{
+					"default": {
+						Host:        "main",
+						ProjectKey:  "PROJ",
+						Workspace:   "workspace",
+						DefaultRepo: "repo",
+					},
+				},
+				Hosts: map[string]*config.Host{
+					"main": {
+						Kind:    tt.hostKind,
+						BaseURL: server.URL,
+						Token:   "test-token",
+					},
+				},
+			}
+
+			var stdout, stderr strings.Builder
+			f := &cmdutil.Factory{
+				AppVersion:     "test",
+				ExecutableName: "bkt",
+				IOStreams: &iostreams.IOStreams{
+					Out:    &stdout,
+					ErrOut: &stderr,
+				},
+				Config: func() (*config.Config, error) {
+					return cfg, nil
+				},
+			}
+
+			cmd := newCreateCmd(f)
+			cmd.SetContext(context.Background())
+			cmd.SilenceErrors = true
+			cmd.SilenceUsage = true
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.errorContains)
+			}
+			if !strings.Contains(err.Error(), tt.errorContains) {
+				t.Fatalf("error = %q, want substring %q", err, tt.errorContains)
+			}
+			if hits != 0 {
+				t.Fatalf("expected validation to avoid HTTP requests, got %d", hits)
+			}
+		})
 	}
 }

--- a/skills/bkt/rules/repo.md
+++ b/skills/bkt/rules/repo.md
@@ -127,10 +127,15 @@ bkt repo clone <repository> [flags]
 Create a new repository in a Bitbucket project (Data Center) or workspace (Cloud).
 
 On Data Center, the repository is created under the specified project with optional
-flags for visibility, forking policy, and default branch. On Cloud, the repository
-is created in the specified workspace; use --cloud-project to assign it to a
-Bitbucket Cloud project. Repositories are private by default on Cloud; pass
---public to make them public.
+flags for visibility, forking policy, SCM, and default branch. On Cloud, the
+repository is created in the specified workspace; use --cloud-project to assign
+it to a Bitbucket Cloud project. Repositories are private by default on Cloud;
+pass --public to make them public.
+
+Host-specific flags are validated before any API request. Data Center accepts
+--project, --forkable, --default-branch, and --scm. Cloud accepts --workspace
+and --cloud-project. Passing a flag that only applies to the other host kind
+returns an error instead of silently ignoring it.
 
 ### Usage
 
@@ -143,13 +148,13 @@ bkt repo create <repository> [flags]
 | Flag | Short | Description |
 |---|---|---|
 | `--cloud-project` |  | Bitbucket Cloud project key |
-| `--default-branch` |  | Default branch to set after creation |
+| `--default-branch` |  | Data Center default branch to set after creation |
 | `--description` |  | Repository description |
-| `--forkable` |  | Allow forking of the repository |
-| `--project` |  | Bitbucket project key override |
+| `--forkable` |  | Allow forking of the Data Center repository |
+| `--project` |  | Bitbucket Data Center project key override |
 | `--public` |  | Create repository as public |
-| `--scm` |  | SCM type (git) |
-| `--workspace` |  | Bitbucket workspace override (Cloud) |
+| `--scm` |  | Data Center SCM type (git) |
+| `--workspace` |  | Bitbucket Cloud workspace override |
 
 ### Inherited Flags
 


### PR DESCRIPTION
## Summary
- Fixes several P0 correctness issues surfaced by the ChatGPT-Pro project review: Data Center branch creation from commit SHAs, Cloud pipeline variable UUID validation, Cloud pipeline step pagination, Cloud async merge timeout/error reporting, Cloud `pr list --mine` identity filtering, and host-specific `repo create` flag validation.
- Updates README, generated `bkt repo` skill docs, and the `[Unreleased]` changelog.
- Leaves the Data Center default-reviewers API shape fix out of this batch; it is tracked separately as follow-up task #11 / P0-6.

## Testing
- `make fmt`
- `go test ./...`
- `go vet ./...`
- `make build`
- `./scripts/check-generated-skill.sh`
- `go test -count=20 ./pkg/bbcloud`
- `git diff --check`
- `git diff --staged --check`