### PR TITLE
feat(clients): page-aware PR primitives with upstream role filters (wave B)

### DIFF
--- a/pkg/bbcloud/client.go
+++ b/pkg/bbcloud/client.go
@@ -716,25 +716,32 @@ func (c *Client) ListWorkspacePullRequestsPage(ctx context.Context, workspace, u
 		return nil, fmt.Errorf("username is required")
 	}
 
-	path := next
-	if path == "" {
-		pageLen := opts.Limit
-		if pageLen <= 0 || pageLen > 100 {
-			pageLen = 20
+	if next != "" {
+		endpoint := fmt.Sprintf("/workspaces/%s/pullrequests/%s",
+			url.PathEscape(workspace), url.PathEscape(username))
+		normalized, err := normalizeNextRef(next, endpoint)
+		if err != nil {
+			return nil, err
 		}
-
-		var params []string
-		params = append(params, fmt.Sprintf("pagelen=%d", pageLen))
-		if state := strings.TrimSpace(opts.State); state != "" && !strings.EqualFold(state, "all") {
-			params = append(params, "state="+url.QueryEscape(strings.ToUpper(state)))
-		}
-
-		path = fmt.Sprintf("/workspaces/%s/pullrequests/%s?%s",
-			url.PathEscape(workspace),
-			url.PathEscape(username),
-			strings.Join(params, "&"),
-		)
+		return c.fetchPullRequestsPage(ctx, normalized)
 	}
+
+	pageLen := opts.Limit
+	if pageLen <= 0 || pageLen > 100 {
+		pageLen = 20
+	}
+
+	var params []string
+	params = append(params, fmt.Sprintf("pagelen=%d", pageLen))
+	if state := strings.TrimSpace(opts.State); state != "" && !strings.EqualFold(state, "all") {
+		params = append(params, "state="+url.QueryEscape(strings.ToUpper(state)))
+	}
+
+	path := fmt.Sprintf("/workspaces/%s/pullrequests/%s?%s",
+		url.PathEscape(workspace),
+		url.PathEscape(username),
+		strings.Join(params, "&"),
+	)
 
 	return c.fetchPullRequestsPage(ctx, path)
 }

--- a/pkg/bbcloud/client.go
+++ b/pkg/bbcloud/client.go
@@ -704,8 +704,11 @@ type WorkspacePullRequestsOptions struct {
 	Limit int
 }
 
-// ListWorkspacePullRequests lists pull requests authored by the specified user across all repositories in the workspace.
-func (c *Client) ListWorkspacePullRequests(ctx context.Context, workspace, username string, opts WorkspacePullRequestsOptions) ([]PullRequest, error) {
+// ListWorkspacePullRequestsPage fetches a single page of pull requests
+// authored by the specified user across the workspace. Pass next="" for the
+// first page or a Next value from a previous page. This endpoint is
+// author-scoped only: the Cloud API has no workspace-wide reviewer filter.
+func (c *Client) ListWorkspacePullRequestsPage(ctx context.Context, workspace, username string, opts WorkspacePullRequestsOptions, next string) (*PullRequestsPage, error) {
 	if workspace == "" {
 		return nil, fmt.Errorf("workspace is required")
 	}
@@ -713,32 +716,36 @@ func (c *Client) ListWorkspacePullRequests(ctx context.Context, workspace, usern
 		return nil, fmt.Errorf("username is required")
 	}
 
-	pageLen := opts.Limit
-	if pageLen <= 0 || pageLen > 100 {
-		pageLen = 20
-	}
-
-	var params []string
-	params = append(params, fmt.Sprintf("pagelen=%d", pageLen))
-	if state := strings.TrimSpace(opts.State); state != "" && !strings.EqualFold(state, "all") {
-		params = append(params, "state="+url.QueryEscape(strings.ToUpper(state)))
-	}
-
-	path := fmt.Sprintf("/workspaces/%s/pullrequests/%s?%s",
-		url.PathEscape(workspace),
-		url.PathEscape(username),
-		strings.Join(params, "&"),
-	)
-
-	var prs []PullRequest
-	for path != "" {
-		req, err := c.http.NewRequest(ctx, "GET", path, nil)
-		if err != nil {
-			return nil, err
+	path := next
+	if path == "" {
+		pageLen := opts.Limit
+		if pageLen <= 0 || pageLen > 100 {
+			pageLen = 20
 		}
 
-		var page pullRequestListPage
-		if err := c.http.Do(req, &page); err != nil {
+		var params []string
+		params = append(params, fmt.Sprintf("pagelen=%d", pageLen))
+		if state := strings.TrimSpace(opts.State); state != "" && !strings.EqualFold(state, "all") {
+			params = append(params, "state="+url.QueryEscape(strings.ToUpper(state)))
+		}
+
+		path = fmt.Sprintf("/workspaces/%s/pullrequests/%s?%s",
+			url.PathEscape(workspace),
+			url.PathEscape(username),
+			strings.Join(params, "&"),
+		)
+	}
+
+	return c.fetchPullRequestsPage(ctx, path)
+}
+
+// ListWorkspacePullRequests lists pull requests authored by the specified user across all repositories in the workspace.
+func (c *Client) ListWorkspacePullRequests(ctx context.Context, workspace, username string, opts WorkspacePullRequestsOptions) ([]PullRequest, error) {
+	var prs []PullRequest
+	next := ""
+	for {
+		page, err := c.ListWorkspacePullRequestsPage(ctx, workspace, username, opts, next)
+		if err != nil {
 			return nil, err
 		}
 
@@ -752,11 +759,7 @@ func (c *Client) ListWorkspacePullRequests(ctx context.Context, workspace, usern
 		if page.Next == "" {
 			break
 		}
-		nextURL, err := url.Parse(page.Next)
-		if err != nil {
-			return nil, err
-		}
-		path = nextURL.RequestURI()
+		next = page.Next
 	}
 
 	return prs, nil

--- a/pkg/bbcloud/pullrequests.go
+++ b/pkg/bbcloud/pullrequests.go
@@ -144,14 +144,18 @@ func pullRequestQFilter(opts PullRequestListOptions) string {
 
 // normalizeNextRef hardens caller-supplied opaque next references: the
 // reference is reduced to its request URI (so it can never point the
-// authenticated client at another host) and must target the endpoint the
-// page sequence started from. Anything else is rejected.
+// authenticated client at another host) and its path must END at the
+// endpoint the page sequence started from. HasSuffix (not Contains) enforces
+// terminal endpoint identity — a trailing "/1" or a glued "/prefixrepos..."
+// is rejected — while the endpoint's leading slash still admits a legitimate
+// base-path prefix such as /2.0.
 func normalizeNextRef(next, endpoint string) (string, error) {
 	u, err := url.Parse(next)
 	if err != nil {
 		return "", fmt.Errorf("invalid next page reference: %w", err)
 	}
-	if !strings.Contains(u.EscapedPath(), endpoint) {
+	path := u.EscapedPath()
+	if path != endpoint && !strings.HasSuffix(path, endpoint) {
 		return "", fmt.Errorf("next page reference does not target %s", endpoint)
 	}
 	return u.RequestURI(), nil

--- a/pkg/bbcloud/pullrequests.go
+++ b/pkg/bbcloud/pullrequests.go
@@ -66,11 +66,14 @@ type PullRequest struct {
 	} `json:"summary"`
 }
 
-// PullRequestListOptions configure PR listings.
+// PullRequestListOptions configure PR listings. Mine and Reviewer carry a
+// user identity (UUID, account id, or nickname) and are encoded upstream as
+// BBQL author/reviewer filters before any limiting happens.
 type PullRequestListOptions struct {
-	State string
-	Limit int
-	Mine  string
+	State    string
+	Limit    int
+	Mine     string
+	Reviewer string
 }
 
 type pullRequestListPage struct {
@@ -78,41 +81,91 @@ type pullRequestListPage struct {
 	Next   string        `json:"next"`
 }
 
-// ListPullRequests lists pull requests for a repository.
-func (c *Client) ListPullRequests(ctx context.Context, workspace, repoSlug string, opts PullRequestListOptions) ([]PullRequest, error) {
+// PullRequestsPage is one bounded page of pull requests. Next is an opaque
+// reference to the following page; empty means the last page.
+type PullRequestsPage struct {
+	Values []PullRequest
+	Next   string
+}
+
+// ListRepoPullRequestsPage fetches a single page of repository pull
+// requests. Pass next="" for the first page (built from opts) or a Next
+// value from a previous page.
+func (c *Client) ListRepoPullRequestsPage(ctx context.Context, workspace, repoSlug string, opts PullRequestListOptions, next string) (*PullRequestsPage, error) {
 	if workspace == "" || repoSlug == "" {
 		return nil, fmt.Errorf("workspace and repository slug are required")
 	}
 
-	pageLen := opts.Limit
-	if pageLen <= 0 || pageLen > 100 {
-		pageLen = 20
+	path := next
+	if path == "" {
+		pageLen := opts.Limit
+		if pageLen <= 0 || pageLen > 100 {
+			pageLen = 20
+		}
+
+		var params []string
+		params = append(params, fmt.Sprintf("pagelen=%d", pageLen))
+		if state := strings.TrimSpace(opts.State); state != "" && !strings.EqualFold(state, "all") {
+			params = append(params, "state="+url.QueryEscape(strings.ToUpper(state)))
+		}
+		if q := pullRequestQFilter(opts); q != "" {
+			params = append(params, "q="+url.QueryEscape(q))
+		}
+
+		path = fmt.Sprintf("/repositories/%s/%s/pullrequests?%s",
+			url.PathEscape(workspace),
+			url.PathEscape(repoSlug),
+			strings.Join(params, "&"),
+		)
 	}
 
-	var params []string
-	params = append(params, fmt.Sprintf("pagelen=%d", pageLen))
-	if state := strings.TrimSpace(opts.State); state != "" && !strings.EqualFold(state, "all") {
-		params = append(params, "state="+url.QueryEscape(strings.ToUpper(state)))
-	}
+	return c.fetchPullRequestsPage(ctx, path)
+}
+
+// pullRequestQFilter builds the upstream BBQL q parameter from the identity
+// filters; multiple filters combine with AND.
+func pullRequestQFilter(opts PullRequestListOptions) string {
+	var terms []string
 	if mine := strings.TrimSpace(opts.Mine); mine != "" {
-		params = append(params, "q="+url.QueryEscape(bbqlEquals(authorFilterField(mine), mine)))
+		terms = append(terms, bbqlEquals(authorFilterField(mine), mine))
+	}
+	if reviewer := strings.TrimSpace(opts.Reviewer); reviewer != "" {
+		terms = append(terms, bbqlEquals(reviewerFilterField(reviewer), reviewer))
+	}
+	return strings.Join(terms, " AND ")
+}
+
+func (c *Client) fetchPullRequestsPage(ctx context.Context, path string) (*PullRequestsPage, error) {
+	req, err := c.http.NewRequest(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
 	}
 
-	path := fmt.Sprintf("/repositories/%s/%s/pullrequests?%s",
-		url.PathEscape(workspace),
-		url.PathEscape(repoSlug),
-		strings.Join(params, "&"),
-	)
+	var page pullRequestListPage
+	if err := c.http.Do(req, &page); err != nil {
+		return nil, err
+	}
 
-	var prs []PullRequest
-	for path != "" {
-		req, err := c.http.NewRequest(ctx, "GET", path, nil)
+	next := ""
+	if page.Next != "" {
+		nextURL, err := url.Parse(page.Next)
 		if err != nil {
 			return nil, err
 		}
+		next = nextURL.RequestURI()
+	}
 
-		var page pullRequestListPage
-		if err := c.http.Do(req, &page); err != nil {
+	return &PullRequestsPage{Values: page.Values, Next: next}, nil
+}
+
+// ListPullRequests lists pull requests for a repository, flattening pages up
+// to opts.Limit.
+func (c *Client) ListPullRequests(ctx context.Context, workspace, repoSlug string, opts PullRequestListOptions) ([]PullRequest, error) {
+	var prs []PullRequest
+	next := ""
+	for {
+		page, err := c.ListRepoPullRequestsPage(ctx, workspace, repoSlug, opts, next)
+		if err != nil {
 			return nil, err
 		}
 
@@ -126,11 +179,7 @@ func (c *Client) ListPullRequests(ctx context.Context, workspace, repoSlug strin
 		if page.Next == "" {
 			break
 		}
-		nextURL, err := url.Parse(page.Next)
-		if err != nil {
-			return nil, err
-		}
-		path = nextURL.RequestURI()
+		next = page.Next
 	}
 
 	return prs, nil
@@ -144,6 +193,19 @@ func authorFilterField(identity string) string {
 		return "author.account_id"
 	default:
 		return "author.username"
+	}
+}
+
+// reviewerFilterField picks the BBQL reviewers field matching the identity
+// shape, mirroring authorFilterField.
+func reviewerFilterField(identity string) string {
+	switch {
+	case LooksLikeUUID(identity):
+		return "reviewers.uuid"
+	case LooksLikeAccountID(identity):
+		return "reviewers.account_id"
+	default:
+		return "reviewers.username"
 	}
 }
 

--- a/pkg/bbcloud/pullrequests.go
+++ b/pkg/bbcloud/pullrequests.go
@@ -96,28 +96,35 @@ func (c *Client) ListRepoPullRequestsPage(ctx context.Context, workspace, repoSl
 		return nil, fmt.Errorf("workspace and repository slug are required")
 	}
 
-	path := next
-	if path == "" {
-		pageLen := opts.Limit
-		if pageLen <= 0 || pageLen > 100 {
-			pageLen = 20
+	if next != "" {
+		endpoint := fmt.Sprintf("/repositories/%s/%s/pullrequests",
+			url.PathEscape(workspace), url.PathEscape(repoSlug))
+		normalized, err := normalizeNextRef(next, endpoint)
+		if err != nil {
+			return nil, err
 		}
-
-		var params []string
-		params = append(params, fmt.Sprintf("pagelen=%d", pageLen))
-		if state := strings.TrimSpace(opts.State); state != "" && !strings.EqualFold(state, "all") {
-			params = append(params, "state="+url.QueryEscape(strings.ToUpper(state)))
-		}
-		if q := pullRequestQFilter(opts); q != "" {
-			params = append(params, "q="+url.QueryEscape(q))
-		}
-
-		path = fmt.Sprintf("/repositories/%s/%s/pullrequests?%s",
-			url.PathEscape(workspace),
-			url.PathEscape(repoSlug),
-			strings.Join(params, "&"),
-		)
+		return c.fetchPullRequestsPage(ctx, normalized)
 	}
+
+	pageLen := opts.Limit
+	if pageLen <= 0 || pageLen > 100 {
+		pageLen = 20
+	}
+
+	var params []string
+	params = append(params, fmt.Sprintf("pagelen=%d", pageLen))
+	if state := strings.TrimSpace(opts.State); state != "" && !strings.EqualFold(state, "all") {
+		params = append(params, "state="+url.QueryEscape(strings.ToUpper(state)))
+	}
+	if q := pullRequestQFilter(opts); q != "" {
+		params = append(params, "q="+url.QueryEscape(q))
+	}
+
+	path := fmt.Sprintf("/repositories/%s/%s/pullrequests?%s",
+		url.PathEscape(workspace),
+		url.PathEscape(repoSlug),
+		strings.Join(params, "&"),
+	)
 
 	return c.fetchPullRequestsPage(ctx, path)
 }
@@ -133,6 +140,21 @@ func pullRequestQFilter(opts PullRequestListOptions) string {
 		terms = append(terms, bbqlEquals(reviewerFilterField(reviewer), reviewer))
 	}
 	return strings.Join(terms, " AND ")
+}
+
+// normalizeNextRef hardens caller-supplied opaque next references: the
+// reference is reduced to its request URI (so it can never point the
+// authenticated client at another host) and must target the endpoint the
+// page sequence started from. Anything else is rejected.
+func normalizeNextRef(next, endpoint string) (string, error) {
+	u, err := url.Parse(next)
+	if err != nil {
+		return "", fmt.Errorf("invalid next page reference: %w", err)
+	}
+	if !strings.Contains(u.EscapedPath(), endpoint) {
+		return "", fmt.Errorf("next page reference does not target %s", endpoint)
+	}
+	return u.RequestURI(), nil
 }
 
 func (c *Client) fetchPullRequestsPage(ctx context.Context, path string) (*PullRequestsPage, error) {
@@ -192,7 +214,7 @@ func authorFilterField(identity string) string {
 	case LooksLikeAccountID(identity):
 		return "author.account_id"
 	default:
-		return "author.username"
+		return "author.nickname"
 	}
 }
 
@@ -205,7 +227,7 @@ func reviewerFilterField(identity string) string {
 	case LooksLikeAccountID(identity):
 		return "reviewers.account_id"
 	default:
-		return "reviewers.username"
+		return "reviewers.nickname"
 	}
 }
 

--- a/pkg/bbcloud/pullrequests_test.go
+++ b/pkg/bbcloud/pullrequests_test.go
@@ -1854,3 +1854,37 @@ func TestListWorkspacePullRequestsPageRejectsForeignNext(t *testing.T) {
 		t.Fatalf("err = %v, want endpoint rejection", err)
 	}
 }
+
+// Endpoint binding must be terminal, not substring containment: a same-host
+// path that merely contains the endpoint (trailing extra segment or a glued
+// prefix) is rejected, while a legitimate /2.0-prefixed reference round-trips.
+func TestNormalizeNextRefEnforcesTerminalEndpoint(t *testing.T) {
+	var apiPaths []string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiPaths = append(apiPaths, r.URL.RequestURI())
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"values": []any{}})
+	}))
+	base := client // same-host references are built from the test server URL below
+
+	// Legitimate base-path-prefixed next reference round-trips.
+	if _, err := base.ListRepoPullRequestsPage(context.Background(), "ws", "repo", bbcloud.PullRequestListOptions{}, "/2.0/repositories/ws/repo/pullrequests?page=2"); err != nil {
+		t.Fatalf("valid /2.0 next reference rejected: %v", err)
+	}
+	if len(apiPaths) != 1 {
+		t.Fatalf("valid reference produced %d requests, want 1", len(apiPaths))
+	}
+
+	// Trailing extra segment (containment, not endpoint identity) rejected.
+	apiPaths = nil
+	if _, err := base.ListRepoPullRequestsPage(context.Background(), "ws", "repo", bbcloud.PullRequestListOptions{}, "/repositories/ws/repo/pullrequests/1"); err == nil || !strings.Contains(err.Error(), "does not target") {
+		t.Fatalf("trailing-segment reference: err = %v, want rejection", err)
+	}
+	// Glued prefix (no segment boundary) rejected.
+	if _, err := base.ListRepoPullRequestsPage(context.Background(), "ws", "repo", bbcloud.PullRequestListOptions{}, "/evilrepositories/ws/repo/pullrequests"); err == nil || !strings.Contains(err.Error(), "does not target") {
+		t.Fatalf("glued-prefix reference: err = %v, want rejection", err)
+	}
+	if len(apiPaths) != 0 {
+		t.Fatalf("rejected references still issued %d requests", len(apiPaths))
+	}
+}

--- a/pkg/bbcloud/pullrequests_test.go
+++ b/pkg/bbcloud/pullrequests_test.go
@@ -1729,7 +1729,7 @@ func TestListPullRequestsEncodesReviewerFilterUpstream(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("ListPullRequests: %v", err)
 	}
-	if want := `reviewers.username = "nick"`; firstQuery != want {
+	if want := `reviewers.nickname = "nick"`; firstQuery != want {
 		t.Fatalf("q = %q, want %q", firstQuery, want)
 	}
 
@@ -1741,7 +1741,7 @@ func TestListPullRequestsEncodesReviewerFilterUpstream(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("ListPullRequests: %v", err)
 	}
-	if want := `author.username = "nick" AND reviewers.uuid = "` + uuid + `"`; firstQuery != want {
+	if want := `author.nickname = "nick" AND reviewers.uuid = "` + uuid + `"`; firstQuery != want {
 		t.Fatalf("q = %q, want %q", firstQuery, want)
 	}
 }
@@ -1800,5 +1800,57 @@ func TestListWorkspacePullRequestsPageIsAuthorScoped(t *testing.T) {
 	}
 	if !strings.HasSuffix(gotPath, "/workspaces/ws/pullrequests/alice") {
 		t.Fatalf("path = %q, want the user-scoped author endpoint", gotPath)
+	}
+}
+
+// Regression for credential exfiltration: a caller-supplied next reference
+// pointing at another host must never be fetched with the Bitbucket
+// Authorization header. The reference is reduced to its request URI (same
+// client host) and must target the original endpoint.
+func TestListRepoPullRequestsPageRejectsForeignNextHost(t *testing.T) {
+	var attackerHits int32
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attackerHits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(attacker.Close)
+
+	var apiPaths []string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiPaths = append(apiPaths, r.URL.RequestURI())
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"values": []any{}})
+	}))
+
+	// Absolute foreign URL with a plausible path: host must be stripped, the
+	// request must go to the client's own base host.
+	foreign := attacker.URL + "/repositories/ws/repo/pullrequests?page=2"
+	if _, err := client.ListRepoPullRequestsPage(context.Background(), "ws", "repo", bbcloud.PullRequestListOptions{}, foreign); err != nil {
+		t.Fatalf("normalized foreign next: %v", err)
+	}
+	if got := atomic.LoadInt32(&attackerHits); got != 0 {
+		t.Fatalf("attacker host received %d requests; credential exfiltration", got)
+	}
+	if len(apiPaths) != 1 || !strings.Contains(apiPaths[0], "/repositories/ws/repo/pullrequests") {
+		t.Fatalf("api paths = %v, want the normalized same-host request", apiPaths)
+	}
+
+	// A next reference targeting a different endpoint must be rejected
+	// without any request.
+	apiPaths = nil
+	if _, err := client.ListRepoPullRequestsPage(context.Background(), "ws", "repo", bbcloud.PullRequestListOptions{}, attacker.URL+"/2.0/user"); err == nil || !strings.Contains(err.Error(), "does not target") {
+		t.Fatalf("foreign endpoint: err = %v, want endpoint rejection", err)
+	}
+	if len(apiPaths) != 0 || atomic.LoadInt32(&attackerHits) != 0 {
+		t.Fatalf("rejected reference still produced requests (api=%v attacker=%d)", apiPaths, attackerHits)
+	}
+}
+
+func TestListWorkspacePullRequestsPageRejectsForeignNext(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("no request expected for a rejected next reference")
+	}))
+	if _, err := client.ListWorkspacePullRequestsPage(context.Background(), "ws", "alice", bbcloud.WorkspacePullRequestsOptions{}, "https://evil.example/steal"); err == nil || !strings.Contains(err.Error(), "does not target") {
+		t.Fatalf("err = %v, want endpoint rejection", err)
 	}
 }

--- a/pkg/bbcloud/pullrequests_test.go
+++ b/pkg/bbcloud/pullrequests_test.go
@@ -1699,3 +1699,106 @@ func TestUpdatePullRequestValidation(t *testing.T) {
 		t.Errorf("expected empty input error, got %v", err)
 	}
 }
+
+func TestListPullRequestsEncodesReviewerFilterUpstream(t *testing.T) {
+	var firstQuery string
+	var requests int32
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&requests, 1) == 1 {
+			firstQuery = r.URL.Query().Get("q")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"values": []any{}})
+	}))
+
+	uuid := "{a1b2c3d4-e5f6-4890-abcd-ef1234567890}"
+	if _, err := client.ListPullRequests(context.Background(), "ws", "repo", bbcloud.PullRequestListOptions{
+		Reviewer: uuid,
+		Limit:    10,
+	}); err != nil {
+		t.Fatalf("ListPullRequests: %v", err)
+	}
+	if want := `reviewers.uuid = "` + uuid + `"`; firstQuery != want {
+		t.Fatalf("first request q = %q, want %q (reviewer filter must be upstream, before any limiting)", firstQuery, want)
+	}
+
+	// Nickname identities use the username field.
+	atomic.StoreInt32(&requests, 0)
+	if _, err := client.ListPullRequests(context.Background(), "ws", "repo", bbcloud.PullRequestListOptions{
+		Reviewer: "nick",
+	}); err != nil {
+		t.Fatalf("ListPullRequests: %v", err)
+	}
+	if want := `reviewers.username = "nick"`; firstQuery != want {
+		t.Fatalf("q = %q, want %q", firstQuery, want)
+	}
+
+	// Author + reviewer combine with AND.
+	atomic.StoreInt32(&requests, 0)
+	if _, err := client.ListPullRequests(context.Background(), "ws", "repo", bbcloud.PullRequestListOptions{
+		Mine:     "nick",
+		Reviewer: uuid,
+	}); err != nil {
+		t.Fatalf("ListPullRequests: %v", err)
+	}
+	if want := `author.username = "nick" AND reviewers.uuid = "` + uuid + `"`; firstQuery != want {
+		t.Fatalf("q = %q, want %q", firstQuery, want)
+	}
+}
+
+func TestListRepoPullRequestsPageNextRoundTrip(t *testing.T) {
+	var paths []string
+	var server *httptest.Server
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.RequestURI())
+		w.Header().Set("Content-Type", "application/json")
+		if len(paths) == 1 {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values": []map[string]any{{"id": 1}},
+				"next":   server.URL + "/repositories/ws/repo/pullrequests?page=2&pagelen=1",
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"values": []map[string]any{{"id": 2}}})
+	})
+	server = httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	client, err := bbcloud.New(bbcloud.Options{BaseURL: server.URL, Username: "u", Token: "t"})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	first, err := client.ListRepoPullRequestsPage(context.Background(), "ws", "repo", bbcloud.PullRequestListOptions{Limit: 1}, "")
+	if err != nil {
+		t.Fatalf("first page: %v", err)
+	}
+	if first.Next == "" {
+		t.Fatal("first page must expose Next")
+	}
+	second, err := client.ListRepoPullRequestsPage(context.Background(), "ws", "repo", bbcloud.PullRequestListOptions{}, first.Next)
+	if err != nil {
+		t.Fatalf("second page: %v", err)
+	}
+	if second.Next != "" {
+		t.Fatal("second page must be last")
+	}
+	if len(paths) != 2 || !strings.Contains(paths[1], "page=2") {
+		t.Fatalf("paths = %v, want second request to follow the opaque next reference", paths)
+	}
+}
+
+func TestListWorkspacePullRequestsPageIsAuthorScoped(t *testing.T) {
+	var gotPath string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"values": []any{}})
+	}))
+
+	if _, err := client.ListWorkspacePullRequestsPage(context.Background(), "ws", "alice", bbcloud.WorkspacePullRequestsOptions{State: "open", Limit: 5}, ""); err != nil {
+		t.Fatalf("ListWorkspacePullRequestsPage: %v", err)
+	}
+	if !strings.HasSuffix(gotPath, "/workspaces/ws/pullrequests/alice") {
+		t.Fatalf("path = %q, want the user-scoped author endpoint", gotPath)
+	}
+}

--- a/pkg/bbdc/client.go
+++ b/pkg/bbdc/client.go
@@ -261,12 +261,88 @@ func (c *Client) GetPullRequest(ctx context.Context, projectKey, repoSlug string
 	return &pr, nil
 }
 
-// ListPullRequests lists pull requests for a repository.
-func (c *Client) ListPullRequests(ctx context.Context, projectKey, repoSlug, state string, limit int) ([]PullRequest, error) {
+// RepoPullRequestsOptions configures repository-scoped pull request pages.
+// Role filtering happens upstream via the REST participant filter params
+// (role.1/username.1); Role requires Username.
+type RepoPullRequestsOptions struct {
+	State    string
+	Role     string // AUTHOR or REVIEWER
+	Username string
+	Limit    int // page size; <=0 or >100 uses the default
+	Start    int // page offset as returned in NextStart
+}
+
+// PullRequestsPage is one bounded page of pull requests.
+type PullRequestsPage struct {
+	Values    []PullRequest
+	IsLast    bool
+	NextStart int
+}
+
+// ListRepoPullRequestsPage fetches a single page of repository pull
+// requests with all filters encoded in the upstream query.
+func (c *Client) ListRepoPullRequestsPage(ctx context.Context, projectKey, repoSlug string, opts RepoPullRequestsOptions) (*PullRequestsPage, error) {
 	if projectKey == "" || repoSlug == "" {
 		return nil, fmt.Errorf("project key and repository slug are required")
 	}
 
+	params, err := repoPullRequestParams(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	u := fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests?%s",
+		url.PathEscape(projectKey),
+		url.PathEscape(repoSlug),
+		strings.Join(params, "&"),
+	)
+	req, err := c.http.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp paged[PullRequest]
+	if err := c.http.Do(req, &resp); err != nil {
+		return nil, err
+	}
+
+	return &PullRequestsPage{
+		Values:    resp.Values,
+		IsLast:    resp.IsLastPage || len(resp.Values) == 0,
+		NextStart: resp.NextPageStart,
+	}, nil
+}
+
+func repoPullRequestParams(opts RepoPullRequestsOptions) ([]string, error) {
+	pageSize := opts.Limit
+	if pageSize <= 0 || pageSize > 100 {
+		pageSize = 25
+	}
+
+	params := []string{fmt.Sprintf("limit=%d", pageSize)}
+	if opts.State != "" {
+		params = append(params, "state="+url.QueryEscape(strings.ToUpper(opts.State)))
+	}
+	if opts.Role != "" {
+		role := strings.ToUpper(strings.TrimSpace(opts.Role))
+		if role != "AUTHOR" && role != "REVIEWER" {
+			return nil, fmt.Errorf("unsupported participant role %q; use AUTHOR or REVIEWER", opts.Role)
+		}
+		if strings.TrimSpace(opts.Username) == "" {
+			return nil, fmt.Errorf("participant role filtering requires a username")
+		}
+		params = append(params,
+			"username.1="+url.QueryEscape(opts.Username),
+			"role.1="+role,
+		)
+	}
+	params = append(params, fmt.Sprintf("start=%d", opts.Start))
+	return params, nil
+}
+
+// ListPullRequests lists pull requests for a repository, flattening pages up
+// to limit.
+func (c *Client) ListPullRequests(ctx context.Context, projectKey, repoSlug, state string, limit int) ([]PullRequest, error) {
 	const defaultPageSize = 25
 
 	var (
@@ -286,33 +362,21 @@ func (c *Client) ListPullRequests(ctx context.Context, projectKey, repoSlug, sta
 			}
 		}
 
-		params := []string{fmt.Sprintf("limit=%d", pageSize)}
-		if state != "" {
-			params = append(params, "state="+url.QueryEscape(strings.ToUpper(state)))
-		}
-
-		u := fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests?%s&start=%d",
-			url.PathEscape(projectKey),
-			url.PathEscape(repoSlug),
-			strings.Join(params, "&"),
-			start,
-		)
-		req, err := c.http.NewRequest(ctx, "GET", u, nil)
+		page, err := c.ListRepoPullRequestsPage(ctx, projectKey, repoSlug, RepoPullRequestsOptions{
+			State: state,
+			Limit: pageSize,
+			Start: start,
+		})
 		if err != nil {
 			return nil, err
 		}
 
-		var resp paged[PullRequest]
-		if err := c.http.Do(req, &resp); err != nil {
-			return nil, err
-		}
+		all = append(all, page.Values...)
 
-		all = append(all, resp.Values...)
-
-		if resp.IsLastPage || len(resp.Values) == 0 {
+		if page.IsLast {
 			break
 		}
-		start = resp.NextPageStart
+		start = page.NextStart
 	}
 
 	if limit > 0 && len(all) > limit {
@@ -349,6 +413,44 @@ type DashboardPullRequestsOptions struct {
 	Limit int
 }
 
+// ListDashboardPullRequestsPage fetches one page of the authenticated
+// user's dashboard pull requests; the role filter (AUTHOR, REVIEWER,
+// PARTICIPANT) is encoded upstream.
+func (c *Client) ListDashboardPullRequestsPage(ctx context.Context, opts DashboardPullRequestsOptions, start int) (*PullRequestsPage, error) {
+	pageSize := opts.Limit
+	if pageSize <= 0 || pageSize > 100 {
+		pageSize = 25
+	}
+
+	params := []string{fmt.Sprintf("limit=%d", pageSize)}
+	if opts.State != "" {
+		params = append(params, "state="+url.QueryEscape(strings.ToUpper(opts.State)))
+	}
+	if opts.Role != "" {
+		params = append(params, "role="+url.QueryEscape(strings.ToUpper(opts.Role)))
+	}
+
+	u := fmt.Sprintf("/rest/api/1.0/dashboard/pull-requests?%s&start=%d",
+		strings.Join(params, "&"),
+		start,
+	)
+	req, err := c.http.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp paged[PullRequest]
+	if err := c.http.Do(req, &resp); err != nil {
+		return nil, err
+	}
+
+	return &PullRequestsPage{
+		Values:    resp.Values,
+		IsLast:    resp.IsLastPage || len(resp.Values) == 0,
+		NextStart: resp.NextPageStart,
+	}, nil
+}
+
 // ListDashboardPullRequests lists pull requests for the authenticated user across all repositories.
 func (c *Client) ListDashboardPullRequests(ctx context.Context, opts DashboardPullRequestsOptions) ([]PullRequest, error) {
 	const defaultPageSize = 25
@@ -370,34 +472,19 @@ func (c *Client) ListDashboardPullRequests(ctx context.Context, opts DashboardPu
 			}
 		}
 
-		params := []string{fmt.Sprintf("limit=%d", pageSize)}
-		if opts.State != "" {
-			params = append(params, "state="+url.QueryEscape(strings.ToUpper(opts.State)))
-		}
-		if opts.Role != "" {
-			params = append(params, "role="+url.QueryEscape(strings.ToUpper(opts.Role)))
-		}
-
-		u := fmt.Sprintf("/rest/api/1.0/dashboard/pull-requests?%s&start=%d",
-			strings.Join(params, "&"),
-			start,
-		)
-		req, err := c.http.NewRequest(ctx, "GET", u, nil)
+		pageOpts := opts
+		pageOpts.Limit = pageSize
+		page, err := c.ListDashboardPullRequestsPage(ctx, pageOpts, start)
 		if err != nil {
 			return nil, err
 		}
 
-		var resp paged[PullRequest]
-		if err := c.http.Do(req, &resp); err != nil {
-			return nil, err
-		}
+		all = append(all, page.Values...)
 
-		all = append(all, resp.Values...)
-
-		if resp.IsLastPage || len(resp.Values) == 0 {
+		if page.IsLast {
 			break
 		}
-		start = resp.NextPageStart
+		start = page.NextStart
 	}
 
 	if opts.Limit > 0 && len(all) > opts.Limit {

--- a/pkg/bbdc/pullrequests_test.go
+++ b/pkg/bbdc/pullrequests_test.go
@@ -985,3 +985,71 @@ func containsParam(query, param string) bool {
 	}
 	return false
 }
+
+func TestListRepoPullRequestsPageEncodesParticipantFilters(t *testing.T) {
+	var requests int32
+	var gotQuery string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"values": []any{}, "isLastPage": true})
+	}))
+
+	page, err := client.ListRepoPullRequestsPage(context.Background(), "PROJ", "repo", bbdc.RepoPullRequestsOptions{
+		State:    "open",
+		Role:     "reviewer",
+		Username: "alice",
+		Limit:    50,
+		Start:    30,
+	})
+	if err != nil {
+		t.Fatalf("ListRepoPullRequestsPage: %v", err)
+	}
+	if !page.IsLast {
+		t.Fatal("empty last page must report IsLast")
+	}
+	if got := atomic.LoadInt32(&requests); got != 1 {
+		t.Fatalf("page fetch made %d requests, want exactly 1", got)
+	}
+	for _, want := range []string{"role.1=REVIEWER", "username.1=alice", "state=OPEN", "limit=50", "start=30"} {
+		if !strings.Contains(gotQuery, want) {
+			t.Errorf("query %q missing upstream filter %q", gotQuery, want)
+		}
+	}
+}
+
+func TestListRepoPullRequestsPageRoleValidation(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("no request expected on validation failure")
+	}))
+
+	if _, err := client.ListRepoPullRequestsPage(context.Background(), "PROJ", "repo", bbdc.RepoPullRequestsOptions{Role: "REVIEWER"}); err == nil || !strings.Contains(err.Error(), "requires a username") {
+		t.Fatalf("role without username: err = %v, want username requirement", err)
+	}
+	if _, err := client.ListRepoPullRequestsPage(context.Background(), "PROJ", "repo", bbdc.RepoPullRequestsOptions{Role: "OWNER", Username: "a"}); err == nil || !strings.Contains(err.Error(), "unsupported participant role") {
+		t.Fatalf("bad role: err = %v, want unsupported role", err)
+	}
+}
+
+func TestListDashboardPullRequestsPageEncodesRole(t *testing.T) {
+	var gotQuery string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"values": []any{}, "isLastPage": true})
+	}))
+
+	if _, err := client.ListDashboardPullRequestsPage(context.Background(), bbdc.DashboardPullRequestsOptions{
+		State: "open",
+		Role:  "reviewer",
+		Limit: 25,
+	}, 75); err != nil {
+		t.Fatalf("ListDashboardPullRequestsPage: %v", err)
+	}
+	for _, want := range []string{"role=REVIEWER", "state=OPEN", "limit=25", "start=75"} {
+		if !strings.Contains(gotQuery, want) {
+			t.Errorf("query %q missing %q", gotQuery, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Wave B of the approved `bkt-mcp-serve` plan: the client layer for the read tools. Single-page bounded fetch primitives with every role/state filter encoded in the **upstream API query** — never fetch-then-filter.

- **DC**: `ListRepoPullRequestsPage` encodes participant filters (`role.1=AUTHOR|REVIEWER` + `username.1`, role requires username); `ListDashboardPullRequestsPage` exposes the dashboard `role=` filter page-by-page.
- **Cloud**: `PullRequestListOptions.Reviewer` filters via identity-shaped BBQL (`reviewers.uuid|account_id|nickname`, AND-combined with the author filter); `ListRepoPullRequestsPage`/`ListWorkspacePullRequestsPage` return opaque `Next` references. The workspace endpoint stays author-scoped (Cloud has no workspace-wide reviewer filter).
- Nickname identities now use `author.nickname`/`reviewers.nickname` per Atlassian's filtering docs (username filtering is deprecated) — this also fixes the pre-existing CLI `--mine` fallback.
- Caller-supplied `Next` references are hardened: reduced to their request URI (no cross-host egress) and bound to the terminal endpoint the page sequence started from.

The four existing flattening methods are now thin wrappers over the page primitives — zero caller changes, existing tests pass unchanged.

## Testing

- Contract tests asserting the exact upstream query on both platforms (participant filters, dashboard role, reviewer BBQL exactness for uuid/nickname/AND-combined, all on the first request)
- SSRF regressions: attacker host receives zero requests; cross-host, trailing-segment, and glued-prefix references rejected with no HTTP call; valid `/2.0` reference round-trips
- `go test ./...`, `-race` on both client packages, vet, `make check-generated-skill`
- Peer-reviewed by codex (three rounds; nickname-field, SSRF, and endpoint-binding findings all fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)