### PR TITLE
feat(cloud): support all six Bitbucket Cloud merge strategies

### DIFF
--- a/pkg/bbcloud/pullrequests.go
+++ b/pkg/bbcloud/pullrequests.go
@@ -496,11 +496,24 @@ func (c *Client) PullRequestDiff(ctx context.Context, workspace, repoSlug string
 	return c.http.Do(req, w)
 }
 
-// validMergeStrategies lists the strategies accepted by Bitbucket Cloud.
-var validMergeStrategies = map[string]bool{
-	"merge_commit": true,
-	"squash":       true,
-	"fast_forward": true,
+// validMergeStrategyValues lists the strategies accepted by Bitbucket Cloud.
+var validMergeStrategyValues = []string{
+	"merge_commit",
+	"squash",
+	"fast_forward",
+	"squash_fast_forward",
+	"rebase_fast_forward",
+	"rebase_merge",
+}
+
+var validMergeStrategies = mergeStrategySet(validMergeStrategyValues)
+
+func mergeStrategySet(strategies []string) map[string]bool {
+	set := make(map[string]bool, len(strategies))
+	for _, strategy := range strategies {
+		set[strategy] = true
+	}
+	return set
 }
 
 // mergeTaskStatus represents the async merge task status response.
@@ -517,7 +530,7 @@ func (c *Client) MergePullRequest(ctx context.Context, workspace, repoSlug strin
 		return fmt.Errorf("workspace and repository slug are required")
 	}
 	if strategy != "" && !validMergeStrategies[strategy] {
-		return fmt.Errorf("invalid merge strategy %q: must be one of merge_commit, squash, fast_forward", strategy)
+		return fmt.Errorf("invalid merge strategy %q: must be one of %s", strategy, strings.Join(validMergeStrategyValues, ", "))
 	}
 
 	body := map[string]any{

--- a/pkg/bbcloud/pullrequests_test.go
+++ b/pkg/bbcloud/pullrequests_test.go
@@ -771,6 +771,40 @@ func TestMergePullRequestValidation(t *testing.T) {
 	}
 }
 
+func TestMergePullRequestAcceptsCloudStrategies(t *testing.T) {
+	strategies := []string{
+		"merge_commit",
+		"squash",
+		"fast_forward",
+		"squash_fast_forward",
+		"rebase_fast_forward",
+		"rebase_merge",
+	}
+
+	for _, strategy := range strategies {
+		t.Run(strategy, func(t *testing.T) {
+			var gotBody map[string]any
+			client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Errorf("method = %s, want POST", r.Method)
+				}
+				if r.URL.Path != "/repositories/ws/repo/pullrequests/1/merge" {
+					t.Errorf("path = %s, want /repositories/ws/repo/pullrequests/1/merge", r.URL.Path)
+				}
+				_ = json.NewDecoder(r.Body).Decode(&gotBody)
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			if err := client.MergePullRequest(context.Background(), "ws", "repo", 1, "", strategy, false); err != nil {
+				t.Fatalf("MergePullRequest strategy %q: %v", strategy, err)
+			}
+			if gotBody["merge_strategy"] != strategy {
+				t.Fatalf("merge_strategy = %v, want %q", gotBody["merge_strategy"], strategy)
+			}
+		})
+	}
+}
+
 func TestMergePullRequestInvalidStrategy(t *testing.T) {
 	client, err := bbcloud.New(bbcloud.Options{
 		BaseURL: "http://localhost", Username: "u", Token: "t",
@@ -780,11 +814,14 @@ func TestMergePullRequestInvalidStrategy(t *testing.T) {
 	}
 
 	// Invalid strategy should return error
-	invalidStrategies := []string{"squah", "rebase", "merge-commit", "SQUASH"}
+	invalidStrategies := []string{"squah", "rebase", "merge-commit", "fast-forward", "SQUASH"}
 	for _, s := range invalidStrategies {
 		t.Run("invalid_"+s, func(t *testing.T) {
-			if err := client.MergePullRequest(context.Background(), "ws", "repo", 1, "", s, false); err == nil {
+			err := client.MergePullRequest(context.Background(), "ws", "repo", 1, "", s, false)
+			if err == nil {
 				t.Errorf("expected error for strategy %q", s)
+			} else if !strings.Contains(err.Error(), "squash_fast_forward, rebase_fast_forward, rebase_merge") {
+				t.Errorf("error = %q, want all valid Cloud strategies listed", err)
 			}
 		})
 	}

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -2377,7 +2377,7 @@ func newMergeCmd(f *cmdutil.Factory) *cobra.Command {
 		Short: "Merge a pull request",
 		Long: `Merge a pull request. The source branch is closed by default (use
 --close-source=false to keep it). An optional merge strategy can be specified
-(e.g. fast-forward, squash) and a custom merge commit message can be provided.
+(e.g. fast_forward, squash) and a custom merge commit message can be provided.
 
 Works on both Data Center and Cloud. On Data Center, the current PR version
 is used for optimistic locking.`,
@@ -2387,8 +2387,8 @@ is used for optimistic locking.`,
   # Merge with a custom commit message
   bkt pr merge 42 --message "Release v1.2.0"
 
-  # Merge using fast-forward strategy and keep source branch
-  bkt pr merge 42 --strategy fast-forward --close-source=false`,
+  # Merge using rebase fast-forward strategy and keep source branch
+  bkt pr merge 42 --strategy rebase_fast_forward --close-source=false`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := strconv.Atoi(args[0])
@@ -2403,7 +2403,7 @@ is used for optimistic locking.`,
 	cmd.Flags().StringVar(&opts.Project, "project", "", "Bitbucket project key override")
 	cmd.Flags().StringVar(&opts.Repo, "repo", "", "Repository slug override")
 	cmd.Flags().StringVar(&opts.Message, "message", "", "Merge commit message override")
-	cmd.Flags().StringVar(&opts.Strategy, "strategy", "", "Merge strategy ID (e.g., fast-forward)")
+	cmd.Flags().StringVar(&opts.Strategy, "strategy", "", "Merge strategy ID (e.g., rebase_fast_forward)")
 	cmd.Flags().BoolVar(&opts.CloseSource, "close-source", true, "Close source branch on merge")
 
 	return cmd

--- a/skills/bkt/rules/pr.md
+++ b/skills/bkt/rules/pr.md
@@ -898,7 +898,7 @@ bkt pr list [flags]
 
 Merge a pull request. The source branch is closed by default (use
 --close-source=false to keep it). An optional merge strategy can be specified
-(e.g. fast-forward, squash) and a custom merge commit message can be provided.
+(e.g. fast_forward, squash) and a custom merge commit message can be provided.
 
 Works on both Data Center and Cloud. On Data Center, the current PR version
 is used for optimistic locking.
@@ -917,7 +917,7 @@ bkt pr merge <id> [flags]
 | `--message` |  | Merge commit message override |
 | `--project` |  | Bitbucket project key override |
 | `--repo` |  | Repository slug override |
-| `--strategy` |  | Merge strategy ID (e.g., fast-forward) |
+| `--strategy` |  | Merge strategy ID (e.g., rebase_fast_forward) |
 | `--workspace` |  | Bitbucket Cloud workspace override |
 
 ### Inherited Flags
@@ -940,8 +940,8 @@ bkt pr merge <id> [flags]
   # Merge with a custom commit message
   bkt pr merge 42 --message "Release v1.2.0"
 
-  # Merge using fast-forward strategy and keep source branch
-  bkt pr merge 42 --strategy fast-forward --close-source=false
+  # Merge using rebase fast-forward strategy and keep source branch
+  bkt pr merge 42 --strategy rebase_fast_forward --close-source=false
 ```
 
 ## bkt pr publish


### PR DESCRIPTION
## Summary
- add the three missing Bitbucket Cloud merge strategies: `squash_fast_forward`, `rebase_fast_forward`, and `rebase_merge`
- derive Cloud merge validation and invalid-strategy error text from one ordered strategy source
- update `bkt pr merge` help/examples to use underscore strategy IDs and regenerate the generated skill docs

Closes #238

## Review
- Manager review approved via AMQ
- ChatGPT-Pro review APPROVED: https://chatgpt.com/c/6a3f6847-fde0-83eb-beb7-233c839afa2e

## Testing
- `go test ./pkg/bbcloud -run 'TestMergePullRequest(AcceptsCloudStrategies|InvalidStrategy)'`\n- `make fmt`\n- `make check-generated-skill`\n- `go test ./...`\n- `git diff --staged --check`