### PR TITLE
fix: call Data Center default-reviewers API with repo IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ All notable changes to this project will be documented here. The format follows
   `--forkable`, `--default-branch`, `--scm`, and `--project` on Cloud or
   `--workspace` and `--cloud-project` on Data Center, instead of silently
   ignoring them.
+- `bkt pr create --with-default-reviewers`, `bkt pr edit --with-default-reviewers`,
+  and Data Center `bkt repo default-reviewers list --source/--target` now call
+  the effective default reviewers API with repository IDs and branch/tag refs,
+  and decode the direct user response returned by Bitbucket Data Center.
 
 ## [0.28.0] - 2026-05-30
 ### Added

--- a/pkg/bbdc/reviewers.go
+++ b/pkg/bbdc/reviewers.go
@@ -13,31 +13,6 @@ type ReviewerGroup struct {
 	ID   int    `json:"id"`
 }
 
-type defaultReviewerCondition struct {
-	ID                int                       `json:"id"`
-	SourceRefMatcher  defaultReviewerRefMatcher `json:"sourceRefMatcher"`
-	TargetRefMatcher  defaultReviewerRefMatcher `json:"targetRefMatcher"`
-	Reviewers         []defaultReviewerGroup    `json:"reviewers"`
-	ReviewerGroups    []defaultReviewerGroup    `json:"reviewerGroups"`
-	RequiredApprovals int                       `json:"requiredApprovals"`
-}
-
-type defaultReviewerRefMatcher struct {
-	ID        string `json:"id"`
-	DisplayID string `json:"displayId"`
-	Type      struct {
-		ID   string `json:"id"`
-		Name string `json:"name"`
-	} `json:"type"`
-}
-
-type defaultReviewerGroup struct {
-	ID          int64  `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Users       []User `json:"users"`
-}
-
 // ListReviewerGroups returns reviewer groups associated with a repository's default reviewers.
 func (c *Client) ListReviewerGroups(ctx context.Context, projectKey, repoSlug string) ([]ReviewerGroup, error) {
 	if projectKey == "" || repoSlug == "" {
@@ -68,6 +43,16 @@ func (c *Client) GetDefaultReviewers(ctx context.Context, projectKey, repoSlug, 
 	if projectKey == "" || repoSlug == "" {
 		return nil, fmt.Errorf("project key and repository slug are required")
 	}
+	sourceRef = strings.TrimSpace(sourceRef)
+	targetRef = strings.TrimSpace(targetRef)
+	if sourceRef == "" || targetRef == "" {
+		return nil, fmt.Errorf("source and target refs are required")
+	}
+
+	repo, err := c.GetRepository(ctx, projectKey, repoSlug)
+	if err != nil {
+		return nil, fmt.Errorf("fetch repository: %w", err)
+	}
 
 	endpoint := fmt.Sprintf("/rest/default-reviewers/1.0/projects/%s/repos/%s/reviewers",
 		url.PathEscape(projectKey),
@@ -75,40 +60,20 @@ func (c *Client) GetDefaultReviewers(ctx context.Context, projectKey, repoSlug, 
 	)
 
 	params := url.Values{}
-	if sourceRef != "" {
-		params.Set("sourceRefId", normalizeRefID(sourceRef))
-	}
-	if targetRef != "" {
-		params.Set("targetRefId", normalizeRefID(targetRef))
-	}
-	if len(params) > 0 {
-		endpoint += "?" + params.Encode()
-	}
+	params.Set("sourceRepoId", fmt.Sprintf("%d", repo.ID))
+	params.Set("targetRepoId", fmt.Sprintf("%d", repo.ID))
+	params.Set("sourceRefId", defaultReviewerRefID(sourceRef))
+	params.Set("targetRefId", defaultReviewerRefID(targetRef))
+	endpoint += "?" + params.Encode()
 
 	req, err := c.http.NewRequest(ctx, "GET", endpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create default reviewers request: %w", err)
 	}
 
-	var conditions []defaultReviewerCondition
-	if err := c.http.Do(req, &conditions); err != nil {
+	var reviewers []User
+	if err := c.http.Do(req, &reviewers); err != nil {
 		return nil, fmt.Errorf("fetch default reviewers: %w", err)
-	}
-
-	reviewers := make([]User, 0)
-	seen := make(map[string]struct{})
-	for _, condition := range conditions {
-		groups := append([]defaultReviewerGroup{}, condition.Reviewers...)
-		groups = append(groups, condition.ReviewerGroups...)
-		for _, group := range groups {
-			for _, user := range group.Users {
-				if _, ok := seen[user.Name]; ok {
-					continue
-				}
-				seen[user.Name] = struct{}{}
-				reviewers = append(reviewers, user)
-			}
-		}
 	}
 
 	return reviewers, nil
@@ -152,9 +117,8 @@ func (c *Client) RemoveReviewerGroup(ctx context.Context, projectKey, repoSlug, 
 	return c.http.Do(req, nil)
 }
 
-func normalizeRefID(ref string) string {
-	if strings.HasPrefix(ref, "refs/") {
-		return ref
-	}
-	return "refs/heads/" + ref
+func defaultReviewerRefID(ref string) string {
+	ref = strings.TrimPrefix(ref, "refs/heads/")
+	ref = strings.TrimPrefix(ref, "refs/tags/")
+	return ref
 }

--- a/pkg/bbdc/reviewers_test.go
+++ b/pkg/bbdc/reviewers_test.go
@@ -4,110 +4,113 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/avivsinai/bitbucket-cli/pkg/bbdc"
 )
 
-func TestGetDefaultReviewers(t *testing.T) {
-	var gotMethod, gotPath, gotQuery string
+func TestGetDefaultReviewersDataCenter75(t *testing.T) {
+	var requests []string
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotMethod = r.Method
-		gotPath = r.URL.Path
-		gotQuery = r.URL.RawQuery
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]map[string]any{
-			{
-				"id": 1,
-				"sourceRefMatcher": map[string]any{
-					"id":        "refs/heads/feature/x",
-					"displayId": "feature/x",
-				},
-				"targetRefMatcher": map[string]any{
-					"id":        "refs/heads/main",
-					"displayId": "main",
-				},
-				"requiredApprovals": 1,
-				"reviewers": []map[string]any{
-					{
-						"id":   101,
-						"name": "backend-team",
-						"users": []map[string]any{
-							{"name": "alice", "slug": "alice", "id": 10, "displayName": "Alice"},
-							{"name": "bob", "slug": "bob", "id": 20, "displayName": "Bob"},
-						},
-					},
-				},
-			},
-		})
+		requests = append(requests, r.Method+" "+r.URL.Path)
+
+		switch r.URL.Path {
+		case "/rest/api/1.0/projects/PROJ/repos/my-repo":
+			if r.Method != http.MethodGet {
+				t.Fatalf("repository method = %s, want GET", r.Method)
+			}
+			_ = json.NewEncoder(w).Encode(bbdc.Repository{Slug: "my-repo", ID: 42})
+		case "/rest/default-reviewers/1.0/projects/PROJ/repos/my-repo/reviewers":
+			if r.Method != http.MethodGet {
+				t.Fatalf("reviewers method = %s, want GET", r.Method)
+			}
+			query := r.URL.Query()
+			wantQuery := map[string]string{
+				"sourceRepoId": "42",
+				"targetRepoId": "42",
+				"sourceRefId":  "feature/x",
+				"targetRefId":  "main",
+			}
+			for key, want := range wantQuery {
+				if got := query.Get(key); got != want {
+					t.Fatalf("%s = %q, want %q", key, got, want)
+				}
+			}
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"name": "alice", "slug": "alice", "id": 10, "displayName": "Alice"},
+				{"name": "bob", "slug": "bob", "id": 20, "displayName": "Bob"},
+			})
+		default:
+			http.NotFound(w, r)
+		}
 	}))
 
 	users, err := client.GetDefaultReviewers(context.Background(), "PROJ", "my-repo", "feature/x", "main")
 	if err != nil {
 		t.Fatalf("GetDefaultReviewers: %v", err)
 	}
-	if gotMethod != "GET" {
-		t.Errorf("method = %s, want GET", gotMethod)
+	wantRequests := []string{
+		"GET /rest/api/1.0/projects/PROJ/repos/my-repo",
+		"GET /rest/default-reviewers/1.0/projects/PROJ/repos/my-repo/reviewers",
 	}
-	if gotPath != "/rest/default-reviewers/1.0/projects/PROJ/repos/my-repo/reviewers" {
-		t.Errorf("path = %q, want /rest/default-reviewers/1.0/projects/PROJ/repos/my-repo/reviewers", gotPath)
-	}
-	if gotQuery != "sourceRefId=refs%2Fheads%2Ffeature%2Fx&targetRefId=refs%2Fheads%2Fmain" {
-		t.Errorf("query = %q, want sourceRefId=refs%%2Fheads%%2Ffeature%%2Fx&targetRefId=refs%%2Fheads%%2Fmain", gotQuery)
+	if !reflect.DeepEqual(requests, wantRequests) {
+		t.Fatalf("requests = %v, want %v", requests, wantRequests)
 	}
 	if len(users) != 2 {
 		t.Fatalf("expected 2 users, got %d", len(users))
 	}
-	if users[0].Name != "alice" {
-		t.Errorf("users[0].Name = %q, want alice", users[0].Name)
-	}
-	if users[1].Name != "bob" {
-		t.Errorf("users[1].Name = %q, want bob", users[1].Name)
+	if got := []string{users[0].Name, users[1].Name}; !reflect.DeepEqual(got, []string{"alice", "bob"}) {
+		t.Fatalf("users = %v, want [alice bob]", got)
 	}
 }
 
-func TestGetDefaultReviewersDedup(t *testing.T) {
+func TestGetDefaultReviewersDataCenter8BranchAndTagRefs(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]map[string]any{
-			{
-				"id": 1,
-				"reviewers": []map[string]any{
-					{
-						"id":   101,
-						"name": "backend-team",
-						"users": []map[string]any{
-							{"name": "alice", "slug": "alice", "id": 10},
-							{"name": "bob", "slug": "bob", "id": 20},
-						},
-					},
+		switch r.URL.Path {
+		case "/rest/api/1.0/projects/PROJ/repos/my-repo":
+			_ = json.NewEncoder(w).Encode(bbdc.Repository{Slug: "my-repo", ID: 99})
+		case "/rest/default-reviewers/1.0/projects/PROJ/repos/my-repo/reviewers":
+			query := r.URL.Query()
+			if got := query.Get("sourceRefId"); got != "feature/auth" {
+				t.Fatalf("sourceRefId = %q, want feature/auth", got)
+			}
+			if got := query.Get("targetRefId"); got != "v1.2.3" {
+				t.Fatalf("targetRefId = %q, want v1.2.3", got)
+			}
+			if got := query.Get("sourceRepoId"); got != "99" {
+				t.Fatalf("sourceRepoId = %q, want 99", got)
+			}
+			if got := query.Get("targetRepoId"); got != "99" {
+				t.Fatalf("targetRepoId = %q, want 99", got)
+			}
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"name":         "charlie",
+					"slug":         "charlie",
+					"id":           30,
+					"displayName":  "Charlie",
+					"emailAddress": "charlie@example.com",
+					"active":       true,
+					"type":         "NORMAL",
 				},
-			},
-			{
-				"id": 2,
-				"reviewers": []map[string]any{
-					{
-						"id":   102,
-						"name": "frontend-team",
-						"users": []map[string]any{
-							{"name": "alice", "slug": "alice", "id": 10},
-							{"name": "charlie", "slug": "charlie", "id": 30},
-						},
-					},
-				},
-			},
-		})
+			})
+		default:
+			http.NotFound(w, r)
+		}
 	}))
 
-	users, err := client.GetDefaultReviewers(context.Background(), "PROJ", "my-repo", "feature/x", "main")
+	users, err := client.GetDefaultReviewers(context.Background(), "PROJ", "my-repo", "refs/heads/feature/auth", "refs/tags/v1.2.3")
 	if err != nil {
 		t.Fatalf("GetDefaultReviewers: %v", err)
 	}
-	if len(users) != 3 {
-		t.Fatalf("expected 3 users, got %d", len(users))
+	if len(users) != 1 {
+		t.Fatalf("expected 1 user, got %d", len(users))
 	}
-	if users[0].Name != "alice" || users[1].Name != "bob" || users[2].Name != "charlie" {
-		t.Fatalf("unexpected user order/content: %#v", users)
+	if users[0].Name != "charlie" || users[0].Email != "charlie@example.com" || !users[0].Active {
+		t.Fatalf("unexpected user: %#v", users[0])
 	}
 }
 
@@ -123,14 +126,20 @@ func TestGetDefaultReviewersValidation(t *testing.T) {
 		name    string
 		project string
 		repo    string
+		source  string
+		target  string
 	}{
-		{name: "empty project", project: "", repo: "repo"},
-		{name: "empty repo", project: "PROJ", repo: ""},
+		{name: "empty project", project: "", repo: "repo", source: "feature/x", target: "main"},
+		{name: "empty repo", project: "PROJ", repo: "", source: "feature/x", target: "main"},
+		{name: "empty source", project: "PROJ", repo: "repo", source: "", target: "main"},
+		{name: "empty target", project: "PROJ", repo: "repo", source: "feature/x", target: ""},
+		{name: "blank source", project: "PROJ", repo: "repo", source: " ", target: "main"},
+		{name: "blank target", project: "PROJ", repo: "repo", source: "feature/x", target: " "},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.GetDefaultReviewers(context.Background(), tt.project, tt.repo, "feature/x", "main")
+			_, err := client.GetDefaultReviewers(context.Background(), tt.project, tt.repo, tt.source, tt.target)
 			if err == nil {
 				t.Error("expected error")
 			}

--- a/pkg/cmd/pr/pr_test.go
+++ b/pkg/cmd/pr/pr_test.go
@@ -3530,20 +3530,24 @@ func TestRunEditDataCenterReviewers(t *testing.T) {
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
+				if r.Method == "GET" && r.URL.Path == "/rest/api/1.0/projects/PROJ/repos/repo" {
+					_ = json.NewEncoder(w).Encode(bbdc.Repository{Slug: "repo", ID: 77})
+					return
+				}
 				if r.Method == "GET" && strings.Contains(r.URL.Path, "/default-reviewers/") {
-					if got := r.URL.Query().Get("sourceRefId"); got != "refs/heads/feature/auth" {
-						t.Fatalf("sourceRefId = %q, want refs/heads/feature/auth", got)
+					if got := r.URL.Query().Get("sourceRepoId"); got != "77" {
+						t.Fatalf("sourceRepoId = %q, want 77", got)
 					}
-					if got := r.URL.Query().Get("targetRefId"); got != "refs/heads/main" {
-						t.Fatalf("targetRefId = %q, want refs/heads/main", got)
+					if got := r.URL.Query().Get("targetRepoId"); got != "77" {
+						t.Fatalf("targetRepoId = %q, want 77", got)
 					}
-					_ = json.NewEncoder(w).Encode([]map[string]any{
-						{
-							"reviewers": []map[string]any{
-								{"users": tt.defaultUsers},
-							},
-						},
-					})
+					if got := r.URL.Query().Get("sourceRefId"); got != "feature/auth" {
+						t.Fatalf("sourceRefId = %q, want feature/auth", got)
+					}
+					if got := r.URL.Query().Get("targetRefId"); got != "main" {
+						t.Fatalf("targetRefId = %q, want main", got)
+					}
+					_ = json.NewEncoder(w).Encode(tt.defaultUsers)
 					return
 				}
 				if r.Method == "GET" {
@@ -4941,6 +4945,83 @@ func TestRunCreateDataCenter(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestRunCreateDataCenterWithDefaultReviewers(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/rest/api/1.0/projects/PROJ/repos/repo":
+			_ = json.NewEncoder(w).Encode(bbdc.Repository{Slug: "repo", ID: 456})
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/default-reviewers/"):
+			query := r.URL.Query()
+			if got := query.Get("sourceRepoId"); got != "456" {
+				t.Fatalf("sourceRepoId = %q, want 456", got)
+			}
+			if got := query.Get("targetRepoId"); got != "456" {
+				t.Fatalf("targetRepoId = %q, want 456", got)
+			}
+			if got := query.Get("sourceRefId"); got != "feature/auth" {
+				t.Fatalf("sourceRefId = %q, want feature/auth", got)
+			}
+			if got := query.Get("targetRefId"); got != "main" {
+				t.Fatalf("targetRefId = %q, want main", got)
+			}
+			_ = json.NewEncoder(w).Encode([]bbdc.User{
+				{Name: "alice"},
+				{Name: "bob"},
+			})
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "/pull-requests"):
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+			_ = json.NewEncoder(w).Encode(bbdc.PullRequest{ID: 42, Title: "Test PR"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ActiveContext: "default",
+		Contexts: map[string]*config.Context{
+			"default": {Host: "main", ProjectKey: "PROJ", DefaultRepo: "repo"},
+		},
+		Hosts: map[string]*config.Host{
+			"main": {Kind: "dc", BaseURL: server.URL, Username: "testuser", Token: "test-token"},
+		},
+	}
+
+	f := &cmdutil.Factory{
+		AppVersion:     "test",
+		ExecutableName: "bkt",
+		IOStreams:      &iostreams.IOStreams{Out: &strings.Builder{}, ErrOut: &strings.Builder{}},
+		Config:         func() (*config.Config, error) { return cfg, nil },
+	}
+
+	cmd := newCreateCmd(f)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--title", "Test PR", "--source", "feature/auth", "--target", "main", "--with-default-reviewers"})
+	cmd.SetContext(context.Background())
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	reviewers, ok := gotBody["reviewers"].([]any)
+	if !ok {
+		t.Fatalf("reviewers not found or wrong type in POST body")
+	}
+	if len(reviewers) != 2 {
+		t.Fatalf("expected 2 reviewers, got %d", len(reviewers))
+	}
+	for i, want := range []string{"alice", "bob"} {
+		reviewer := reviewers[i].(map[string]any)
+		user := reviewer["user"].(map[string]any)
+		if got := user["name"]; got != want {
+			t.Fatalf("reviewer[%d] name = %v, want %s", i, got, want)
+		}
 	}
 }
 

--- a/pkg/cmd/repo/defaultreviewers.go
+++ b/pkg/cmd/repo/defaultreviewers.go
@@ -3,6 +3,7 @@ package repo
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -14,6 +15,8 @@ type defaultReviewersOptions struct {
 	Workspace string
 	Project   string
 	Repo      string
+	Source    string
+	Target    string
 }
 
 func newDefaultReviewersCmd(f *cmdutil.Factory) *cobra.Command {
@@ -23,8 +26,8 @@ func newDefaultReviewersCmd(f *cmdutil.Factory) *cobra.Command {
 		Long: `Manage default reviewers configured for a repository.
 
 On Cloud, returns the effective default reviewers (merged from workspace and
-repository-level settings). On Data Center, returns the default reviewers
-configured at the repository level within the project.`,
+repository-level settings). On Data Center, returns the effective default
+reviewers for a pull request from --source to --target.`,
 	}
 	cmd.AddCommand(newDefaultReviewersListCmd(f))
 	return cmd
@@ -39,8 +42,9 @@ func newDefaultReviewersListCmd(f *cmdutil.Factory) *cobra.Command {
 
 On Cloud, this returns the effective default reviewers that would be automatically
 added to new pull requests, including reviewers inherited from workspace-level
-settings. On Data Center, this returns the default reviewer conditions set at the
-repository level within the project.
+settings. On Data Center, this returns the effective default reviewers that would
+be added to a pull request from --source to --target. Data Center requires
+source and target branch or tag names.
 
 The workspace/project and repository are resolved from the active context unless
 overridden with flags.`,
@@ -51,7 +55,7 @@ overridden with flags.`,
   bkt repo default-reviewers list --workspace my-team --repo api-service
 
   # List default reviewers for a Data Center repository
-  bkt repo default-reviewers list --project PLATFORM --repo backend`,
+  bkt repo default-reviewers list --project PLATFORM --repo backend --source feature/auth --target main`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDefaultReviewersList(cmd, f, opts)
 		},
@@ -59,6 +63,8 @@ overridden with flags.`,
 	cmd.Flags().StringVar(&opts.Workspace, "workspace", "", "Bitbucket Cloud workspace override")
 	cmd.Flags().StringVar(&opts.Project, "project", "", "Bitbucket project key override")
 	cmd.Flags().StringVar(&opts.Repo, "repo", "", "Repository slug override")
+	cmd.Flags().StringVar(&opts.Source, "source", "", "Data Center source branch or tag")
+	cmd.Flags().StringVar(&opts.Target, "target", "", "Data Center target branch or tag")
 	return cmd
 }
 
@@ -76,6 +82,9 @@ func runDefaultReviewersList(cmd *cobra.Command, f *cmdutil.Factory, opts *defau
 
 	switch host.Kind {
 	case "cloud":
+		if cmd.Flags().Changed("source") || cmd.Flags().Changed("target") {
+			return fmt.Errorf("--source and --target are only supported for Data Center default reviewer lookup")
+		}
 		workspace := cmdutil.FirstNonEmpty(opts.Workspace, ctxCfg.Workspace)
 		repoSlug := cmdutil.FirstNonEmpty(opts.Repo, ctxCfg.DefaultRepo)
 		if workspace == "" || repoSlug == "" {
@@ -142,6 +151,11 @@ func runDefaultReviewersList(cmd *cobra.Command, f *cmdutil.Factory, opts *defau
 		if projectKey == "" || repoSlug == "" {
 			return fmt.Errorf("context must supply project and repo; use --project/--repo if needed")
 		}
+		sourceRef := strings.TrimSpace(opts.Source)
+		targetRef := strings.TrimSpace(opts.Target)
+		if sourceRef == "" || targetRef == "" {
+			return fmt.Errorf("data center default reviewers require --source and --target refs")
+		}
 
 		client, err := cmdutil.NewDCClient(host)
 		if err != nil {
@@ -151,7 +165,7 @@ func runDefaultReviewersList(cmd *cobra.Command, f *cmdutil.Factory, opts *defau
 		ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
 		defer cancel()
 
-		users, err := client.GetDefaultReviewers(ctx, projectKey, repoSlug, "", "")
+		users, err := client.GetDefaultReviewers(ctx, projectKey, repoSlug, sourceRef, targetRef)
 		if err != nil {
 			return err
 		}
@@ -174,10 +188,14 @@ func runDefaultReviewersList(cmd *cobra.Command, f *cmdutil.Factory, opts *defau
 		payload := struct {
 			Project   string            `json:"project"`
 			Repo      string            `json:"repo"`
+			Source    string            `json:"source"`
+			Target    string            `json:"target"`
 			Reviewers []reviewerSummary `json:"reviewers"`
 		}{
 			Project:   projectKey,
 			Repo:      repoSlug,
+			Source:    sourceRef,
+			Target:    targetRef,
 			Reviewers: summaries,
 		}
 

--- a/pkg/cmd/repo/repo_test.go
+++ b/pkg/cmd/repo/repo_test.go
@@ -129,6 +129,140 @@ func TestBrowseWithoutRepoDefaults(t *testing.T) {
 	}
 }
 
+func TestDefaultReviewersListDataCenterRequiresRefs(t *testing.T) {
+	cfg := &config.Config{
+		ActiveContext: "default",
+		Contexts: map[string]*config.Context{
+			"default": {Host: "main", ProjectKey: "PROJ", DefaultRepo: "repo"},
+		},
+		Hosts: map[string]*config.Host{
+			"main": {Kind: "dc", BaseURL: "https://bitbucket.example.com", Token: "test-token"},
+		},
+	}
+
+	f := &cmdutil.Factory{
+		AppVersion:     "test",
+		ExecutableName: "bkt",
+		IOStreams:      &iostreams.IOStreams{Out: &strings.Builder{}, ErrOut: &strings.Builder{}},
+		Config: func() (*config.Config, error) {
+			return cfg, nil
+		},
+	}
+
+	cmd := newDefaultReviewersListCmd(f)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when Data Center source/target refs are missing")
+	}
+	if !strings.Contains(err.Error(), "data center default reviewers require --source and --target refs") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDefaultReviewersListDataCenterUsesEffectiveReviewersEndpoint(t *testing.T) {
+	var sawReviewersRequest bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/rest/api/1.0/projects/PROJ/repos/repo":
+			_ = json.NewEncoder(w).Encode(bbdc.Repository{Slug: "repo", ID: 123})
+		case "/rest/default-reviewers/1.0/projects/PROJ/repos/repo/reviewers":
+			sawReviewersRequest = true
+			query := r.URL.Query()
+			if got := query.Get("sourceRepoId"); got != "123" {
+				t.Fatalf("sourceRepoId = %q, want 123", got)
+			}
+			if got := query.Get("targetRepoId"); got != "123" {
+				t.Fatalf("targetRepoId = %q, want 123", got)
+			}
+			if got := query.Get("sourceRefId"); got != "feature/auth" {
+				t.Fatalf("sourceRefId = %q, want feature/auth", got)
+			}
+			if got := query.Get("targetRefId"); got != "main" {
+				t.Fatalf("targetRefId = %q, want main", got)
+			}
+			_ = json.NewEncoder(w).Encode([]bbdc.User{
+				{Name: "alice", FullName: "Alice", ID: 7},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	cfg := &config.Config{
+		ActiveContext: "default",
+		Contexts: map[string]*config.Context{
+			"default": {Host: "main", ProjectKey: "PROJ", DefaultRepo: "repo"},
+		},
+		Hosts: map[string]*config.Host{
+			"main": {Kind: "dc", BaseURL: server.URL, Token: "test-token"},
+		},
+	}
+
+	stdout := &strings.Builder{}
+	f := &cmdutil.Factory{
+		AppVersion:     "test",
+		ExecutableName: "bkt",
+		IOStreams:      &iostreams.IOStreams{Out: stdout, ErrOut: &strings.Builder{}},
+		Config: func() (*config.Config, error) {
+			return cfg, nil
+		},
+	}
+
+	cmd := newDefaultReviewersListCmd(f)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--source", "refs/heads/feature/auth", "--target", "main"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !sawReviewersRequest {
+		t.Fatal("expected default reviewers request")
+	}
+	if !strings.Contains(stdout.String(), "Alice") || !strings.Contains(stdout.String(), "alice") {
+		t.Fatalf("expected reviewer output, got %q", stdout.String())
+	}
+}
+
+func TestDefaultReviewersListCloudRejectsRefFlags(t *testing.T) {
+	cfg := &config.Config{
+		ActiveContext: "default",
+		Contexts: map[string]*config.Context{
+			"default": {Host: "main", Workspace: "ws", DefaultRepo: "repo"},
+		},
+		Hosts: map[string]*config.Host{
+			"main": {Kind: "cloud", BaseURL: "https://api.bitbucket.org/2.0", Token: "test-token"},
+		},
+	}
+
+	f := &cmdutil.Factory{
+		AppVersion:     "test",
+		ExecutableName: "bkt",
+		IOStreams:      &iostreams.IOStreams{Out: &strings.Builder{}, ErrOut: &strings.Builder{}},
+		Config: func() (*config.Config, error) {
+			return cfg, nil
+		},
+	}
+
+	cmd := newDefaultReviewersListCmd(f)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--source", "feature", "--target", "main"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when Cloud source/target refs are provided")
+	}
+	if !strings.Contains(err.Error(), "--source and --target are only supported for Data Center") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestRepoCreateRejectsHostNoOpFlags(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/skills/bkt/rules/repo.md
+++ b/skills/bkt/rules/repo.md
@@ -188,8 +188,8 @@ bkt repo create <repository> [flags]
 Manage default reviewers configured for a repository.
 
 On Cloud, returns the effective default reviewers (merged from workspace and
-repository-level settings). On Data Center, returns the default reviewers
-configured at the repository level within the project.
+repository-level settings). On Data Center, returns the effective default
+reviewers for a pull request from --source to --target.
 
 ```
 bkt repo default-reviewers <command> [flags]
@@ -205,8 +205,9 @@ List the default reviewers configured for a repository.
 
 On Cloud, this returns the effective default reviewers that would be automatically
 added to new pull requests, including reviewers inherited from workspace-level
-settings. On Data Center, this returns the default reviewer conditions set at the
-repository level within the project.
+settings. On Data Center, this returns the effective default reviewers that would
+be added to a pull request from --source to --target. Data Center requires
+source and target branch or tag names.
 
 The workspace/project and repository are resolved from the active context unless
 overridden with flags.
@@ -223,6 +224,8 @@ bkt repo default-reviewers list [flags]
 |---|---|---|
 | `--project` |  | Bitbucket project key override |
 | `--repo` |  | Repository slug override |
+| `--source` |  | Data Center source branch or tag |
+| `--target` |  | Data Center target branch or tag |
 | `--workspace` |  | Bitbucket Cloud workspace override |
 
 ### Inherited Flags
@@ -246,7 +249,7 @@ bkt repo default-reviewers list [flags]
   bkt repo default-reviewers list --workspace my-team --repo api-service
 
   # List default reviewers for a Data Center repository
-  bkt repo default-reviewers list --project PLATFORM --repo backend
+  bkt repo default-reviewers list --project PLATFORM --repo backend --source feature/auth --target main
 ```
 
 ## bkt repo list


### PR DESCRIPTION
## Summary
- Fetch the Data Center repository before resolving effective default reviewers so `sourceRepoId` and `targetRepoId` are sent with the repository ID.
- Send Data Center default-reviewer refs as branch/tag names, decode the endpoint's direct `[]User` response, and remove the old condition-flattening path.
- Require and document `--source`/`--target` for Data Center `bkt repo default-reviewers list`, reject those flags on Cloud, and regenerate `skills/bkt/rules/repo.md`.

## Sources
- Bitbucket Server 7.5 default-reviewers REST docs: https://docs.atlassian.com/bitbucket-server/rest/7.5.0/bitbucket-default-reviewers-rest.html
- Bitbucket Data Center 8.x NoSuchBranchException KB: https://support.atlassian.com/bitbucket-data-center/kb/get-default-reviewers-api-in-bitbucket-datacenter-fails-with-nosuchbranchexception/

## Testing
- `make lint`
- `go test ./...`
- `go vet ./...`
- `make check-generated-skill`
- `make build`
- `git diff --check`
