### PR TITLE
fix(httpx): don't retry non-idempotent requests on 5xx / network errors

### DIFF
--- a/pkg/httpx/client.go
+++ b/pkg/httpx/client.go
@@ -285,7 +285,7 @@ func (c *Client) Do(req *http.Request, v any) error {
 
 		resp, err := c.httpClient.Do(attemptReq)
 		if err != nil {
-			if !c.shouldRetry(attempts, 0) {
+			if !c.shouldRetry(attempts, attemptReq.Method, 0) {
 				if c.debug {
 					fmt.Fprintf(os.Stderr, "<-- network error: %v\n", err)
 				}
@@ -324,7 +324,7 @@ func (c *Client) Do(req *http.Request, v any) error {
 			// Read body for retry logic; errors are intentionally ignored as we'll retry anyway
 			bodyBytes, _ := io.ReadAll(resp.Body)
 			_ = resp.Body.Close()
-			if !c.shouldRetry(attempts, resp.StatusCode) {
+			if !c.shouldRetry(attempts, attemptReq.Method, resp.StatusCode) {
 				if len(bodyBytes) > 0 {
 					resp.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 				}
@@ -499,8 +499,34 @@ func shouldRetryStatus(code int) bool {
 	return code >= 500 && code <= 599
 }
 
-func (c *Client) shouldRetry(attempts int, status int) bool {
-	return attempts+1 < c.retry.MaxAttempts
+// shouldRetry reports whether another attempt should be made for the given
+// method and status. A 429 (Too Many Requests) is safe to retry for any method
+// because the request was rejected, not processed. 5xx responses and transport
+// errors (status == 0) may have already applied a server-side side effect, so
+// they are only retried for idempotent methods — this prevents a transient 500
+// after a successful write from duplicating a non-idempotent POST (e.g. creating
+// a pull request comment twice).
+func (c *Client) shouldRetry(attempts int, method string, status int) bool {
+	if attempts+1 >= c.retry.MaxAttempts {
+		return false
+	}
+	if status == http.StatusTooManyRequests {
+		return true
+	}
+	return isIdempotentMethod(method)
+}
+
+// isIdempotentMethod reports whether retrying the method is safe per HTTP
+// semantics (RFC 9110 §9.2.2). POST and PATCH are excluded because they are not
+// idempotent.
+func isIdempotentMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions,
+		http.MethodPut, http.MethodDelete, http.MethodTrace:
+		return true
+	default:
+		return false
+	}
 }
 
 func (c *Client) retryDelay(attempts int, resp *http.Response) time.Duration {

--- a/pkg/httpx/client_test.go
+++ b/pkg/httpx/client_test.go
@@ -937,6 +937,47 @@ func TestClientRetriesPostOn429(t *testing.T) {
 	}
 }
 
+func TestShouldRetry(t *testing.T) {
+	client, err := New(Options{BaseURL: "https://example.com", Retry: RetryPolicy{MaxAttempts: 4}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		attempts int
+		method   string
+		status   int
+		want     bool
+	}{
+		// status == 0 is a transport/network error: unsafe for non-idempotent methods.
+		{"network error POST", 0, http.MethodPost, 0, false},
+		{"network error PATCH", 0, http.MethodPatch, 0, false},
+		{"network error GET", 0, http.MethodGet, 0, true},
+		{"network error PUT", 0, http.MethodPut, 0, true},
+		{"network error DELETE", 0, http.MethodDelete, 0, true},
+		// 5xx: same idempotency rule as transport errors.
+		{"500 POST", 0, http.MethodPost, http.StatusInternalServerError, false},
+		{"503 PATCH", 0, http.MethodPatch, http.StatusServiceUnavailable, false},
+		{"500 GET", 0, http.MethodGet, http.StatusInternalServerError, true},
+		{"502 PUT", 0, http.MethodPut, http.StatusBadGateway, true},
+		// 429: rejected, not processed — retryable for any method.
+		{"429 POST", 0, http.MethodPost, http.StatusTooManyRequests, true},
+		{"429 PATCH", 0, http.MethodPatch, http.StatusTooManyRequests, true},
+		// attempt budget exhausted: no retry even for an idempotent GET.
+		{"attempts exhausted GET 500", 3, http.MethodGet, http.StatusInternalServerError, false},
+		{"attempts exhausted POST 429", 3, http.MethodPost, http.StatusTooManyRequests, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := client.shouldRetry(tt.attempts, tt.method, tt.status); got != tt.want {
+				t.Errorf("shouldRetry(%d, %q, %d) = %v, want %v", tt.attempts, tt.method, tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRetryDelayCapsRetryAfter(t *testing.T) {
 	client, err := New(Options{
 		BaseURL: "https://example.com",

--- a/pkg/httpx/client_test.go
+++ b/pkg/httpx/client_test.go
@@ -822,6 +822,121 @@ func TestClientRetriesOn429(t *testing.T) {
 	}
 }
 
+func TestClientDoesNotRetryPostOnServerError(t *testing.T) {
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{
+		BaseURL: server.URL,
+		Retry: RetryPolicy{
+			MaxAttempts:    4,
+			InitialBackoff: 10 * time.Millisecond,
+			MaxBackoff:     20 * time.Millisecond,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodPost, "/comments", payload{Message: "hi"})
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	if err := client.Do(req, nil); err == nil {
+		t.Fatalf("expected error from 500, got nil")
+	}
+
+	// A non-idempotent POST must not be retried on 5xx: the server may have
+	// already created the resource, so a retry would duplicate it.
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("expected exactly 1 POST attempt, got %d", got)
+	}
+}
+
+func TestClientRetriesIdempotentPutOnServerError(t *testing.T) {
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&hits, 1)
+		if count == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload{Message: "ok"})
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{
+		BaseURL: server.URL,
+		Retry: RetryPolicy{
+			MaxAttempts:    4,
+			InitialBackoff: 10 * time.Millisecond,
+			MaxBackoff:     20 * time.Millisecond,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodPut, "/comments/1", payload{Message: "edit"})
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	var out payload
+	if err := client.Do(req, &out); err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	// PUT is idempotent, so a 5xx is retried like GET.
+	if got := atomic.LoadInt32(&hits); got != 2 {
+		t.Fatalf("expected 2 PUT attempts, got %d", got)
+	}
+}
+
+func TestClientRetriesPostOn429(t *testing.T) {
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&hits, 1)
+		if count == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload{Message: "ok"})
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{
+		BaseURL: server.URL,
+		Retry: RetryPolicy{
+			MaxAttempts:    4,
+			InitialBackoff: 10 * time.Millisecond,
+			MaxBackoff:     20 * time.Millisecond,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodPost, "/comments", payload{Message: "hi"})
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	var out payload
+	if err := client.Do(req, &out); err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	// 429 means the request was rejected, not processed, so retrying a POST is
+	// safe and expected.
+	if got := atomic.LoadInt32(&hits); got != 2 {
+		t.Fatalf("expected 2 POST attempts on 429, got %d", got)
+	}
+}
+
 func TestRetryDelayCapsRetryAfter(t *testing.T) {
 	client, err := New(Options{
 		BaseURL: "https://example.com",


### PR DESCRIPTION
## Summary

The HTTP client retried **all** 5xx, 429, and transport errors up to `MaxAttempts` (4) regardless of method. For a non-idempotent `POST` — e.g. creating a PR comment — a transient 500 returned *after* the server already created the comment gets retried and can **duplicate** it.

Found during the #228 live Cloud smoke test: a `POST .../pullrequests/1/comments` with a bad parent returned `500` and was retried **4×** (`pkg/cmdutil/client.go` sets `MaxAttempts: 4`; `pkg/httpx` retried on status alone, no method check).

## Change

- Retry 5xx and transport errors **only for idempotent methods** (GET/HEAD/OPTIONS/PUT/DELETE/TRACE).
- **429** (Too Many Requests) means the request was rejected, not processed, so it stays retryable for **any** method (including POST) — preserves useful rate-limit backoff.
- OAuth **401 refresh-and-retry** path unchanged.

## Tests

- `TestClientDoesNotRetryPostOnServerError` — POST 500 → exactly 1 attempt (verified to fail on old behavior: 4 attempts).
- `TestClientRetriesIdempotentPutOnServerError` — PUT 500 → retried.
- `TestClientRetriesPostOn429` — POST 429 → retried.
- Existing `TestClientRetriesOnServerError` / `TestClientRetriesOn429` (both GET) unaffected.

`go build ./...`, `go vet`, `gofmt`, `go test ./pkg/httpx/... ./pkg/cmd/pr/...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)