### PR TITLE
fix(httpx): make token refresh safe for concurrent use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented here. The format follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- The HTTP client is now safe for concurrent use during OAuth token refresh:
+  credential updates are mutex-protected and simultaneous 401 responses
+  coalesce into a single token refresh instead of racing. Groundwork for the
+  upcoming MCP server, which issues parallel API calls.
+
 ### Added
 - `bkt pipeline view --wait` and `bkt pipeline run --wait` poll a pipeline
   until it completes, using the same backoff flags (`--interval`,

--- a/pkg/httpx/client.go
+++ b/pkg/httpx/client.go
@@ -18,11 +18,16 @@ import (
 
 // Client wraps HTTP access with Bitbucket-aware defaults.
 type Client struct {
-	baseURL    *url.URL
+	baseURL   *url.URL
+	userAgent string
+
+	// credMu guards username, password, and authMethod: they are read on
+	// every request and rewritten when a 401 triggers a token refresh, and
+	// the client must stay safe for concurrent use.
+	credMu     sync.RWMutex
 	username   string
 	password   string
 	authMethod string
-	userAgent  string
 
 	httpClient *http.Client
 
@@ -37,11 +42,22 @@ type Client struct {
 
 	// tokenRefresher is called on 401 Unauthorized responses. It should return
 	// a new access token. The client retries the original request once with the
-	// updated credentials.
-	tokenRefresher func(ctx context.Context) (string, error)
-	requestHook    func(*http.Request)
+	// updated credentials. Concurrent 401s coalesce into a single refresher
+	// call via refreshMu/refreshInFlight.
+	tokenRefresher  func(ctx context.Context) (string, error)
+	refreshMu       sync.Mutex
+	refreshInFlight *refreshCall
+	requestHook     func(*http.Request)
 
 	debug bool
+}
+
+// refreshCall is a single in-flight token refresh that concurrent 401 paths
+// wait on instead of issuing their own refresh.
+type refreshCall struct {
+	done  chan struct{}
+	token string
+	err   error
 }
 
 // Options configures a Client.
@@ -241,16 +257,75 @@ func (c *Client) NewRequest(ctx context.Context, method, path string, body any) 
 
 // applyAuth sets the Authorization header based on the configured auth method.
 func (c *Client) applyAuth(req *http.Request) {
-	switch c.authMethod {
+	c.credMu.RLock()
+	username, password, authMethod := c.username, c.password, c.authMethod
+	c.credMu.RUnlock()
+
+	switch authMethod {
 	case "bearer":
-		if c.password != "" {
-			req.Header.Set("Authorization", "Bearer "+c.password)
+		if password != "" {
+			req.Header.Set("Authorization", "Bearer "+password)
 		}
 	default:
-		if c.username != "" || c.password != "" {
-			req.SetBasicAuth(c.username, c.password)
+		if username != "" || password != "" {
+			req.SetBasicAuth(username, password)
 		}
 	}
+}
+
+// authorizationHeader returns the Authorization header value the current
+// credentials would produce, so a 401 path can detect that another goroutine
+// already rotated them.
+func (c *Client) authorizationHeader() string {
+	probe, err := http.NewRequest(http.MethodGet, "http://probe.invalid/", nil)
+	if err != nil {
+		return ""
+	}
+	c.applyAuth(probe)
+	return probe.Header.Get("Authorization")
+}
+
+// refreshCredentials handles a 401: if the credentials already changed since
+// the failed request was built, it simply retries with them; otherwise it
+// coalesces all concurrent callers into one tokenRefresher invocation and
+// installs the resulting bearer token.
+func (c *Client) refreshCredentials(ctx context.Context, usedAuth string) error {
+	if h := c.authorizationHeader(); h != "" && h != usedAuth {
+		// Credentials rotated while this request was in flight; retry with
+		// the current ones without spending another refresh.
+		return nil
+	}
+
+	c.refreshMu.Lock()
+	if call := c.refreshInFlight; call != nil {
+		c.refreshMu.Unlock()
+		select {
+		case <-call.done:
+			return call.err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	call := &refreshCall{done: make(chan struct{})}
+	c.refreshInFlight = call
+	c.refreshMu.Unlock()
+
+	call.token, call.err = c.tokenRefresher(ctx)
+	if call.err == nil {
+		c.credMu.Lock()
+		c.password = call.token
+		// OAuth access tokens are always sent as Bearer regardless of the
+		// auth method the client was originally constructed with.
+		c.authMethod = "bearer"
+		c.credMu.Unlock()
+	}
+
+	c.refreshMu.Lock()
+	c.refreshInFlight = nil
+	c.refreshMu.Unlock()
+	close(call.done)
+
+	return call.err
 }
 
 func (c *Client) applyRequestHook(req *http.Request) {
@@ -346,17 +421,9 @@ func (c *Client) Do(req *http.Request, v any) error {
 
 		if resp.StatusCode == http.StatusUnauthorized && c.tokenRefresher != nil && !tokenRefreshed {
 			_ = resp.Body.Close()
-			newToken, refreshErr := c.tokenRefresher(req.Context())
-			if refreshErr != nil {
+			if refreshErr := c.refreshCredentials(req.Context(), attemptReq.Header.Get("Authorization")); refreshErr != nil {
 				return fmt.Errorf("refresh token: %w", refreshErr)
 			}
-			// c.password and c.authMethod are updated without a mutex. Client is
-			// not safe for concurrent use during token refresh; CLI commands are
-			// single-threaded so this is acceptable.
-			c.password = newToken
-			// OAuth access tokens are always sent as Bearer regardless of the
-			// auth method the client was originally constructed with.
-			c.authMethod = "bearer"
 			c.applyAuth(req) // update auth header on original request for next clone
 			tokenRefreshed = true
 			continue

--- a/pkg/httpx/client.go
+++ b/pkg/httpx/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -55,9 +56,8 @@ type Client struct {
 // refreshCall is a single in-flight token refresh that concurrent 401 paths
 // wait on instead of issuing their own refresh.
 type refreshCall struct {
-	done  chan struct{}
-	token string
-	err   error
+	done chan struct{}
+	err  error
 }
 
 // Options configures a Client.
@@ -289,43 +289,63 @@ func (c *Client) authorizationHeader() string {
 // the failed request was built, it simply retries with them; otherwise it
 // coalesces all concurrent callers into one tokenRefresher invocation and
 // installs the resulting bearer token.
+//
+// The stale-credential check and leader election happen in one refreshMu
+// critical section, so a goroutine that raced past a completed refresh cannot
+// become a redundant second leader (rotating refresh tokens make redundant
+// refreshes harmful, not just wasteful). Lock order is refreshMu -> credMu
+// (read); credMu is never held while acquiring refreshMu.
 func (c *Client) refreshCredentials(ctx context.Context, usedAuth string) error {
-	if h := c.authorizationHeader(); h != "" && h != usedAuth {
-		// Credentials rotated while this request was in flight; retry with
-		// the current ones without spending another refresh.
-		return nil
-	}
-
-	c.refreshMu.Lock()
-	if call := c.refreshInFlight; call != nil {
-		c.refreshMu.Unlock()
-		select {
-		case <-call.done:
-			return call.err
-		case <-ctx.Done():
-			return ctx.Err()
+	for {
+		c.refreshMu.Lock()
+		if h := c.authorizationHeader(); h != "" && h != usedAuth {
+			// Credentials rotated while this request was in flight; retry
+			// with the current ones without spending another refresh.
+			c.refreshMu.Unlock()
+			return nil
 		}
+		if call := c.refreshInFlight; call != nil {
+			c.refreshMu.Unlock()
+			select {
+			case <-call.done:
+				// Inherit real refresh failures, but not another request's
+				// context death: if the leader was cancelled while this
+				// caller is still live, contend for leadership again.
+				if isContextError(call.err) && ctx.Err() == nil {
+					continue
+				}
+				return call.err
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		call := &refreshCall{done: make(chan struct{})}
+		c.refreshInFlight = call
+		c.refreshMu.Unlock()
+
+		token, err := c.tokenRefresher(ctx)
+		if err == nil {
+			c.credMu.Lock()
+			c.password = token
+			// OAuth access tokens are always sent as Bearer regardless of
+			// the auth method the client was originally constructed with.
+			c.authMethod = "bearer"
+			c.credMu.Unlock()
+		}
+		call.err = err
+
+		c.refreshMu.Lock()
+		c.refreshInFlight = nil
+		c.refreshMu.Unlock()
+		close(call.done)
+
+		return err
 	}
-	call := &refreshCall{done: make(chan struct{})}
-	c.refreshInFlight = call
-	c.refreshMu.Unlock()
+}
 
-	call.token, call.err = c.tokenRefresher(ctx)
-	if call.err == nil {
-		c.credMu.Lock()
-		c.password = call.token
-		// OAuth access tokens are always sent as Bearer regardless of the
-		// auth method the client was originally constructed with.
-		c.authMethod = "bearer"
-		c.credMu.Unlock()
-	}
-
-	c.refreshMu.Lock()
-	c.refreshInFlight = nil
-	c.refreshMu.Unlock()
-	close(call.done)
-
-	return call.err
+// isContextError reports whether err is a context cancellation or deadline.
+func isContextError(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
 func (c *Client) applyRequestHook(req *http.Request) {

--- a/pkg/httpx/client_test.go
+++ b/pkg/httpx/client_test.go
@@ -1375,3 +1375,83 @@ func TestRefreshSkippedWhenCredentialsAlreadyRotated(t *testing.T) {
 		t.Fatalf("TokenRefresher called %d times, want exactly 1", got)
 	}
 }
+
+func TestFollowerRetriesWhenLeaderContextCancelled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "Bearer new-token" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(payload{Message: "ok"})
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(server.Close)
+
+	var refreshCalls int32
+	leaderInRefresh := make(chan struct{})
+	client, err := New(Options{
+		BaseURL:  server.URL,
+		Username: "user",
+		Password: "old-token",
+		TokenRefresher: func(ctx context.Context) (string, error) {
+			if atomic.AddInt32(&refreshCalls, 1) == 1 {
+				close(leaderInRefresh)
+				<-ctx.Done() // first leader hangs until its request is cancelled
+				return "", ctx.Err()
+			}
+			return "new-token", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	defer cancelLeader()
+
+	var wg sync.WaitGroup
+	var leaderErr, followerErr error
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		req, err := client.NewRequest(leaderCtx, http.MethodGet, "/api", nil)
+		if err != nil {
+			leaderErr = err
+			return
+		}
+		var out payload
+		leaderErr = client.Do(req, &out)
+	}()
+
+	<-leaderInRefresh // leader is inside the refresher, holding the in-flight call
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		req, err := client.NewRequest(context.Background(), http.MethodGet, "/api", nil)
+		if err != nil {
+			followerErr = err
+			return
+		}
+		var out payload
+		followerErr = client.Do(req, &out)
+	}()
+
+	// Give the follower a moment to join the in-flight call, then kill the
+	// leader. Either interleaving (follower waiting on the call, or arriving
+	// after it fails) must converge on the same outcome.
+	time.Sleep(50 * time.Millisecond)
+	cancelLeader()
+	wg.Wait()
+
+	if leaderErr == nil || !errors.Is(leaderErr, context.Canceled) {
+		t.Fatalf("leader err = %v, want context.Canceled", leaderErr)
+	}
+	if followerErr != nil {
+		t.Fatalf("follower err = %v, want success via replacement refresh", followerErr)
+	}
+	if got := atomic.LoadInt32(&refreshCalls); got != 2 {
+		t.Fatalf("TokenRefresher called %d times, want 2 (failed leader + follower replacement)", got)
+	}
+}

--- a/pkg/httpx/client_test.go
+++ b/pkg/httpx/client_test.go
@@ -1269,3 +1269,109 @@ func TestNewRequestAbsoluteURL(t *testing.T) {
 		t.Fatalf("expected absolute URL to be preserved, got %s", got)
 	}
 }
+
+func TestConcurrent401RefreshCoalesced(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "Bearer new-token" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(payload{Message: "ok"})
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(server.Close)
+
+	var refreshCalls int32
+	client, err := New(Options{
+		BaseURL:  server.URL,
+		Username: "user",
+		Password: "old-token",
+		TokenRefresher: func(ctx context.Context) (string, error) {
+			atomic.AddInt32(&refreshCalls, 1)
+			time.Sleep(100 * time.Millisecond) // widen the coalescing window
+			return "new-token", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	const workers = 8
+	var wg sync.WaitGroup
+	errs := make([]error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			req, err := client.NewRequest(context.Background(), http.MethodGet, "/api", nil)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			var out payload
+			errs[i] = client.Do(req, &out)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("worker %d: %v", i, err)
+		}
+	}
+	if got := atomic.LoadInt32(&refreshCalls); got != 1 {
+		t.Fatalf("TokenRefresher called %d times, want exactly 1 (coalesced)", got)
+	}
+}
+
+func TestRefreshSkippedWhenCredentialsAlreadyRotated(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "Bearer new-token" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(payload{Message: "ok"})
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(server.Close)
+
+	var refreshCalls int32
+	client, err := New(Options{
+		BaseURL:  server.URL,
+		Username: "user",
+		Password: "old-token",
+		TokenRefresher: func(ctx context.Context) (string, error) {
+			atomic.AddInt32(&refreshCalls, 1)
+			return "new-token", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Build a request while the old token is still installed, so its baked
+	// Authorization header goes stale after the first refresh.
+	staleReq, err := client.NewRequest(context.Background(), http.MethodGet, "/api", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	// First request triggers the one and only refresh.
+	firstReq, err := client.NewRequest(context.Background(), http.MethodGet, "/api", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	var out payload
+	if err := client.Do(firstReq, &out); err != nil {
+		t.Fatalf("Do(first): %v", err)
+	}
+
+	// The stale request 401s, but the 401 path must notice the rotated
+	// credentials and retry with them instead of refreshing again.
+	if err := client.Do(staleReq, &out); err != nil {
+		t.Fatalf("Do(stale): %v", err)
+	}
+	if got := atomic.LoadInt32(&refreshCalls); got != 1 {
+		t.Fatalf("TokenRefresher called %d times, want exactly 1", got)
+	}
+}


### PR DESCRIPTION
## Summary

Prerequisite (wave 0) for the approved `bkt mcp serve` plan: MCP clients issue parallel API calls, invalidating the HTTP client's single-threaded assumption.

- Credential fields (`username`/`password`/`authMethod`) are guarded by a RWMutex; `applyAuth` reads a snapshot.
- Concurrent 401s coalesce into a single `tokenRefresher` invocation — the stale-credential check and leader election share one critical section (no TOCTOU double-refresh), which matters because rotating OAuth refresh tokens make redundant refreshes actively harmful.
- A request whose baked Authorization header went stale mid-flight retries with the rotated credentials without spending a refresh.
- A follower waiting on a leader whose request context died re-contends with its own live context instead of failing spuriously; real refresh errors stay shared.

## Testing

- New: `TestConcurrent401RefreshCoalesced` (8 workers → exactly 1 refresh), `TestRefreshSkippedWhenCredentialsAlreadyRotated`, `TestFollowerRetriesWhenLeaderContextCancelled` (deterministic across both interleavings)
- `go test ./...`, `go test -race ./pkg/httpx` (plus 20× stress on refresh tests), `go vet ./...` — all green
- Peer-reviewed by codex (two rounds; both concurrency findings — TOCTOU and follower ctx-poisoning — surfaced there and fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)