### PR TITLE
feat(mcp): add normalized DTO adapters (wave C.1)

### DIFF
--- a/internal/mcpserver/adapters.go
+++ b/internal/mcpserver/adapters.go
@@ -1,0 +1,392 @@
+package mcpserver
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/avivsinai/bitbucket-cli/pkg/bbcloud"
+	"github.com/avivsinai/bitbucket-cli/pkg/bbdc"
+	"github.com/avivsinai/bitbucket-cli/pkg/types"
+)
+
+func adaptDCRepository(raw bbdc.Repository) Repository {
+	scope := ""
+	isPrivate := true
+	if raw.Project != nil {
+		scope = raw.Project.Key
+		isPrivate = !raw.Project.Public
+	}
+
+	return Repository{
+		Scope:         scope,
+		Slug:          raw.Slug,
+		Name:          raw.Name,
+		DefaultBranch: raw.DefaultBranch,
+		IsPrivate:     isPrivate,
+		URL:           stripURLQuery(firstDCLink(raw.Links.Web, raw.Links.Self)),
+	}
+}
+
+func adaptCloudRepository(raw bbcloud.Repository) Repository {
+	return Repository{
+		Scope:         raw.Workspace.Slug,
+		Slug:          raw.Slug,
+		Name:          raw.Name,
+		DefaultBranch: raw.MainBranch.Name,
+		IsPrivate:     raw.IsPrivate,
+		URL:           stripURLQuery(raw.Links.HTML.Href),
+	}
+}
+
+func adaptDCPullRequest(raw bbdc.PullRequest, full bool) (PullRequest, error) {
+	createdAt, err := formatDCTimestamp("createdDate", raw.CreatedDate)
+	if err != nil {
+		return PullRequest{}, err
+	}
+	updatedAt, err := formatDCTimestamp("updatedDate", raw.UpdatedDate)
+	if err != nil {
+		return PullRequest{}, err
+	}
+	reviewers, err := adaptDCReviewers(raw.Reviewers)
+	if err != nil {
+		return PullRequest{}, err
+	}
+
+	result := PullRequest{
+		ID:           raw.ID,
+		Title:        raw.Title,
+		State:        raw.State,
+		Author:       adaptDCUser(raw.Author.User),
+		SourceBranch: raw.FromRef.DisplayID,
+		TargetBranch: raw.ToRef.DisplayID,
+		Repo:         adaptDCRepositoryRef(raw.ToRef.Repository),
+		CreatedAt:    createdAt,
+		UpdatedAt:    updatedAt,
+		URL:          stripURLQuery(firstDCSelfLink(raw.Links.Self)),
+		Reviewers:    reviewers,
+	}
+	if full {
+		description := boundBitbucketText(raw.Description, PullRequestDescriptionLimit)
+		result.Description = &description
+	}
+	return result, nil
+}
+
+func adaptCloudPullRequest(raw bbcloud.PullRequest, full bool) (PullRequest, error) {
+	createdAt, err := formatCloudTimestamp("created_on", raw.CreatedOn)
+	if err != nil {
+		return PullRequest{}, err
+	}
+	updatedAt, err := formatCloudTimestamp("updated_on", raw.UpdatedOn)
+	if err != nil {
+		return PullRequest{}, err
+	}
+	reviewers, err := adaptCloudReviewers(raw.Reviewers, raw.Participants)
+	if err != nil {
+		return PullRequest{}, err
+	}
+
+	result := PullRequest{
+		ID:    raw.ID,
+		Title: raw.Title,
+		State: raw.State,
+		Author: User{
+			Name:        firstNonEmpty(raw.AuthorNickname, raw.Author.Username, raw.Author.AccountID, raw.Author.UUID),
+			DisplayName: raw.Author.DisplayName,
+		},
+		SourceBranch: raw.Source.Branch.Name,
+		TargetBranch: raw.Destination.Branch.Name,
+		Repo:         adaptCloudRepositoryRef(raw.Destination.Repository),
+		CreatedAt:    createdAt,
+		UpdatedAt:    updatedAt,
+		URL:          stripURLQuery(raw.Links.HTML.Href),
+		Reviewers:    reviewers,
+	}
+	if full {
+		description := boundBitbucketText(raw.Description, PullRequestDescriptionLimit)
+		result.Description = &description
+	}
+	return result, nil
+}
+
+func adaptDCComment(raw bbdc.PullRequestComment) (Comment, error) {
+	createdAt := ""
+	if raw.CreatedDate != nil {
+		var err error
+		createdAt, err = formatDCTimestamp("createdDate", *raw.CreatedDate)
+		if err != nil {
+			return Comment{}, err
+		}
+	}
+
+	result := Comment{
+		ID:        raw.ID,
+		Author:    adaptDCUser(raw.Author),
+		Body:      boundBitbucketText(raw.Text, CommentBodyLimit),
+		CreatedAt: createdAt,
+	}
+	if raw.Parent != nil {
+		result.ParentID = intPointer(raw.Parent.ID)
+	}
+	if raw.Anchor != nil {
+		result.Path = raw.Anchor.Path
+		result.Line = intPointer(raw.Anchor.Line)
+	}
+	return result, nil
+}
+
+func adaptCloudComment(raw bbcloud.PullRequestComment) (Comment, error) {
+	createdAt := ""
+	if raw.CreatedOn != "" {
+		var err error
+		createdAt, err = formatCloudTimestamp("created_on", raw.CreatedOn)
+		if err != nil {
+			return Comment{}, err
+		}
+	}
+
+	result := Comment{
+		ID:        raw.ID,
+		Body:      boundBitbucketText(raw.Content.Raw, CommentBodyLimit),
+		CreatedAt: createdAt,
+	}
+	if raw.User != nil {
+		result.Author = User{
+			Name:        firstNonEmpty(raw.User.Nickname, raw.User.AccountID, raw.User.UUID),
+			DisplayName: raw.User.DisplayName,
+		}
+	}
+	if raw.Parent != nil {
+		result.ParentID = intPointer(raw.Parent.ID)
+	}
+	if raw.Inline != nil {
+		result.Path = raw.Inline.Path
+		switch {
+		case raw.Inline.To != nil:
+			result.Line = intPointer(*raw.Inline.To)
+		case raw.Inline.From != nil:
+			result.Line = intPointer(*raw.Inline.From)
+		}
+	}
+	return result, nil
+}
+
+var dcCheckStates = map[string]CheckState{
+	"INPROGRESS": CheckRunning,
+	"SUCCESSFUL": CheckSuccessful,
+	"FAILED":     CheckFailed,
+	"CANCELLED":  CheckStopped,
+	"UNKNOWN":    CheckUnknown,
+}
+
+var cloudCheckStates = map[string]CheckState{
+	"PENDING":              CheckPending,
+	"IN_PROGRESS":          CheckRunning,
+	"INPROGRESS":           CheckRunning,
+	"RUNNING":              CheckRunning,
+	"SUCCESSFUL":           CheckSuccessful,
+	"COMPLETED SUCCESSFUL": CheckSuccessful,
+	"FAILED":               CheckFailed,
+	"ERROR":                CheckFailed,
+	"COMPLETED FAILED":     CheckFailed,
+	"COMPLETED ERROR":      CheckFailed,
+	"STOPPED":              CheckStopped,
+	"CANCELLED":            CheckStopped,
+	"COMPLETED STOPPED":    CheckStopped,
+}
+
+func adaptDCCheck(raw types.CommitStatus) Check {
+	return adaptCheck(raw, stateFromMap(raw.State, dcCheckStates))
+}
+
+func adaptCloudCheck(raw types.CommitStatus) Check {
+	return adaptCheck(raw, stateFromMap(raw.State, cloudCheckStates))
+}
+
+func adaptCheck(raw types.CommitStatus, state CheckState) Check {
+	return Check{
+		Key:   raw.Key,
+		Name:  raw.Name,
+		State: state,
+		URL:   stripURLQuery(raw.URL),
+	}
+}
+
+func adaptDiff(content, sourceCommit, targetCommit string) Diff {
+	return Diff{
+		Content:      boundBitbucketText(content, DiffContentLimit),
+		SourceCommit: sourceCommit,
+		TargetCommit: targetCommit,
+	}
+}
+
+func adaptDCReviewers(raw []bbdc.PullRequestReviewer) ([]Reviewer, error) {
+	reviewers := make([]Reviewer, 0, len(raw))
+	for _, reviewer := range raw {
+		approved, ok := approvalState(reviewer.Approved, reviewer.Status)
+		if !ok {
+			return nil, fmt.Errorf("reviewer %q has no approval state", firstNonEmpty(reviewer.User.Name, reviewer.User.Slug))
+		}
+		reviewers = append(reviewers, Reviewer{
+			Name:        firstNonEmpty(reviewer.User.Name, reviewer.User.Slug),
+			DisplayName: reviewer.User.FullName,
+			Approved:    approved,
+		})
+	}
+	return reviewers, nil
+}
+
+func adaptCloudReviewers(raw []bbcloud.User, participants []bbcloud.PullRequestParticipant) ([]Reviewer, error) {
+	reviewers := make([]Reviewer, 0, len(raw))
+	for _, reviewer := range raw {
+		approved, known, matched := cloudReviewerApproval(reviewer, participants)
+		if matched && !known {
+			return nil, fmt.Errorf("reviewer %q has no participant approval state", cloudUserName(reviewer))
+		}
+		reviewers = append(reviewers, Reviewer{
+			Name:        cloudUserName(reviewer),
+			DisplayName: reviewer.Display,
+			Approved:    approved,
+		})
+	}
+	return reviewers, nil
+}
+
+func cloudReviewerApproval(reviewer bbcloud.User, participants []bbcloud.PullRequestParticipant) (approved, known, matched bool) {
+	for _, participant := range participants {
+		if sameCloudUser(reviewer, participant.User) {
+			approved, known := approvalState(participant.Approved, participant.State)
+			return approved, known, true
+		}
+	}
+	return false, true, false
+}
+
+func approvalState(approved *bool, state string) (bool, bool) {
+	if approved != nil {
+		return *approved, true
+	}
+	switch strings.ToUpper(strings.TrimSpace(state)) {
+	case "APPROVED":
+		return true, true
+	case "UNAPPROVED", "NOT_APPROVED", "CHANGES_REQUESTED", "NEEDS_WORK":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+func sameCloudUser(a, b bbcloud.User) bool {
+	for _, pair := range [][2]string{
+		{a.UUID, b.UUID},
+		{a.AccountID, b.AccountID},
+		{a.Nickname, b.Nickname},
+		{a.Username, b.Username},
+	} {
+		if pair[0] != "" && pair[1] != "" && pair[0] == pair[1] {
+			return true
+		}
+	}
+	return false
+}
+
+func cloudUserName(user bbcloud.User) string {
+	return firstNonEmpty(user.Nickname, user.Username, user.AccountID, user.UUID)
+}
+
+func adaptDCUser(user bbdc.User) User {
+	return User{
+		Name:        firstNonEmpty(user.Name, user.Slug),
+		DisplayName: user.FullName,
+	}
+}
+
+func adaptDCRepositoryRef(repo bbdc.Repository) RepositoryRef {
+	scope := ""
+	if repo.Project != nil {
+		scope = repo.Project.Key
+	}
+	return RepositoryRef{Scope: scope, Slug: repo.Slug}
+}
+
+func adaptCloudRepositoryRef(repo bbcloud.RepositoryRef) RepositoryRef {
+	scope, slug, _ := strings.Cut(repo.FullName, "/")
+	if repo.Slug != "" {
+		slug = repo.Slug
+	}
+	return RepositoryRef{Scope: scope, Slug: slug}
+}
+
+func formatDCTimestamp(field string, millis int64) (string, error) {
+	if millis <= 0 {
+		return "", fmt.Errorf("missing or invalid Bitbucket Data Center %s", field)
+	}
+	return time.UnixMilli(millis).UTC().Format(time.RFC3339Nano), nil
+}
+
+func formatCloudTimestamp(field, value string) (string, error) {
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return "", fmt.Errorf("parse Bitbucket Cloud %s: %w", field, err)
+	}
+	return parsed.UTC().Format(time.RFC3339Nano), nil
+}
+
+func stateFromMap(raw string, states map[string]CheckState) CheckState {
+	normalized := strings.Join(strings.Fields(strings.ToUpper(raw)), " ")
+	if state, ok := states[normalized]; ok {
+		return state
+	}
+	return CheckUnknown
+}
+
+func firstDCLink(groups ...[]struct {
+	Href string `json:"href"`
+}) string {
+	for _, group := range groups {
+		if link := firstDCSelfLink(group); link != "" {
+			return link
+		}
+	}
+	return ""
+}
+
+func firstDCSelfLink(links []struct {
+	Href string `json:"href"`
+}) string {
+	for _, link := range links {
+		if link.Href != "" {
+			return link.Href
+		}
+	}
+	return ""
+}
+
+func stripURLQuery(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		before, _, _ := strings.Cut(raw, "?")
+		return before
+	}
+	parsed.RawQuery = ""
+	parsed.ForceQuery = false
+	return parsed.String()
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func intPointer(value int) *int {
+	return &value
+}

--- a/internal/mcpserver/adapters_test.go
+++ b/internal/mcpserver/adapters_test.go
@@ -1,0 +1,348 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/bitbucket-cli/pkg/bbcloud"
+	"github.com/avivsinai/bitbucket-cli/pkg/bbdc"
+	"github.com/avivsinai/bitbucket-cli/pkg/types"
+)
+
+func TestRepositoryAdapters(t *testing.T) {
+	t.Run("data center", func(t *testing.T) {
+		var raw bbdc.Repository
+		mustUnmarshal(t, `{
+			"slug":"api","name":"API","defaultBranch":"main",
+			"project":{"key":"PROJ","public":false},
+			"links":{"web":[{"href":"https://dc.example/projects/PROJ/repos/api?token=redacted"}]}
+		}`, &raw)
+
+		got := adaptDCRepository(raw)
+		want := Repository{
+			Scope: "PROJ", Slug: "api", Name: "API", DefaultBranch: "main",
+			IsPrivate: true, URL: "https://dc.example/projects/PROJ/repos/api",
+		}
+		if got != want {
+			t.Fatalf("adaptDCRepository() = %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("cloud", func(t *testing.T) {
+		var raw bbcloud.Repository
+		mustUnmarshal(t, `{
+			"slug":"api","name":"API","is_private":true,
+			"workspace":{"slug":"team"},"mainbranch":{"name":"trunk"},
+			"links":{"html":{"href":"https://bitbucket.org/team/api?secret=nope"}}
+		}`, &raw)
+
+		got := adaptCloudRepository(raw)
+		want := Repository{
+			Scope: "team", Slug: "api", Name: "API", DefaultBranch: "trunk",
+			IsPrivate: true, URL: "https://bitbucket.org/team/api",
+		}
+		if got != want {
+			t.Fatalf("adaptCloudRepository() = %+v, want %+v", got, want)
+		}
+	})
+}
+
+func TestDCPullRequestAdapter(t *testing.T) {
+	longDescription := strings.Repeat("x", PullRequestDescriptionLimit+1)
+	var raw bbdc.PullRequest
+	mustUnmarshal(t, `{
+		"id":42,"title":"Ship it","description":`+mustJSONString(t, longDescription)+`,"state":"OPEN",
+		"createdDate":1704067200000,"updatedDate":1704067200123,
+		"author":{"user":{"name":"alice","displayName":"Alice A"}},
+		"fromRef":{"displayId":"feature","repository":{"slug":"fork","project":{"key":"FORK"}}},
+		"toRef":{"displayId":"main","repository":{"slug":"api","project":{"key":"PROJ"}}},
+		"reviewers":[
+			{"user":{"name":"bob","displayName":"Bob B"},"approved":true,"role":"REVIEWER","status":"APPROVED"},
+			{"user":{"name":"carol","displayName":"Carol C"},"approved":false,"role":"REVIEWER","status":"UNAPPROVED"}
+		],
+		"links":{"self":[{"href":"https://dc.example/pr/42?auth=drop"}]}
+	}`, &raw)
+
+	got, err := adaptDCPullRequest(raw, true)
+	if err != nil {
+		t.Fatalf("adaptDCPullRequest: %v", err)
+	}
+	if got.ID != 42 || got.Title != "Ship it" || got.State != "OPEN" {
+		t.Fatalf("identity fields = %+v", got)
+	}
+	if got.Author != (User{Name: "alice", DisplayName: "Alice A"}) {
+		t.Fatalf("author = %+v", got.Author)
+	}
+	if got.SourceBranch != "feature" || got.TargetBranch != "main" || got.Repo != (RepositoryRef{Scope: "PROJ", Slug: "api"}) {
+		t.Fatalf("refs/repo = %q/%q %+v", got.SourceBranch, got.TargetBranch, got.Repo)
+	}
+	if got.CreatedAt != "2024-01-01T00:00:00Z" || got.UpdatedAt != "2024-01-01T00:00:00.123Z" {
+		t.Fatalf("timestamps = %q/%q", got.CreatedAt, got.UpdatedAt)
+	}
+	if got.URL != "https://dc.example/pr/42" {
+		t.Fatalf("URL = %q, want query-free URL", got.URL)
+	}
+	if len(got.Reviewers) != 2 || !got.Reviewers[0].Approved || got.Reviewers[1].Approved {
+		t.Fatalf("reviewers = %+v", got.Reviewers)
+	}
+	assertBounded(t, got.Description, PullRequestDescriptionLimit, len(longDescription))
+
+	list, err := adaptDCPullRequest(raw, false)
+	if err != nil {
+		t.Fatalf("adaptDCPullRequest list variant: %v", err)
+	}
+	if list.Description != nil {
+		t.Fatalf("list variant description = %+v, want omitted", list.Description)
+	}
+}
+
+func TestDCPullRequestAdapterRejectsMissingApproval(t *testing.T) {
+	var raw bbdc.PullRequest
+	mustUnmarshal(t, `{
+		"createdDate":1704067200000,"updatedDate":1704067200000,
+		"reviewers":[{"user":{"name":"alice"}}]
+	}`, &raw)
+	if _, err := adaptDCPullRequest(raw, false); err == nil || !strings.Contains(err.Error(), "approval") {
+		t.Fatalf("error = %v, want missing-approval error", err)
+	}
+}
+
+func TestCloudPullRequestAdapter(t *testing.T) {
+	longDescription := strings.Repeat("€", PullRequestDescriptionLimit/3+1)
+	var raw bbcloud.PullRequest
+	mustUnmarshal(t, `{
+		"id":7,"title":"Cloud PR","description":`+mustJSONString(t, longDescription)+`,"state":"OPEN",
+		"created_on":"2024-01-01T02:30:00+02:00","updated_on":"2024-01-01T00:00:00.123456+00:00",
+		"author":{"nickname":"alice","display_name":"Alice A"},
+		"source":{"branch":{"name":"feature"},"repository":{"slug":"fork","full_name":"other/fork"}},
+		"destination":{"branch":{"name":"main"},"repository":{"slug":"api","full_name":"team/api"}},
+		"reviewers":[
+			{"uuid":"{bob}","nickname":"bob","display_name":"Bob B"},
+			{"account_id":"carol-id","nickname":"carol","display_name":"Carol C"}
+		],
+		"participants":[
+			{"user":{"uuid":"{bob}"},"role":"REVIEWER","approved":true,"state":"approved"},
+			{"user":{"account_id":"carol-id"},"role":"REVIEWER","approved":false,"state":"unapproved"}
+		],
+		"links":{"html":{"href":"https://bitbucket.org/team/api/pull-requests/7?token=drop"}}
+	}`, &raw)
+
+	got, err := adaptCloudPullRequest(raw, true)
+	if err != nil {
+		t.Fatalf("adaptCloudPullRequest: %v", err)
+	}
+	if got.Author != (User{Name: "alice", DisplayName: "Alice A"}) {
+		t.Fatalf("author = %+v", got.Author)
+	}
+	if got.Repo != (RepositoryRef{Scope: "team", Slug: "api"}) {
+		t.Fatalf("repo = %+v", got.Repo)
+	}
+	if got.CreatedAt != "2024-01-01T00:30:00Z" || got.UpdatedAt != "2024-01-01T00:00:00.123456Z" {
+		t.Fatalf("timestamps = %q/%q", got.CreatedAt, got.UpdatedAt)
+	}
+	if got.URL != "https://bitbucket.org/team/api/pull-requests/7" {
+		t.Fatalf("URL = %q", got.URL)
+	}
+	if len(got.Reviewers) != 2 || !got.Reviewers[0].Approved || got.Reviewers[1].Approved {
+		t.Fatalf("reviewers = %+v", got.Reviewers)
+	}
+	assertBounded(t, got.Description, PullRequestDescriptionLimit, len(longDescription))
+}
+
+func TestCloudPullRequestAdapterErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "invalid timestamp",
+			raw:  `{"created_on":"not-a-time","updated_on":"2024-01-01T00:00:00Z"}`,
+			want: "created_on",
+		},
+		{
+			name: "matched participant missing approval",
+			raw:  `{"created_on":"2024-01-01T00:00:00Z","updated_on":"2024-01-01T00:00:00Z","reviewers":[{"uuid":"{bob}"}],"participants":[{"user":{"uuid":"{bob}"}}]}`,
+			want: "approval",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var raw bbcloud.PullRequest
+			mustUnmarshal(t, tt.raw, &raw)
+			if _, err := adaptCloudPullRequest(raw, false); err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestCloudPullRequestAdapterTreatsReviewerMissingFromParticipantsAsUnapproved(t *testing.T) {
+	var raw bbcloud.PullRequest
+	mustUnmarshal(t, `{
+		"created_on":"2024-01-01T00:00:00Z","updated_on":"2024-01-01T00:00:00Z",
+		"reviewers":[{"uuid":"{bob}","nickname":"bob","display_name":"Bob B"}]
+	}`, &raw)
+
+	got, err := adaptCloudPullRequest(raw, false)
+	if err != nil {
+		t.Fatalf("adaptCloudPullRequest: %v", err)
+	}
+	if len(got.Reviewers) != 1 || got.Reviewers[0] != (Reviewer{Name: "bob", DisplayName: "Bob B", Approved: false}) {
+		t.Fatalf("reviewers = %+v, want bob unapproved", got.Reviewers)
+	}
+}
+
+func TestCommentAdapters(t *testing.T) {
+	t.Run("data center", func(t *testing.T) {
+		body := strings.Repeat("d", CommentBodyLimit+1)
+		var raw bbdc.PullRequestComment
+		mustUnmarshal(t, `{
+			"id":9,"text":`+mustJSONString(t, body)+`,"createdDate":1704067200123,
+			"author":{"name":"alice","displayName":"Alice A"},
+			"parent":{"id":7},"anchor":{"path":"src/main.go","line":12}
+		}`, &raw)
+
+		got, err := adaptDCComment(raw)
+		if err != nil {
+			t.Fatalf("adaptDCComment: %v", err)
+		}
+		if got.CreatedAt != "2024-01-01T00:00:00.123Z" || got.ParentID == nil || *got.ParentID != 7 {
+			t.Fatalf("date/parent = %q/%v", got.CreatedAt, got.ParentID)
+		}
+		if got.Path != "src/main.go" || got.Line == nil || *got.Line != 12 {
+			t.Fatalf("inline = %q/%v", got.Path, got.Line)
+		}
+		assertTextBounded(t, got.Body, CommentBodyLimit, len(body))
+	})
+
+	t.Run("data center omits absent created date", func(t *testing.T) {
+		got, err := adaptDCComment(bbdc.PullRequestComment{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.CreatedAt != "" {
+			t.Fatalf("created_at = %q, want omitted", got.CreatedAt)
+		}
+	})
+
+	t.Run("cloud", func(t *testing.T) {
+		var raw bbcloud.PullRequestComment
+		mustUnmarshal(t, `{
+			"id":5,"content":{"raw":"hello"},
+			"user":{"nickname":"alice","display_name":"Alice A"},
+			"created_on":"2024-01-01T02:00:00+02:00",
+			"parent":{"id":3},"inline":{"path":"README.md","from":8,"to":9}
+		}`, &raw)
+
+		got, err := adaptCloudComment(raw)
+		if err != nil {
+			t.Fatalf("adaptCloudComment: %v", err)
+		}
+		if got.CreatedAt != "2024-01-01T00:00:00Z" || got.ParentID == nil || *got.ParentID != 3 {
+			t.Fatalf("date/parent = %q/%v", got.CreatedAt, got.ParentID)
+		}
+		if got.Path != "README.md" || got.Line == nil || *got.Line != 9 {
+			t.Fatalf("inline = %q/%v, want destination line 9", got.Path, got.Line)
+		}
+	})
+}
+
+func TestCheckStateMappings(t *testing.T) {
+	dc := []struct {
+		raw  string
+		want CheckState
+	}{
+		{"INPROGRESS", CheckRunning},
+		{"SUCCESSFUL", CheckSuccessful},
+		{"FAILED", CheckFailed},
+		{"CANCELLED", CheckStopped},
+		{"UNKNOWN", CheckUnknown},
+		{"new-state", CheckUnknown},
+	}
+	for _, tt := range dc {
+		t.Run("dc "+tt.raw, func(t *testing.T) {
+			got := adaptDCCheck(types.CommitStatus{State: tt.raw, Key: "build", Name: "CI", URL: "https://ci.example/run?token=drop"})
+			if got.State != tt.want || got.URL != "https://ci.example/run" {
+				t.Fatalf("adaptDCCheck(%q) = %+v, want state %q and query-free URL", tt.raw, got, tt.want)
+			}
+		})
+	}
+
+	cloud := []struct {
+		raw  string
+		want CheckState
+	}{
+		{"PENDING", CheckPending},
+		{"IN_PROGRESS", CheckRunning},
+		{"INPROGRESS", CheckRunning},
+		{"RUNNING", CheckRunning},
+		{"SUCCESSFUL", CheckSuccessful},
+		{"COMPLETED SUCCESSFUL", CheckSuccessful},
+		{"FAILED", CheckFailed},
+		{"ERROR", CheckFailed},
+		{"COMPLETED FAILED", CheckFailed},
+		{"COMPLETED ERROR", CheckFailed},
+		{"STOPPED", CheckStopped},
+		{"CANCELLED", CheckStopped},
+		{"COMPLETED STOPPED", CheckStopped},
+		{"COMPLETED", CheckUnknown},
+		{"new-state", CheckUnknown},
+	}
+	for _, tt := range cloud {
+		t.Run("cloud "+tt.raw, func(t *testing.T) {
+			got := adaptCloudCheck(types.CommitStatus{State: tt.raw})
+			if got.State != tt.want {
+				t.Fatalf("adaptCloudCheck(%q).State = %q, want %q", tt.raw, got.State, tt.want)
+			}
+		})
+	}
+}
+
+func TestDiffAdapterBoundsContent(t *testing.T) {
+	content := strings.Repeat("x", DiffContentLimit) + "€"
+	got := adaptDiff(content, "source-sha", "target-sha")
+	if got.SourceCommit != "source-sha" || got.TargetCommit != "target-sha" {
+		t.Fatalf("commits = %q/%q", got.SourceCommit, got.TargetCommit)
+	}
+	assertTextBounded(t, got.Content, DiffContentLimit, len(content))
+}
+
+func mustUnmarshal(t *testing.T, raw string, out any) {
+	t.Helper()
+	if err := json.Unmarshal([]byte(raw), out); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+}
+
+func mustJSONString(t *testing.T, value string) string {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(raw)
+}
+
+func assertBounded(t *testing.T, got *BoundedText, limit, originalSize int) {
+	t.Helper()
+	if got == nil {
+		t.Fatal("bounded text is nil")
+		return
+	}
+	assertTextBounded(t, *got, limit, originalSize)
+}
+
+func assertTextBounded(t *testing.T, got BoundedText, limit, originalSize int) {
+	t.Helper()
+	if !got.Truncated || got.OriginalSize == nil || *got.OriginalSize != originalSize {
+		t.Fatalf("bounded text metadata = %+v, want truncated with original_size %d", got, originalSize)
+	}
+	if len(got.Text) > limit {
+		t.Fatalf("bounded text length = %d, exceeds %d", len(got.Text), limit)
+	}
+	if got.Provenance.Source != ProvenanceSourceBitbucket || got.Provenance.Trust != ProvenanceTrustUntrusted {
+		t.Fatalf("provenance = %+v", got.Provenance)
+	}
+}

--- a/internal/mcpserver/dto.go
+++ b/internal/mcpserver/dto.go
@@ -1,0 +1,213 @@
+package mcpserver
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	// DefaultListLimit and MaxListLimit freeze the v1 collection bounds.
+	DefaultListLimit            = 25
+	MaxListLimit                = 100
+	CommentBodyLimit            = 16 * 1024
+	PullRequestDescriptionLimit = 16 * 1024
+	DiffContentLimit            = 256 * 1024
+)
+
+const (
+	// ProvenanceSourceBitbucket and ProvenanceTrustUntrusted mark external
+	// content without rewriting it.
+	ProvenanceSourceBitbucket = "bitbucket"
+	ProvenanceTrustUntrusted  = "untrusted"
+)
+
+// ContextInfo is the bkt_get_context result DTO. Field shapes are part of
+// the frozen v1 contract; never include credentials.
+type ContextInfo struct {
+	Platform     string   `json:"platform" jsonschema:"the pinned Bitbucket platform: dc (Data Center) or cloud"`
+	HostLabel    string   `json:"host_label" jsonschema:"the bkt config host entry this server is pinned to"`
+	DefaultScope string   `json:"default_scope,omitempty" jsonschema:"default scope (DC project key or Cloud workspace) used when a tool call omits the repository locator"`
+	DefaultRepo  string   `json:"default_repo,omitempty" jsonschema:"default repository slug used when a tool call omits the repository locator"`
+	Capabilities []string `json:"capabilities" jsonschema:"capability identifiers for the tools and roles this server supports on the pinned platform"`
+}
+
+// Repository is the platform-neutral repository result.
+type Repository struct {
+	Scope         string `json:"scope"`
+	Slug          string `json:"slug"`
+	Name          string `json:"name"`
+	DefaultBranch string `json:"default_branch,omitempty"`
+	IsPrivate     bool   `json:"is_private"`
+	URL           string `json:"url"`
+}
+
+// User is the stable identity shape embedded in author and reviewer results.
+type User struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+}
+
+// RepositoryRef identifies a repository without leaking platform client types.
+type RepositoryRef struct {
+	Scope string `json:"scope"`
+	Slug  string `json:"slug"`
+}
+
+// Reviewer carries the approval state returned by the upstream platform.
+type Reviewer struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	Approved    bool   `json:"approved"`
+}
+
+// PullRequest is the shared DC/Cloud pull request result. Description is set
+// only by full-detail adapters.
+type PullRequest struct {
+	ID           int           `json:"id"`
+	Title        string        `json:"title"`
+	State        string        `json:"state"`
+	Author       User          `json:"author"`
+	SourceBranch string        `json:"source_branch"`
+	TargetBranch string        `json:"target_branch"`
+	Repo         RepositoryRef `json:"repo"`
+	CreatedAt    string        `json:"created_at"`
+	UpdatedAt    string        `json:"updated_at"`
+	URL          string        `json:"url"`
+	Reviewers    []Reviewer    `json:"reviewers"`
+	Description  *BoundedText  `json:"description,omitempty"`
+}
+
+// Comment is a normalized pull request comment. CreatedAt is omitted when an
+// upstream response genuinely has no timestamp.
+type Comment struct {
+	ID        int         `json:"id"`
+	Author    User        `json:"author"`
+	Body      BoundedText `json:"body"`
+	CreatedAt string      `json:"created_at,omitempty"`
+	ParentID  *int        `json:"parent_id,omitempty"`
+	Path      string      `json:"path,omitempty"`
+	Line      *int        `json:"line,omitempty"`
+}
+
+// CheckState is the closed set of normalized build/check outcomes.
+type CheckState string
+
+const (
+	CheckPending    CheckState = "pending"
+	CheckRunning    CheckState = "running"
+	CheckSuccessful CheckState = "successful"
+	CheckFailed     CheckState = "failed"
+	CheckStopped    CheckState = "stopped"
+	CheckUnknown    CheckState = "unknown"
+)
+
+// Check is a normalized commit build status.
+type Check struct {
+	Key   string     `json:"key"`
+	Name  string     `json:"name,omitempty"`
+	State CheckState `json:"state"`
+	URL   string     `json:"url,omitempty"`
+}
+
+// Diff contains bounded, untrusted unified diff content.
+type Diff struct {
+	Content      BoundedText `json:"content"`
+	SourceCommit string      `json:"source_commit,omitempty"`
+	TargetCommit string      `json:"target_commit,omitempty"`
+}
+
+// TextProvenance identifies where externally authored content came from and
+// how consumers must treat it.
+type TextProvenance struct {
+	Source string `json:"source"`
+	Trust  string `json:"trust"`
+}
+
+// BoundedText is the only carrier for Bitbucket-authored prose and diff data.
+type BoundedText struct {
+	Text         string         `json:"text"`
+	Truncated    bool           `json:"truncated"`
+	OriginalSize *int           `json:"original_size,omitempty"`
+	Provenance   TextProvenance `json:"provenance"`
+}
+
+// ListEnvelope is a bounded collection result. A cursor can be added later
+// without changing the existing fields.
+type ListEnvelope[T any] struct {
+	Items     []T  `json:"items"`
+	Limit     int  `json:"limit"`
+	Count     int  `json:"count"`
+	Truncated bool `json:"truncated"`
+}
+
+func newListEnvelope[T any](items []T, requestedLimit int, hasMore bool) ListEnvelope[T] {
+	limit := normalizedListLimit(requestedLimit)
+	count := min(len(items), limit)
+	bounded := make([]T, count)
+	copy(bounded, items[:count])
+	return ListEnvelope[T]{
+		Items:     bounded,
+		Limit:     limit,
+		Count:     count,
+		Truncated: hasMore || len(items) > limit,
+	}
+}
+
+func normalizedListLimit(requested int) int {
+	switch {
+	case requested <= 0:
+		return DefaultListLimit
+	case requested > MaxListLimit:
+		return MaxListLimit
+	default:
+		return requested
+	}
+}
+
+// ErrorCode is the closed set of machine-readable v1 error categories.
+type ErrorCode string
+
+const (
+	ErrorInvalidInput          ErrorCode = "invalid_input"
+	ErrorNotFound              ErrorCode = "not_found"
+	ErrorAuthFailed            ErrorCode = "auth_failed"
+	ErrorUnsupportedOnPlatform ErrorCode = "unsupported_on_platform"
+	ErrorRateLimited           ErrorCode = "rate_limited"
+	ErrorUpstream              ErrorCode = "upstream_error"
+)
+
+// Error is the redacted, machine-readable tool error payload.
+type Error struct {
+	Code      ErrorCode      `json:"code"`
+	Message   string         `json:"message"`
+	Retryable bool           `json:"retryable"`
+	Details   map[string]any `json:"details,omitempty"`
+}
+
+func boundBitbucketText(text string, limit int) BoundedText {
+	text = strings.ToValidUTF8(text, "\ufffd")
+	sourceSize := len(text)
+	if limit < 0 {
+		limit = 0
+	}
+
+	bounded := BoundedText{
+		Text: text,
+		Provenance: TextProvenance{
+			Source: ProvenanceSourceBitbucket,
+			Trust:  ProvenanceTrustUntrusted,
+		},
+	}
+	if len(text) <= limit {
+		return bounded
+	}
+
+	cut := limit
+	for cut > 0 && !utf8.RuneStart(text[cut]) {
+		cut--
+	}
+	bounded.Text = text[:cut]
+	bounded.Truncated = true
+	bounded.OriginalSize = &sourceSize
+	return bounded
+}

--- a/internal/mcpserver/dto_test.go
+++ b/internal/mcpserver/dto_test.go
@@ -1,0 +1,187 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestFrozenBounds(t *testing.T) {
+	if DefaultListLimit != 25 || MaxListLimit != 100 {
+		t.Fatalf("list bounds = default %d, max %d; want 25 and 100", DefaultListLimit, MaxListLimit)
+	}
+	if CommentBodyLimit != 16*1024 || PullRequestDescriptionLimit != 16*1024 {
+		t.Fatalf("prose bounds = comment %d, PR description %d; want 16 KiB each", CommentBodyLimit, PullRequestDescriptionLimit)
+	}
+	if DiffContentLimit != 256*1024 {
+		t.Fatalf("diff bound = %d; want 256 KiB", DiffContentLimit)
+	}
+}
+
+func TestNewListEnvelopeEnforcesBounds(t *testing.T) {
+	tests := []struct {
+		name          string
+		items         []int
+		requested     int
+		hasMore       bool
+		wantItems     []int
+		wantLimit     int
+		wantTruncated bool
+	}{
+		{name: "default and non-null items", requested: 0, wantItems: []int{}, wantLimit: DefaultListLimit},
+		{name: "negative uses default", requested: -1, wantItems: []int{}, wantLimit: DefaultListLimit},
+		{name: "requested limit truncates", items: []int{1, 2, 3}, requested: 2, wantItems: []int{1, 2}, wantLimit: 2, wantTruncated: true},
+		{name: "max clamps", requested: MaxListLimit + 1, wantItems: []int{}, wantLimit: MaxListLimit},
+		{name: "upstream has more", items: []int{1}, requested: 2, hasMore: true, wantItems: []int{1}, wantLimit: 2, wantTruncated: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newListEnvelope(tt.items, tt.requested, tt.hasMore)
+			if got.Limit != tt.wantLimit || got.Count != len(tt.wantItems) || got.Truncated != tt.wantTruncated {
+				t.Fatalf("envelope metadata = %+v, want limit=%d count=%d truncated=%v", got, tt.wantLimit, len(tt.wantItems), tt.wantTruncated)
+			}
+			if got.Items == nil {
+				t.Fatal("items must be a non-null empty slice")
+			}
+			if len(got.Items) != len(tt.wantItems) {
+				t.Fatalf("items = %v, want %v", got.Items, tt.wantItems)
+			}
+			for i := range got.Items {
+				if got.Items[i] != tt.wantItems[i] {
+					t.Fatalf("items = %v, want %v", got.Items, tt.wantItems)
+				}
+			}
+		})
+	}
+}
+
+func TestBoundedTextPreservesUTF8AndByteCounts(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		limit         int
+		wantText      string
+		wantTruncated bool
+		wantOriginal  int
+	}{
+		{name: "empty", input: "", limit: 4, wantText: ""},
+		{name: "exactly at limit", input: "abcd", limit: 4, wantText: "abcd"},
+		{name: "ASCII over limit", input: "abcde", limit: 4, wantText: "abcd", wantTruncated: true, wantOriginal: 5},
+		{name: "multibyte rune straddles boundary", input: "ab€cd", limit: 4, wantText: "ab", wantTruncated: true, wantOriginal: 7},
+		{name: "invalid input becomes valid UTF-8", input: string([]byte{'a', 0xff, 'b'}), limit: 16, wantText: "a\ufffdb"},
+		{name: "invalid input byte count follows valid replacement", input: string([]byte{'a', 0xff, 'b'}), limit: 2, wantText: "a", wantTruncated: true, wantOriginal: 5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := boundBitbucketText(tt.input, tt.limit)
+			if got.Text != tt.wantText || got.Truncated != tt.wantTruncated {
+				t.Fatalf("boundBitbucketText() = %+v, want text %q truncated %v", got, tt.wantText, tt.wantTruncated)
+			}
+			if !utf8.ValidString(got.Text) {
+				t.Fatalf("bounded text is invalid UTF-8: %q", got.Text)
+			}
+			if len(got.Text) > tt.limit {
+				t.Fatalf("bounded text is %d bytes, exceeds limit %d", len(got.Text), tt.limit)
+			}
+			if got.Provenance.Source != ProvenanceSourceBitbucket || got.Provenance.Trust != ProvenanceTrustUntrusted {
+				t.Fatalf("provenance = %+v, want bitbucket/untrusted", got.Provenance)
+			}
+			if tt.wantOriginal == 0 {
+				if got.OriginalSize != nil {
+					t.Fatalf("original_size = %v, want omitted when content is not truncated", *got.OriginalSize)
+				}
+			} else if got.OriginalSize == nil || *got.OriginalSize != tt.wantOriginal {
+				t.Fatalf("original_size = %v, want %d canonical UTF-8 bytes", got.OriginalSize, tt.wantOriginal)
+			}
+		})
+	}
+}
+
+func TestBoundedTextJSONShape(t *testing.T) {
+	full, err := json.Marshal(boundBitbucketText("abcde", 4))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		`"text":"abcd"`,
+		`"truncated":true`,
+		`"original_size":5`,
+		`"provenance":{"source":"bitbucket","trust":"untrusted"}`,
+	} {
+		if !strings.Contains(string(full), want) {
+			t.Fatalf("bounded text JSON missing %s: %s", want, full)
+		}
+	}
+
+	short, err := json.Marshal(boundBitbucketText("abcd", 4))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(short), "original_size") {
+		t.Fatalf("untruncated JSON must omit original_size: %s", short)
+	}
+}
+
+func TestFrozenCheckStates(t *testing.T) {
+	want := []CheckState{
+		CheckPending,
+		CheckRunning,
+		CheckSuccessful,
+		CheckFailed,
+		CheckStopped,
+		CheckUnknown,
+	}
+	got := []string{"pending", "running", "successful", "failed", "stopped", "unknown"}
+	for i := range want {
+		if string(want[i]) != got[i] {
+			t.Fatalf("check state %d = %q, want %q", i, want[i], got[i])
+		}
+	}
+}
+
+func TestFrozenErrorCodes(t *testing.T) {
+	want := []ErrorCode{
+		ErrorInvalidInput,
+		ErrorNotFound,
+		ErrorAuthFailed,
+		ErrorUnsupportedOnPlatform,
+		ErrorRateLimited,
+		ErrorUpstream,
+	}
+	got := []string{"invalid_input", "not_found", "auth_failed", "unsupported_on_platform", "rate_limited", "upstream_error"}
+	for i := range want {
+		if string(want[i]) != got[i] {
+			t.Fatalf("error code %d = %q, want %q", i, want[i], got[i])
+		}
+	}
+}
+
+func TestDTOOptionalFieldsAreActuallyOptional(t *testing.T) {
+	doc, err := json.Marshal(struct {
+		Repository  Repository        `json:"repository"`
+		PullRequest PullRequest       `json:"pull_request"`
+		Comment     Comment           `json:"comment"`
+		Check       Check             `json:"check"`
+		Diff        Diff              `json:"diff"`
+		List        ListEnvelope[int] `json:"list"`
+		Error       Error             `json:"error"`
+	}{
+		PullRequest: PullRequest{Reviewers: []Reviewer{}},
+		List:        ListEnvelope[int]{Items: []int{}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, absent := range []string{"default_branch", "description", "parent_id", "path", "line", "source_commit", "target_commit", "details"} {
+		if strings.Contains(string(doc), `"`+absent+`"`) {
+			t.Fatalf("zero-value DTO JSON unexpectedly contains optional field %q: %s", absent, doc)
+		}
+	}
+	for _, want := range []string{`"reviewers":[]`, `"items":[]`} {
+		if !strings.Contains(string(doc), want) {
+			t.Fatalf("zero-value DTO JSON missing non-null collection %s: %s", want, doc)
+		}
+	}
+}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -53,16 +53,6 @@ func ResolveSnapshot(f *cmdutil.Factory, contextOverride string) (*Snapshot, err
 	}, nil
 }
 
-// ContextInfo is the bkt_get_context result DTO. Field shapes are part of
-// the frozen v1 contract; never include credentials.
-type ContextInfo struct {
-	Platform     string   `json:"platform" jsonschema:"the pinned Bitbucket platform: dc (Data Center) or cloud"`
-	HostLabel    string   `json:"host_label" jsonschema:"the bkt config host entry this server is pinned to"`
-	DefaultScope string   `json:"default_scope,omitempty" jsonschema:"default scope (DC project key or Cloud workspace) used when a tool call omits the repository locator"`
-	DefaultRepo  string   `json:"default_repo,omitempty" jsonschema:"default repository slug used when a tool call omits the repository locator"`
-	Capabilities []string `json:"capabilities" jsonschema:"capability identifiers for the tools and roles this server supports on the pinned platform"`
-}
-
 // New builds the MCP server for the given frozen snapshot. All registered
 // tools are read-only in v1; addReadOnlyTool is the single registration path
 // and stamps truthful annotations.

--- a/pkg/bbcloud/client.go
+++ b/pkg/bbcloud/client.go
@@ -76,6 +76,7 @@ func New(opts Options) (*Client, error) {
 type User struct {
 	UUID      string `json:"uuid"`
 	Username  string `json:"username"`
+	Nickname  string `json:"nickname,omitempty"`
 	AccountID string `json:"account_id"`
 	Display   string `json:"display_name"`
 }
@@ -115,6 +116,9 @@ type Repository struct {
 	Project struct {
 		Key string `json:"key"`
 	} `json:"project"`
+	MainBranch struct {
+		Name string `json:"name"`
+	} `json:"mainbranch,omitempty"`
 }
 
 // PipelineResult is a Bitbucket pipeline outcome object.

--- a/pkg/bbcloud/pullrequest_models_test.go
+++ b/pkg/bbcloud/pullrequest_models_test.go
@@ -1,0 +1,56 @@
+package bbcloud_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/avivsinai/bitbucket-cli/pkg/bbcloud"
+)
+
+func TestPullRequestPreservesDescriptionAndParticipantApproval(t *testing.T) {
+	var pr bbcloud.PullRequest
+	err := json.Unmarshal([]byte(`{
+		"description": "full description",
+		"author": {"nickname": "author-nick"},
+		"reviewers": [{"uuid": "{reviewer}", "nickname": "reviewer-nick"}],
+		"participants": [{
+			"user": {"uuid": "{reviewer}", "nickname": "reviewer-nick"},
+			"role": "REVIEWER",
+			"approved": true,
+			"state": "approved"
+		}]
+	}`), &pr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pr.Description != "full description" || pr.AuthorNickname != "author-nick" {
+		t.Fatalf("description/author nickname = %q/%q", pr.Description, pr.AuthorNickname)
+	}
+	if len(pr.Reviewers) != 1 || pr.Reviewers[0].Nickname != "reviewer-nick" {
+		t.Fatalf("reviewers = %+v, want retained nickname", pr.Reviewers)
+	}
+	if len(pr.Participants) != 1 {
+		t.Fatalf("participants = %d, want 1", len(pr.Participants))
+	}
+	participant := pr.Participants[0]
+	if participant.Role != "REVIEWER" || participant.State != "approved" {
+		t.Fatalf("participant role/state = %q/%q", participant.Role, participant.State)
+	}
+	if participant.Approved == nil || !*participant.Approved {
+		t.Fatalf("participant approved = %v, want explicit true", participant.Approved)
+	}
+}
+
+func TestRepositoryPreservesMainBranch(t *testing.T) {
+	var repo bbcloud.Repository
+	err := json.Unmarshal([]byte(`{
+		"slug": "api",
+		"mainbranch": {"name": "main"}
+	}`), &repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repo.MainBranch.Name != "main" {
+		t.Fatalf("main branch = %q, want main", repo.MainBranch.Name)
+	}
+}

--- a/pkg/bbcloud/pullrequests.go
+++ b/pkg/bbcloud/pullrequests.go
@@ -2,6 +2,7 @@ package bbcloud
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/url"
@@ -28,19 +29,21 @@ type RepositoryRef struct {
 
 // PullRequest models a Bitbucket Cloud pull request.
 type PullRequest struct {
-	ID        int    `json:"id"`
-	Title     string `json:"title"`
-	State     string `json:"state"`
-	Draft     bool   `json:"draft"`
-	CreatedOn string `json:"created_on"`
-	UpdatedOn string `json:"updated_on"`
-	Author    struct {
+	ID          int    `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description,omitempty"`
+	State       string `json:"state"`
+	Draft       bool   `json:"draft"`
+	CreatedOn   string `json:"created_on"`
+	UpdatedOn   string `json:"updated_on"`
+	Author      struct {
 		DisplayName string `json:"display_name"`
 		Username    string `json:"username"`
 		UUID        string `json:"uuid"`
 		AccountID   string `json:"account_id"`
 	} `json:"author"`
-	Source struct {
+	AuthorNickname string `json:"-"`
+	Source         struct {
 		Branch struct {
 			Name string `json:"name"`
 		} `json:"branch"`
@@ -60,10 +63,41 @@ type PullRequest struct {
 			Href string `json:"href"`
 		} `json:"html"`
 	} `json:"links"`
-	Reviewers []User `json:"reviewers"`
-	Summary   struct {
+	Reviewers    []User                   `json:"reviewers"`
+	Participants []PullRequestParticipant `json:"participants,omitempty"`
+	Summary      struct {
 		Raw string `json:"raw"`
 	} `json:"summary"`
+}
+
+// UnmarshalJSON preserves the current anonymous Author field shape for
+// source compatibility while retaining Cloud's nickname field separately.
+func (p *PullRequest) UnmarshalJSON(data []byte) error {
+	type pullRequestAlias PullRequest
+	var decoded pullRequestAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	var extra struct {
+		Author struct {
+			Nickname string `json:"nickname"`
+		} `json:"author"`
+	}
+	if err := json.Unmarshal(data, &extra); err != nil {
+		return err
+	}
+	*p = PullRequest(decoded)
+	p.AuthorNickname = extra.Author.Nickname
+	return nil
+}
+
+// PullRequestParticipant retains the approval state Bitbucket Cloud returns
+// separately from the pull request's reviewer identities.
+type PullRequestParticipant struct {
+	User     User   `json:"user"`
+	Role     string `json:"role,omitempty"`
+	State    string `json:"state,omitempty"`
+	Approved *bool  `json:"approved,omitempty"`
 }
 
 // PullRequestListOptions configure PR listings. Mine and Reviewer carry a

--- a/pkg/bbdc/pullrequest_models_test.go
+++ b/pkg/bbdc/pullrequest_models_test.go
@@ -1,0 +1,52 @@
+package bbdc_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/avivsinai/bitbucket-cli/pkg/bbdc"
+)
+
+func TestPullRequestReviewerPreservesApprovalFields(t *testing.T) {
+	var pr bbdc.PullRequest
+	err := json.Unmarshal([]byte(`{
+		"reviewers": [{
+			"user": {"name": "alice", "displayName": "Alice A"},
+			"role": "REVIEWER",
+			"approved": true,
+			"status": "APPROVED"
+		}]
+	}`), &pr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pr.Reviewers) != 1 {
+		t.Fatalf("reviewers = %d, want 1", len(pr.Reviewers))
+	}
+	reviewer := pr.Reviewers[0]
+	if reviewer.Role != "REVIEWER" || reviewer.Status != "APPROVED" {
+		t.Fatalf("reviewer role/status = %q/%q, want REVIEWER/APPROVED", reviewer.Role, reviewer.Status)
+	}
+	if reviewer.Approved == nil || !*reviewer.Approved {
+		t.Fatalf("reviewer approved = %v, want explicit true", reviewer.Approved)
+	}
+}
+
+func TestPullRequestCommentPreservesCreatedDateAndParent(t *testing.T) {
+	var comment bbdc.PullRequestComment
+	err := json.Unmarshal([]byte(`{
+		"id": 9,
+		"text": "reply",
+		"createdDate": 1720951200123,
+		"parent": {"id": 7}
+	}`), &comment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if comment.CreatedDate == nil || *comment.CreatedDate != 1720951200123 {
+		t.Fatalf("created date = %v, want 1720951200123", comment.CreatedDate)
+	}
+	if comment.Parent == nil || comment.Parent.ID != 7 {
+		t.Fatalf("parent = %+v, want id 7", comment.Parent)
+	}
+}

--- a/pkg/bbdc/pullrequests.go
+++ b/pkg/bbdc/pullrequests.go
@@ -16,7 +16,10 @@ var ErrPullRequestCommentNotTopLevel = errors.New("only top-level pull request c
 
 // PullRequestReviewer represents a reviewer assignment.
 type PullRequestReviewer struct {
-	User User `json:"user"`
+	User     User   `json:"user"`
+	Role     string `json:"role,omitempty"`
+	Status   string `json:"status,omitempty"`
+	Approved *bool  `json:"approved,omitempty"`
 }
 
 // PullRequestParticipant wraps a reviewer/participant entry.
@@ -29,18 +32,22 @@ type PullRequestParticipant struct {
 
 // PullRequestComment represents a PR comment.
 type PullRequestComment struct {
-	ID             int                       `json:"id"`
-	Version        int                       `json:"version"`
-	Text           string                    `json:"text"`
-	Severity       string                    `json:"severity"` // "NORMAL" or "BLOCKER" (task)
-	State          string                    `json:"state"`    // "OPEN" or "RESOLVED"
-	Properties     map[string]any            `json:"properties,omitempty"`
-	Author         User                      `json:"author"`
-	ThreadResolved bool                      `json:"threadResolved"`
-	Anchor         *PullRequestCommentAnchor `json:"anchor,omitempty"`
-	Comments       []PullRequestComment      `json:"comments,omitempty"`
-	Depth          int                       `json:"-"` // nesting depth, set during flattening
-	raw            map[string]any
+	ID             int            `json:"id"`
+	Version        int            `json:"version"`
+	Text           string         `json:"text"`
+	CreatedDate    *int64         `json:"createdDate,omitempty"`
+	Severity       string         `json:"severity"` // "NORMAL" or "BLOCKER" (task)
+	State          string         `json:"state"`    // "OPEN" or "RESOLVED"
+	Properties     map[string]any `json:"properties,omitempty"`
+	Author         User           `json:"author"`
+	ThreadResolved bool           `json:"threadResolved"`
+	Parent         *struct {
+		ID int `json:"id"`
+	} `json:"parent,omitempty"`
+	Anchor   *PullRequestCommentAnchor `json:"anchor,omitempty"`
+	Comments []PullRequestComment      `json:"comments,omitempty"`
+	Depth    int                       `json:"-"` // nesting depth, set during flattening
+	raw      map[string]any
 }
 
 type PullRequestCommentAnchor struct {


### PR DESCRIPTION
## Summary

- add platform-neutral MCP DTOs with frozen v1 bounds, provenance, list, check-state, and error contracts
- normalize Data Center and Cloud repositories, pull requests, reviewers, comments, checks, and diffs through adapter functions
- extend raw client models additively for reviewer approval and timestamp metadata while preserving existing command compatibility
- cover raw JSON unmarshalling and cross-platform adapter behavior, including URL redaction and UTF-8-safe truncation

This is Wave C.1 of `bkt mcp serve`: DTOs and adapters only. It does not register tools, change CLI behavior, or close an issue.

## Verification

- `go test ./...`
- `go test -race ./internal/mcpserver ./pkg/bbdc ./pkg/bbcloud`
- `go vet ./...`
- `go build -o /private/tmp/bkt-mcp-dtos-review ./cmd/bkt`
- `make check-generated-skill`
- `golangci-lint run ./internal/mcpserver ./pkg/bbdc ./pkg/bbcloud`
- `golangci-lint run --new-from-rev=03522dd20fb394e93da02dd0670ca6980a592678`
