### PR TITLE
chore(release): v0.28.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented here. The format follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
+## [0.28.2] - 2026-06-06
 ### Fixed
 - `bkt pr comment --parent` on Bitbucket Cloud no longer reports success when
   Bitbucket does not thread the reply under the requested parent. When the
@@ -14,6 +16,7 @@ All notable changes to this project will be documented here. The format follows
   server (5xx) or network errors, preventing duplicate pull request comments
   when a transient failure occurs after the comment was already created.
   Rate-limited (429) responses remain retryable for all methods.
+
 
 ## [0.28.1] - 2026-05-30
 ### Fixed
@@ -584,7 +587,8 @@ All notable changes to this project will be documented here. The format follows
 ## [0.1.0] - 2025-10-26
 - Initial public release of `bkt`.
 
-[Unreleased]: https://github.com/avivsinai/bitbucket-cli/compare/v0.28.1...HEAD
+[Unreleased]: https://github.com/avivsinai/bitbucket-cli/compare/v0.28.2...HEAD
+[0.28.2]: https://github.com/avivsinai/bitbucket-cli/compare/v0.28.1...v0.28.2
 [0.28.1]: https://github.com/avivsinai/bitbucket-cli/compare/v0.28.0...v0.28.1
 [0.28.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.27.1...v0.28.0
 [0.27.1]: https://github.com/avivsinai/bitbucket-cli/compare/v0.27.0...v0.27.1

--- a/skills/bkt/SKILL.md
+++ b/skills/bkt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bkt
-version: 0.28.1
+version: 0.28.2
 description: Bitbucket CLI for Data Center and Cloud. Use when users need to manage repositories, pull requests, branches, issues, webhooks, or pipelines in Bitbucket. Triggers include "bitbucket", "bkt", "pull request", "PR", "repo list", "branch create", "Bitbucket Data Center", "Bitbucket Cloud", "keyring timeout".
 metadata:
   short-description: Bitbucket CLI for repos, PRs, branches


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.28.2`
- aligns skill/plugin metadata to `0.28.2`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.28.2`, publishes the release, and publishes skills in the same workflow run