### PR TITLE
fix(cloud): surface when a threaded reply was not threaded (#228)

### DIFF
--- a/pkg/bbcloud/pullrequests.go
+++ b/pkg/bbcloud/pullrequests.go
@@ -450,7 +450,27 @@ func (c *Client) CommentPullRequest(ctx context.Context, workspace, repoSlug str
 		return err
 	}
 
-	return c.http.Do(req, nil)
+	// Capture the created comment so a requested threaded reply can be
+	// verified. Bitbucket Cloud echoes the created representation, including
+	// parent.id, on a successful POST.
+	var created PullRequestComment
+	if err := c.http.Do(req, &created); err != nil {
+		return err
+	}
+
+	// Only verify threading when a reply was requested and Bitbucket actually
+	// returned a parseable body (created.ID != 0). Some responses (and test
+	// stubs) return a 2xx with an empty body, which is still a success.
+	if opts.ParentID > 0 && created.ID != 0 {
+		if created.Parent == nil || created.Parent.ID != opts.ParentID {
+			return fmt.Errorf(
+				"comment created (id %d) but Bitbucket did not thread it under parent %d; the parent may not be a valid reply target (e.g. resolved, deleted, or a comment that does not accept replies) — delete the stray comment or retry against a top-level comment",
+				created.ID, opts.ParentID,
+			)
+		}
+	}
+
+	return nil
 }
 
 // PullRequestDiff streams the unified diff for the given pull request into w.

--- a/pkg/bbcloud/pullrequests_test.go
+++ b/pkg/bbcloud/pullrequests_test.go
@@ -452,6 +452,92 @@ func TestCommentPullRequestWithoutParent(t *testing.T) {
 	}
 }
 
+func TestCommentPullRequestParentThreadingVerification(t *testing.T) {
+	tests := []struct {
+		name         string
+		parentID     int
+		responseBody string
+		wantErr      bool
+		wantErrParts []string
+	}{
+		{
+			name:         "threaded reply echoed by Bitbucket",
+			parentID:     42,
+			responseBody: `{"id":100,"parent":{"id":42},"content":{"raw":"reply"}}`,
+			wantErr:      false,
+		},
+		{
+			name:         "parent silently dropped to top-level",
+			parentID:     42,
+			responseBody: `{"id":100,"content":{"raw":"reply"}}`,
+			wantErr:      true,
+			wantErrParts: []string{"100", "42", "parent"},
+		},
+		{
+			name:         "parent threaded under a different comment",
+			parentID:     42,
+			responseBody: `{"id":100,"parent":{"id":7},"content":{"raw":"reply"}}`,
+			wantErr:      true,
+			wantErrParts: []string{"100", "42", "parent"},
+		},
+		{
+			name:         "empty 2xx body is treated as success",
+			parentID:     42,
+			responseBody: "",
+			wantErr:      false,
+		},
+		{
+			name:         "no parent requested skips verification even if body lacks parent",
+			parentID:     0,
+			responseBody: `{"id":100,"content":{"raw":"top-level"}}`,
+			wantErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotBody map[string]any
+			client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewDecoder(r.Body).Decode(&gotBody)
+				w.WriteHeader(http.StatusCreated)
+				if tt.responseBody != "" {
+					_, _ = w.Write([]byte(tt.responseBody))
+				}
+			}))
+
+			err := client.CommentPullRequest(context.Background(), "myworkspace", "my-repo", 7, bbcloud.CommentOptions{
+				Text:     "reply",
+				ParentID: tt.parentID,
+			})
+
+			if tt.parentID > 0 {
+				parent, ok := gotBody["parent"].(map[string]any)
+				if !ok {
+					t.Fatalf("request body missing parent object")
+				}
+				if id, ok := parent["id"].(float64); !ok || int(id) != tt.parentID {
+					t.Errorf("parent.id = %v, want %d", parent["id"], tt.parentID)
+				}
+			}
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				for _, part := range tt.wantErrParts {
+					if !strings.Contains(err.Error(), part) {
+						t.Errorf("error %q missing %q", err.Error(), part)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CommentPullRequest: %v", err)
+			}
+		})
+	}
+}
+
 func TestCommentPullRequestInlineToLine(t *testing.T) {
 	var gotBody map[string]any
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Fixes the false-success reported in #228. On Bitbucket **Cloud**, `bkt pr comment <pr> --parent <id>` printed `✓ Commented` on any 2xx even when Bitbucket did not actually thread the reply under the requested parent.

Root cause: `CommentPullRequest` discarded the POST response (`c.http.Do(req, nil)`), so the CLI had no way to tell a genuine threaded reply from one Bitbucket silently created as top-level.

## Change

- Capture the created comment (reusing the existing `PullRequestComment` struct) and, when a parent reply was requested and Bitbucket returned a parseable body whose `parent.id` does not match, return an actionable error instead of a silent success.
- Empty 2xx bodies and non-parent comments keep their existing success behavior.
- Public signature unchanged; the Data Center (`bbdc`) client is intentionally untouched.

## Tests

`TestCommentPullRequestParentThreadingVerification` — table-driven, asserts the request body carries `parent.id` **and** drives outcomes off the response (echoed → ok; dropped → error; mismatched → error; empty body → ok; no-parent → ok). Verified to fail against the pre-fix `Do(req, nil)`.

`go test ./pkg/bbcloud/... ./pkg/cmd/pr/...` green; `go build ./...`, `go vet`, `gofmt` clean.

## Caveat

This converts the silent false-success into a real error and confirms genuine threaded replies, but pinning the exact server-side trigger (H1 inline/wrong-tab visibility vs H2 deleted/outdated parent vs H3 silent demotion) still needs a **live Cloud repro** with `--debug`. The reporter was on v0.26.6; Cloud `parent` support has existed since v0.14.0, so this is not a version gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)