### PR TITLE
feat(mcp): add repository and pull request list tools

### DIFF
--- a/internal/mcpserver/backend.go
+++ b/internal/mcpserver/backend.go
@@ -1,0 +1,234 @@
+package mcpserver
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/avivsinai/bitbucket-cli/pkg/bbcloud"
+	"github.com/avivsinai/bitbucket-cli/pkg/bbdc"
+	"github.com/avivsinai/bitbucket-cli/pkg/cmdutil"
+)
+
+// repositoryBackend is the normalized, fakeable seam used by repository
+// handlers. Platform client types never cross into tool handlers.
+type repositoryBackend interface {
+	listRepositories(context.Context, string, int) ([]Repository, bool, error)
+	getRepository(context.Context, RepositoryRef) (Repository, error)
+}
+
+type platformBackend interface {
+	repositoryBackend
+	listPullRequests(context.Context, RepositoryRef, string, string, int) ([]PullRequest, bool, error)
+	listMyPullRequests(context.Context, string, string, string, int) ([]PullRequest, bool, error)
+}
+
+type dcBackend struct {
+	client   *bbdc.Client
+	username string
+}
+
+type cloudBackend struct {
+	client *bbcloud.Client
+}
+
+func newPlatformBackend(snap *Snapshot) (platformBackend, error) {
+	if snap == nil {
+		return nil, fmt.Errorf("MCP snapshot is required")
+	}
+	host := snap.Host
+	switch snap.Platform {
+	case "dc":
+		client, err := cmdutil.NewDCClient(&host)
+		if err != nil {
+			return nil, fmt.Errorf("create Bitbucket Data Center client: %w", err)
+		}
+		return &dcBackend{client: client, username: host.Username}, nil
+	case "cloud":
+		client, err := cmdutil.NewFrozenCloudClient(&host)
+		if err != nil {
+			return nil, fmt.Errorf("create Bitbucket Cloud client: %w", err)
+		}
+		return &cloudBackend{client: client}, nil
+	default:
+		return nil, fmt.Errorf("unsupported MCP platform %q", snap.Platform)
+	}
+}
+
+func (b *dcBackend) listRepositories(ctx context.Context, scope string, limit int) ([]Repository, bool, error) {
+	page, err := b.client.ListRepositoriesPage(ctx, scope, limit, 0)
+	if err != nil {
+		return nil, false, err
+	}
+	items := make([]Repository, 0, len(page.Values))
+	for _, raw := range page.Values {
+		items = append(items, adaptDCRepository(raw))
+	}
+	return items, !page.IsLast, nil
+}
+
+func (b *dcBackend) getRepository(ctx context.Context, locator RepositoryRef) (Repository, error) {
+	raw, err := b.client.GetRepository(ctx, locator.Scope, locator.Slug)
+	if err != nil {
+		return Repository{}, err
+	}
+	return adaptDCRepository(*raw), nil
+}
+
+func (b *cloudBackend) listRepositories(ctx context.Context, scope string, limit int) ([]Repository, bool, error) {
+	page, err := b.client.ListRepositoriesPage(ctx, scope, limit, "")
+	if err != nil {
+		return nil, false, err
+	}
+	items := make([]Repository, 0, len(page.Values))
+	for _, raw := range page.Values {
+		items = append(items, adaptCloudRepository(raw))
+	}
+	return items, page.Next != "", nil
+}
+
+func (b *cloudBackend) getRepository(ctx context.Context, locator RepositoryRef) (Repository, error) {
+	raw, err := b.client.GetRepository(ctx, locator.Scope, locator.Slug)
+	if err != nil {
+		return Repository{}, err
+	}
+	return adaptCloudRepository(*raw), nil
+}
+
+func (b *dcBackend) listPullRequests(ctx context.Context, locator RepositoryRef, state, role string, limit int) ([]PullRequest, bool, error) {
+	if role != "ALL" && strings.TrimSpace(b.username) == "" {
+		return nil, false, newToolError(
+			ErrorInvalidInput,
+			"repo-scoped role filtering needs a username in the frozen Data Center context; re-authenticate with a username, use role=all, or use bkt_list_my_pull_requests",
+			false,
+		)
+	}
+	opts := bbdc.RepoPullRequestsOptions{State: state, Limit: limit}
+	if role != "ALL" {
+		opts.Role = role
+		opts.Username = b.username
+	}
+	page, err := b.client.ListRepoPullRequestsPage(ctx, locator.Scope, locator.Slug, opts)
+	if err != nil {
+		return nil, false, err
+	}
+	items, err := adaptDCPullRequests(page.Values)
+	if err != nil {
+		return nil, false, err
+	}
+	return items, !page.IsLast, nil
+}
+
+func (b *dcBackend) listMyPullRequests(ctx context.Context, _ string, state, role string, limit int) ([]PullRequest, bool, error) {
+	page, err := b.client.ListDashboardPullRequestsPage(ctx, bbdc.DashboardPullRequestsOptions{
+		State: state,
+		Role:  role,
+		Limit: limit,
+	}, 0)
+	if err != nil {
+		return nil, false, err
+	}
+	items, err := adaptDCPullRequests(page.Values)
+	if err != nil {
+		return nil, false, err
+	}
+	return items, !page.IsLast, nil
+}
+
+func (b *cloudBackend) listPullRequests(ctx context.Context, locator RepositoryRef, state, role string, limit int) ([]PullRequest, bool, error) {
+	opts := bbcloud.PullRequestListOptions{State: state, Limit: limit}
+	if role != "ALL" {
+		identity, err := b.repositoryUserIdentity(ctx)
+		if err != nil {
+			return nil, false, err
+		}
+		if role == "AUTHOR" {
+			opts.Mine = identity
+		} else {
+			opts.Reviewer = identity
+		}
+	}
+	page, err := b.client.ListRepoPullRequestsPage(ctx, locator.Scope, locator.Slug, opts, "")
+	if err != nil {
+		return nil, false, err
+	}
+	items, err := adaptCloudPullRequests(page.Values)
+	if err != nil {
+		return nil, false, err
+	}
+	return items, page.Next != "", nil
+}
+
+func (b *cloudBackend) listMyPullRequests(ctx context.Context, scope, state, role string, limit int) ([]PullRequest, bool, error) {
+	if role != "AUTHOR" {
+		return nil, false, fmt.Errorf("workspace pull requests on Bitbucket Cloud support only author role")
+	}
+	identity, err := b.workspaceUserIdentity(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	page, err := b.client.ListWorkspacePullRequestsPage(ctx, scope, identity, bbcloud.WorkspacePullRequestsOptions{
+		State: state,
+		Limit: limit,
+	}, "")
+	if err != nil {
+		return nil, false, err
+	}
+	items, err := adaptCloudPullRequests(page.Values)
+	if err != nil {
+		return nil, false, err
+	}
+	return items, page.Next != "", nil
+}
+
+func (b *cloudBackend) repositoryUserIdentity(ctx context.Context) (string, error) {
+	user, err := b.client.CurrentUser(ctx)
+	if err != nil {
+		return "", err
+	}
+	if identity := bbcloud.NormalizeUUID(user.UUID); identity != "" {
+		return identity, nil
+	}
+	if user.AccountID != "" {
+		return user.AccountID, nil
+	}
+	return "", fmt.Errorf("authenticated Bitbucket Cloud user has no stable repository-filter identity")
+}
+
+func (b *cloudBackend) workspaceUserIdentity(ctx context.Context) (string, error) {
+	user, err := b.client.CurrentUser(ctx)
+	if err != nil {
+		return "", err
+	}
+	if identity := bbcloud.NormalizeUUID(user.UUID); identity != "" {
+		return identity, nil
+	}
+	if user.AccountID != "" {
+		return user.AccountID, nil
+	}
+	return "", fmt.Errorf("authenticated Bitbucket Cloud user has no stable workspace-filter identity")
+}
+
+func adaptDCPullRequests(raw []bbdc.PullRequest) ([]PullRequest, error) {
+	items := make([]PullRequest, 0, len(raw))
+	for _, item := range raw {
+		adapted, err := adaptDCPullRequest(item, false)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, adapted)
+	}
+	return items, nil
+}
+
+func adaptCloudPullRequests(raw []bbcloud.PullRequest) ([]PullRequest, error) {
+	items := make([]PullRequest, 0, len(raw))
+	for _, item := range raw {
+		adapted, err := adaptCloudPullRequest(item, false)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, adapted)
+	}
+	return items, nil
+}

--- a/internal/mcpserver/backend_test.go
+++ b/internal/mcpserver/backend_test.go
@@ -1,0 +1,275 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/avivsinai/bitbucket-cli/internal/config"
+	"github.com/avivsinai/bitbucket-cli/pkg/bbcloud"
+	"github.com/avivsinai/bitbucket-cli/pkg/bbdc"
+	"github.com/avivsinai/bitbucket-cli/pkg/httpx"
+)
+
+func TestNewPlatformBackendDoesNotMutateFrozenSnapshot(t *testing.T) {
+	snap := &Snapshot{
+		Platform:  "cloud",
+		HostLabel: "cloud",
+		Host:      config.Host{Kind: "cloud", Token: "token"},
+	}
+	want := *snap
+	if _, err := newPlatformBackend(snap); err != nil {
+		t.Fatalf("newPlatformBackend: %v", err)
+	}
+	if !reflect.DeepEqual(*snap, want) {
+		t.Fatalf("snapshot mutated during client construction:\n got: %+v\nwant: %+v", *snap, want)
+	}
+}
+
+func TestNewPlatformBackendCloudOAuthUsesOnlyFrozenCredential(t *testing.T) {
+	t.Setenv("BKT_TOKEN", "")
+	t.Setenv("BKT_OAUTH_CLIENT_ID", "")
+	t.Setenv("BKT_OAUTH_CLIENT_SECRET", "")
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if got := r.Header.Get("Authorization"); got != "Bearer startup-token" {
+			t.Errorf("Authorization = %q, want startup bearer token", got)
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(server.Close)
+	snap := &Snapshot{
+		Platform: "cloud",
+		Host: config.Host{
+			Kind:           "cloud",
+			BaseURL:        server.URL,
+			AuthMethod:     "oauth",
+			Token:          "startup-token",
+			OAuthExpiresAt: time.Now().Add(-time.Minute),
+		},
+	}
+
+	backend, err := newPlatformBackend(snap)
+	if err != nil {
+		t.Fatalf("newPlatformBackend: %v", err)
+	}
+	_, _, err = backend.listRepositories(context.Background(), "team", 25)
+	var httpErr *httpx.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("listRepositories error = %T %v, want frozen 401 HTTPError", err, err)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("requests = %d, want one request with no refresh retry", got)
+	}
+	if snap.Host.Token != "startup-token" {
+		t.Fatalf("snapshot token mutated to %q", snap.Host.Token)
+	}
+}
+
+func TestDCBackendAppliesRepositoryRoleFiltersUpstream(t *testing.T) {
+	for _, role := range []string{"AUTHOR", "REVIEWER"} {
+		t.Run(strings.ToLower(role), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/rest/api/1.0/projects/PROJ/repos/api/pull-requests" {
+					t.Fatalf("path = %q", r.URL.Path)
+				}
+				query := r.URL.Query()
+				if query.Get("state") != "OPEN" || query.Get("role.1") != role || query.Get("username.1") != "alice" || query.Get("limit") != "7" {
+					t.Fatalf("query = %q", r.URL.RawQuery)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"values": []map[string]any{{
+						"id": 1, "title": "One", "createdDate": int64(1704067200000), "updatedDate": int64(1704067200000), "reviewers": []any{},
+					}},
+					"isLastPage":    false,
+					"nextPageStart": 7,
+				})
+			}))
+			t.Cleanup(server.Close)
+			client, err := bbdc.New(bbdc.Options{BaseURL: server.URL, Token: "token", AuthMethod: "bearer", Retry: httpx.RetryPolicy{MaxAttempts: 1}})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			items, hasMore, err := (&dcBackend{client: client, username: "alice"}).listPullRequests(
+				context.Background(), RepositoryRef{Scope: "PROJ", Slug: "api"}, "OPEN", role, 7,
+			)
+			if err != nil {
+				t.Fatalf("listPullRequests: %v", err)
+			}
+			if len(items) != 1 || !hasMore {
+				t.Fatalf("items=%#v hasMore=%v, want one item and continuation", items, hasMore)
+			}
+		})
+	}
+}
+
+func TestDCBackendUsesNativeDashboardRoleUpstream(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/api/1.0/dashboard/pull-requests" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		if r.URL.Query().Get("role") != "AUTHOR" || r.URL.Query().Get("state") != "MERGED" || r.URL.Query().Get("limit") != "5" {
+			t.Fatalf("query = %q", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"values": []any{}, "isLastPage": true})
+	}))
+	t.Cleanup(server.Close)
+	client, err := bbdc.New(bbdc.Options{BaseURL: server.URL, Token: "token", AuthMethod: "bearer", Retry: httpx.RetryPolicy{MaxAttempts: 1}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	items, hasMore, err := (&dcBackend{client: client}).listMyPullRequests(context.Background(), "", "MERGED", "AUTHOR", 5)
+	if err != nil {
+		t.Fatalf("listMyPullRequests: %v", err)
+	}
+	if items == nil || hasMore {
+		t.Fatalf("items=%#v hasMore=%v, want non-nil empty final page", items, hasMore)
+	}
+}
+
+func TestDCBackendDashboardReviewerDoesNotNeedUsername(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/api/1.0/dashboard/pull-requests" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		if r.URL.Query().Get("role") != "REVIEWER" || r.URL.Query().Get("state") != "OPEN" {
+			t.Fatalf("query = %q", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"values": []any{}, "isLastPage": true})
+	}))
+	t.Cleanup(server.Close)
+	client, err := bbdc.New(bbdc.Options{BaseURL: server.URL, Token: "token", AuthMethod: "bearer", Retry: httpx.RetryPolicy{MaxAttempts: 1}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	items, hasMore, err := (&dcBackend{client: client}).listMyPullRequests(context.Background(), "", "OPEN", "REVIEWER", 5)
+	if err != nil {
+		t.Fatalf("listMyPullRequests: %v", err)
+	}
+	if items == nil || hasMore {
+		t.Fatalf("items=%#v hasMore=%v, want non-nil empty final page", items, hasMore)
+	}
+}
+
+func TestCloudBackendResolvesCurrentUserBeforeRepositoryRoleFilters(t *testing.T) {
+	const uuid = "{123e4567-e89b-12d3-a456-426614174000}"
+	tests := []struct {
+		role      string
+		wantField string
+	}{
+		{role: "AUTHOR", wantField: "author.uuid"},
+		{role: "REVIEWER", wantField: "reviewers.uuid"},
+	}
+	for _, tt := range tests {
+		t.Run(strings.ToLower(tt.role), func(t *testing.T) {
+			var requests []string
+			var server *httptest.Server
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests = append(requests, r.URL.RequestURI())
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/user":
+					_ = json.NewEncoder(w).Encode(map[string]any{"uuid": uuid})
+				case "/repositories/team/api/pullrequests":
+					if got := r.URL.Query().Get("q"); got != tt.wantField+` = "`+uuid+`"` {
+						t.Fatalf("q = %q", got)
+					}
+					if r.URL.Query().Get("state") != "OPEN" || r.URL.Query().Get("pagelen") != "3" {
+						t.Fatalf("query = %q", r.URL.RawQuery)
+					}
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"values": []any{},
+						"next":   server.URL + "/repositories/team/api/pullrequests?page=2",
+					})
+				default:
+					t.Fatalf("path = %q", r.URL.Path)
+				}
+			}))
+			t.Cleanup(server.Close)
+			client, err := bbcloud.New(bbcloud.Options{BaseURL: server.URL, Token: "token", Retry: httpx.RetryPolicy{MaxAttempts: 1}})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			items, hasMore, err := (&cloudBackend{client: client}).listPullRequests(
+				context.Background(), RepositoryRef{Scope: "team", Slug: "api"}, "OPEN", tt.role, 3,
+			)
+			if err != nil {
+				t.Fatalf("listPullRequests: %v", err)
+			}
+			if len(requests) != 2 || items == nil || !hasMore {
+				t.Fatalf("requests=%v items=%#v hasMore=%v", requests, items, hasMore)
+			}
+		})
+	}
+}
+
+func TestCloudBackendUsesNativeWorkspaceAuthorEndpoint(t *testing.T) {
+	const uuid = "{123e4567-e89b-12d3-a456-426614174000}"
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.URL.RequestURI())
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/user":
+			_ = json.NewEncoder(w).Encode(map[string]any{"uuid": uuid, "username": "legacy-alice", "account_id": "account-alice"})
+		case "/workspaces/team/pullrequests/" + uuid:
+			if r.URL.Query().Get("state") != "DECLINED" || r.URL.Query().Get("pagelen") != "4" {
+				t.Fatalf("query = %q", r.URL.RawQuery)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"values": []any{}})
+		default:
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+	client, err := bbcloud.New(bbcloud.Options{BaseURL: server.URL, Token: "token", Retry: httpx.RetryPolicy{MaxAttempts: 1}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	items, hasMore, err := (&cloudBackend{client: client}).listMyPullRequests(context.Background(), "team", "DECLINED", "AUTHOR", 4)
+	if err != nil {
+		t.Fatalf("listMyPullRequests: %v", err)
+	}
+	if len(requests) != 2 || items == nil || hasMore {
+		t.Fatalf("requests=%v items=%#v hasMore=%v", requests, items, hasMore)
+	}
+	if strings.Contains(strings.Join(requests, " "), "reviewer") {
+		t.Fatalf("workspace author flow unexpectedly contains reviewer filter: %v", requests)
+	}
+}
+
+func TestCloudWorkspaceUserIdentityFallsBackToAccountID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"username": "legacy-alice", "account_id": "account-alice"})
+	}))
+	t.Cleanup(server.Close)
+	client, err := bbcloud.New(bbcloud.Options{BaseURL: server.URL, Token: "token", Retry: httpx.RetryPolicy{MaxAttempts: 1}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	identity, err := (&cloudBackend{client: client}).workspaceUserIdentity(context.Background())
+	if err != nil {
+		t.Fatalf("workspaceUserIdentity: %v", err)
+	}
+	if identity != "account-alice" {
+		t.Fatalf("identity = %q, want stable account ID", identity)
+	}
+}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -15,9 +15,9 @@ import (
 )
 
 // Snapshot is the frozen effective target resolved once at server startup.
-// It is a deep copy: later config edits require a server restart, and the
-// working directory never influences it (resolution skips git-remote
-// default detection).
+// It is a deep copy: later config or credential edits require a server restart,
+// and the working directory never influences it (resolution skips git-remote
+// default detection). Cloud OAuth access tokens do not refresh after startup.
 type Snapshot struct {
 	ContextName  string
 	Platform     string // "dc" or "cloud"
@@ -56,9 +56,19 @@ func ResolveSnapshot(f *cmdutil.Factory, contextOverride string) (*Snapshot, err
 // New builds the MCP server for the given frozen snapshot. All registered
 // tools are read-only in v1; addReadOnlyTool is the single registration path
 // and stamps truthful annotations.
-func New(snap *Snapshot, version string) *mcp.Server {
+func New(snap *Snapshot, version string) (*mcp.Server, error) {
+	backend, err := newPlatformBackend(snap)
+	if err != nil {
+		return nil, err
+	}
+	return newServer(snap, version, backend), nil
+}
+
+func newServer(snap *Snapshot, version string, backend platformBackend) *mcp.Server {
 	server := mcp.NewServer(&mcp.Implementation{Name: "bkt", Version: version}, nil)
 	registerGetContext(server, snap)
+	registerRepositoryTools(server, snap, backend)
+	registerPullRequestListTools(server, snap, backend)
 	return server
 }
 
@@ -72,11 +82,12 @@ func addReadOnlyTool[In, Out any](server *mcp.Server, tool *mcp.Tool, handler mc
 	mcp.AddTool(server, tool, handler)
 }
 
-// capabilities lists platform feature identifiers (e.g. my_prs.role.reviewer)
-// supported by the pinned platform. Empty until such features land in wave C;
-// identifiers are part of the public contract and must not be invented here.
+// capabilities enumerates only discriminating platform features. Universal
+// behavior is implied by the registered tool and is not repeated here.
 func capabilities(snap *Snapshot) []string {
-	_ = snap
+	if snap != nil && snap.Platform == "dc" {
+		return []string{"my_prs.role.reviewer"}
+	}
 	return []string{}
 }
 
@@ -119,7 +130,8 @@ func registerGetContext(server *mcp.Server, snap *Snapshot) {
 		Name: "bkt_get_context",
 		Description: "Describe the Bitbucket target this server is pinned to: " +
 			"platform (dc or cloud), host label, default repository scope/slug, " +
-			"and the capabilities available here. Never returns credentials.",
+			"and the capabilities available here. Never returns credentials. " +
+			"For Cloud OAuth, the access token is frozen at startup; restart the server after it expires.",
 		OutputSchema: contextInfoSchema,
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args getContextArgs) (*mcp.CallToolResult, ContextInfo, error) {
 		return nil, ContextInfo{

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -114,21 +114,53 @@ func TestGetContextToolRoundTrip(t *testing.T) {
 		DefaultScope: "PROJ",
 		DefaultRepo:  "api",
 	}
-	session := connectPair(t, New(snap, "test"))
+	session := connectPair(t, newServer(snap, "test", &fakeRepositoryBackend{}))
 
 	tools, err := session.ListTools(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("ListTools: %v", err)
 	}
-	if len(tools.Tools) != 1 || tools.Tools[0].Name != "bkt_get_context" {
-		t.Fatalf("tools = %+v, want exactly bkt_get_context", tools.Tools)
+	if len(tools.Tools) != 5 {
+		t.Fatalf("tools = %+v, want context plus four C.2a tools", tools.Tools)
 	}
-	tool := tools.Tools[0]
-	if tool.Annotations == nil || !tool.Annotations.ReadOnlyHint {
-		t.Fatal("bkt_get_context must advertise ReadOnlyHint: true — v1 is read-only")
+	wantTools := map[string]bool{
+		"bkt_get_context":           false,
+		"bkt_list_repositories":     false,
+		"bkt_get_repository":        false,
+		"bkt_list_pull_requests":    false,
+		"bkt_list_my_pull_requests": false,
 	}
-	if tool.OutputSchema == nil {
-		t.Fatal("bkt_get_context has no output schema; typed contract missing")
+	var tool *mcp.Tool
+	for _, candidate := range tools.Tools {
+		if _, ok := wantTools[candidate.Name]; !ok {
+			t.Fatalf("unexpected tool %q", candidate.Name)
+		}
+		wantTools[candidate.Name] = true
+		if candidate.Annotations == nil || !candidate.Annotations.ReadOnlyHint {
+			t.Fatalf("%s must advertise ReadOnlyHint: true", candidate.Name)
+		}
+		if candidate.InputSchema == nil || candidate.OutputSchema == nil {
+			t.Fatalf("%s missing typed input/output schema", candidate.Name)
+		}
+		if (candidate.Name == "bkt_list_repositories" || candidate.Name == "bkt_get_repository") &&
+			!strings.Contains(candidate.Description, "untrusted Bitbucket-authored data") {
+			t.Fatalf("%s must describe repository fields as untrusted: %q", candidate.Name, candidate.Description)
+		}
+		if candidate.Name == "bkt_get_context" {
+			tool = candidate
+		}
+	}
+	for name, found := range wantTools {
+		if !found {
+			t.Fatalf("tool list missing %s", name)
+		}
+	}
+	if tool == nil {
+		t.Fatalf("tools = %+v, missing bkt_get_context", tools.Tools)
+		return
+	}
+	if !strings.Contains(tool.Description, "Cloud OAuth") || !strings.Contains(tool.Description, "restart") {
+		t.Fatalf("bkt_get_context description must document frozen Cloud OAuth expiry: %q", tool.Description)
 	}
 	schemaJSON, err := json.Marshal(tool.OutputSchema)
 	if err != nil {
@@ -165,8 +197,8 @@ func TestGetContextToolRoundTrip(t *testing.T) {
 	if info.Capabilities == nil {
 		t.Fatal("capabilities must be a non-null array (empty is fine until platform features land)")
 	}
-	if !strings.Contains(string(raw), `"capabilities":[]`) {
-		t.Fatalf("capabilities must serialize as an empty array, got: %s", raw)
+	if !strings.Contains(string(raw), `"capabilities":["my_prs.role.reviewer"]`) {
+		t.Fatalf("DC capabilities must advertise cross-repository reviewer support, got: %s", raw)
 	}
 	for _, s := range []string{"token", "Token", "secret"} {
 		if string(raw) != "" && json.Valid(raw) && containsInsensitive(raw, s) {

--- a/internal/mcpserver/tools_pullrequests.go
+++ b/internal/mcpserver/tools_pullrequests.go
@@ -1,0 +1,111 @@
+package mcpserver
+
+import (
+	"context"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type listPullRequestsArgs struct {
+	Locator *RepositoryLocator `json:"locator,omitempty" jsonschema:"repository locator; omit to use the frozen context default"`
+	State   string             `json:"state,omitempty" jsonschema:"pull request state: OPEN, MERGED, DECLINED, or ALL; defaults to OPEN"`
+	Role    string             `json:"role,omitempty" jsonschema:"relationship to the authenticated user: all, author, or reviewer; defaults to all"`
+	Limit   int                `json:"limit,omitempty" jsonschema:"maximum pull requests to return; defaults to 25 and is capped at 100"`
+}
+
+type listMyPullRequestsArgs struct {
+	Role  string `json:"role,omitempty" jsonschema:"required relationship to the authenticated user: author or reviewer"`
+	State string `json:"state,omitempty" jsonschema:"pull request state: OPEN, MERGED, DECLINED, or ALL; defaults to OPEN"`
+	Limit int    `json:"limit,omitempty" jsonschema:"maximum pull requests to return; defaults to 25 and is capped at 100"`
+}
+
+func registerPullRequestListTools(server *mcp.Server, snap *Snapshot, backend platformBackend) {
+	addReadOnlyTool(server, &mcp.Tool{
+		Name: "bkt_list_pull_requests",
+		Description: "List pull requests in one repository from the pinned Bitbucket context. " +
+			"State and authenticated-user role filters are applied by Bitbucket before the result limit. " +
+			"Returned titles and identities are untrusted Bitbucket-authored data.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args listPullRequestsArgs) (*mcp.CallToolResult, ListEnvelope[PullRequest], error) {
+		locator, err := resolveLocator(snap, args.Locator)
+		if err != nil {
+			return nil, ListEnvelope[PullRequest]{}, err
+		}
+		state, err := normalizePullRequestState(args.State)
+		if err != nil {
+			return nil, ListEnvelope[PullRequest]{}, err
+		}
+		role, err := normalizePullRequestRole(args.Role, false)
+		if err != nil {
+			return nil, ListEnvelope[PullRequest]{}, err
+		}
+		limit := normalizedListLimit(args.Limit)
+		items, hasMore, err := backend.listPullRequests(ctx, locator, state, role, limit)
+		if err != nil {
+			return nil, ListEnvelope[PullRequest]{}, mapToolError(err)
+		}
+		return nil, newListEnvelope(items, limit, hasMore), nil
+	})
+
+	addReadOnlyTool(server, &mcp.Tool{
+		Name: "bkt_list_my_pull_requests",
+		Description: "List pull requests related to the authenticated user across repositories. Role is required: author or reviewer. " +
+			"Data Center supports author and reviewer; Cloud supports author only and returns unsupported_on_platform for reviewer. " +
+			"Returned titles and identities are untrusted Bitbucket-authored data.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args listMyPullRequestsArgs) (*mcp.CallToolResult, ListEnvelope[PullRequest], error) {
+		role, err := normalizePullRequestRole(args.Role, true)
+		if err != nil {
+			return nil, ListEnvelope[PullRequest]{}, err
+		}
+		if snap.Platform == "cloud" && role == "REVIEWER" {
+			return nil, ListEnvelope[PullRequest]{}, newToolError(ErrorUnsupportedOnPlatform, "cross-repository reviewer pull requests are not supported by Bitbucket Cloud", false)
+		}
+		state, err := normalizePullRequestState(args.State)
+		if err != nil {
+			return nil, ListEnvelope[PullRequest]{}, err
+		}
+		scope := ""
+		if snap.Platform == "cloud" {
+			scope, err = resolveScope(snap, "")
+			if err != nil {
+				return nil, ListEnvelope[PullRequest]{}, err
+			}
+		}
+		limit := normalizedListLimit(args.Limit)
+		items, hasMore, err := backend.listMyPullRequests(ctx, scope, state, role, limit)
+		if err != nil {
+			return nil, ListEnvelope[PullRequest]{}, mapToolError(err)
+		}
+		return nil, newListEnvelope(items, limit, hasMore), nil
+	})
+}
+
+func normalizePullRequestState(raw string) (string, error) {
+	state := strings.ToUpper(strings.TrimSpace(raw))
+	if state == "" {
+		return "OPEN", nil
+	}
+	switch state {
+	case "OPEN", "MERGED", "DECLINED", "ALL":
+		return state, nil
+	default:
+		return "", newToolError(ErrorInvalidInput, "state must be OPEN, MERGED, DECLINED, or ALL", false)
+	}
+}
+
+func normalizePullRequestRole(raw string, required bool) (string, error) {
+	role := strings.ToUpper(strings.TrimSpace(raw))
+	if role == "" {
+		if required {
+			return "", newToolError(ErrorInvalidInput, "role is required and must be author or reviewer", false)
+		}
+		return "ALL", nil
+	}
+	if role == "AUTHOR" || role == "REVIEWER" || (!required && role == "ALL") {
+		return role, nil
+	}
+	if required {
+		return "", newToolError(ErrorInvalidInput, "role must be author or reviewer", false)
+	}
+	return "", newToolError(ErrorInvalidInput, "role must be all, author, or reviewer", false)
+}

--- a/internal/mcpserver/tools_pullrequests_test.go
+++ b/internal/mcpserver/tools_pullrequests_test.go
@@ -1,0 +1,257 @@
+package mcpserver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/avivsinai/bitbucket-cli/pkg/bbdc"
+	"github.com/avivsinai/bitbucket-cli/pkg/httpx"
+)
+
+type fakeC2ABackend struct {
+	fakeRepositoryBackend
+
+	listPRLocator RepositoryRef
+	listPRState   string
+	listPRRole    string
+	listPRLimit   int
+	listPRItems   []PullRequest
+	listPRMore    bool
+	listPRErr     error
+	listPRCalls   int
+
+	listMyScope string
+	listMyState string
+	listMyRole  string
+	listMyLimit int
+	listMyItems []PullRequest
+	listMyMore  bool
+	listMyErr   error
+	listMyCalls int
+}
+
+func (f *fakeC2ABackend) listPullRequests(_ context.Context, locator RepositoryRef, state, role string, limit int) ([]PullRequest, bool, error) {
+	f.listPRCalls++
+	f.listPRLocator = locator
+	f.listPRState = state
+	f.listPRRole = role
+	f.listPRLimit = limit
+	return f.listPRItems, f.listPRMore, f.listPRErr
+}
+
+func (f *fakeC2ABackend) listMyPullRequests(_ context.Context, scope, state, role string, limit int) ([]PullRequest, bool, error) {
+	f.listMyCalls++
+	f.listMyScope = scope
+	f.listMyState = state
+	f.listMyRole = role
+	f.listMyLimit = limit
+	return f.listMyItems, f.listMyMore, f.listMyErr
+}
+
+func TestListPullRequestsToolPassesValidatedFiltersBeforeLimit(t *testing.T) {
+	backend := &fakeC2ABackend{
+		listPRItems: []PullRequest{{ID: 7, Title: "Review me", Reviewers: []Reviewer{}}},
+		listPRMore:  true,
+	}
+	snap := &Snapshot{Platform: "cloud", HostLabel: "cloud", DefaultScope: "team", DefaultRepo: "api"}
+	session := connectPair(t, newServer(snap, "test", backend))
+
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "bkt_list_pull_requests",
+		Arguments: map[string]any{
+			"state": "merged",
+			"role":  "reviewer",
+			"limit": 2,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool error: %+v", res.Content)
+	}
+	if backend.listPRLocator != (RepositoryRef{Scope: "team", Slug: "api"}) || backend.listPRState != "MERGED" || backend.listPRRole != "REVIEWER" || backend.listPRLimit != 2 {
+		t.Fatalf("backend args = locator:%+v state:%q role:%q limit:%d", backend.listPRLocator, backend.listPRState, backend.listPRRole, backend.listPRLimit)
+	}
+	var got ListEnvelope[PullRequest]
+	decodeStructuredContent(t, res, &got)
+	if got.Count != 1 || got.Limit != 2 || !got.Truncated || len(got.Items) != 1 {
+		t.Fatalf("result = %+v", got)
+	}
+}
+
+func TestPullRequestListToolsPreserveEmptyUpstreamContinuation(t *testing.T) {
+	tests := []struct {
+		name string
+		tool string
+		args map[string]any
+	}{
+		{name: "repository", tool: "bkt_list_pull_requests", args: map[string]any{}},
+		{name: "cross repository", tool: "bkt_list_my_pull_requests", args: map[string]any{"role": "author"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := &fakeC2ABackend{listPRMore: true, listMyMore: true}
+			session := connectPair(t, newServer(
+				&Snapshot{Platform: "dc", HostLabel: "dc", DefaultScope: "PROJ", DefaultRepo: "api"},
+				"test",
+				backend,
+			))
+
+			res, err := session.CallTool(context.Background(), &mcp.CallToolParams{Name: tt.tool, Arguments: tt.args})
+			if err != nil {
+				t.Fatalf("CallTool: %v", err)
+			}
+			var got ListEnvelope[PullRequest]
+			decodeStructuredContent(t, res, &got)
+			if got.Items == nil || got.Count != 0 || !got.Truncated {
+				t.Fatalf("result = %#v, want non-nil empty items with continuation", got)
+			}
+		})
+	}
+}
+
+func TestListPullRequestsToolRejectsInvalidFilterBeforeBackend(t *testing.T) {
+	backend := &fakeC2ABackend{}
+	snap := &Snapshot{Platform: "dc", HostLabel: "dc", DefaultScope: "PROJ", DefaultRepo: "api"}
+	session := connectPair(t, newServer(snap, "test", backend))
+
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "bkt_list_pull_requests",
+		Arguments: map[string]any{
+			"state": "deleted",
+			"role":  "owner",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	got := decodeStructuredToolError(t, res)
+	if got.Code != ErrorInvalidInput || backend.listPRCalls != 0 {
+		t.Fatalf("error = %+v, backend calls = %d", got, backend.listPRCalls)
+	}
+}
+
+func TestListPullRequestsToolDCBearerOnlyRoleIsInvalidInputBeforeHTTP(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"values":[],"isLastPage":true}`))
+	}))
+	t.Cleanup(server.Close)
+	client, err := bbdc.New(bbdc.Options{
+		BaseURL: server.URL, AuthMethod: "bearer", Token: "token",
+		Retry: httpx.RetryPolicy{MaxAttempts: 1},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := &dcBackend{client: client}
+	snap := &Snapshot{Platform: "dc", HostLabel: "dc", DefaultScope: "PROJ", DefaultRepo: "api"}
+	session := connectPair(t, newServer(snap, "test", backend))
+
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "bkt_list_pull_requests",
+		Arguments: map[string]any{
+			"role": "reviewer",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	got := decodeStructuredToolError(t, res)
+	if got.Code != ErrorInvalidInput || got.Retryable {
+		t.Fatalf("error = %+v", got)
+	}
+	if requests.Load() != 0 {
+		t.Fatalf("HTTP requests = %d, want zero", requests.Load())
+	}
+
+	res, err = session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "bkt_list_pull_requests",
+		Arguments: map[string]any{"role": "all"},
+	})
+	if err != nil {
+		t.Fatalf("role=all CallTool: %v", err)
+	}
+	if res.IsError || requests.Load() != 1 {
+		t.Fatalf("role=all result=%+v HTTP requests=%d, want success and one request", res, requests.Load())
+	}
+}
+
+func TestListMyPullRequestsToolCloudAuthorAndReviewerCapability(t *testing.T) {
+	backend := &fakeC2ABackend{
+		listMyItems: []PullRequest{{ID: 8, Title: "Mine", Reviewers: []Reviewer{}}},
+	}
+	snap := &Snapshot{Platform: "cloud", HostLabel: "cloud", DefaultScope: "team"}
+	session := connectPair(t, newServer(snap, "test", backend))
+
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "bkt_list_my_pull_requests",
+		Arguments: map[string]any{
+			"role": "author",
+		},
+	})
+	if err != nil {
+		t.Fatalf("author CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("author tool error: %+v", res.Content)
+	}
+	if backend.listMyScope != "team" || backend.listMyState != "OPEN" || backend.listMyRole != "AUTHOR" || backend.listMyLimit != DefaultListLimit {
+		t.Fatalf("author backend args = scope:%q state:%q role:%q limit:%d", backend.listMyScope, backend.listMyState, backend.listMyRole, backend.listMyLimit)
+	}
+
+	res, err = session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "bkt_list_my_pull_requests",
+		Arguments: map[string]any{
+			"role": "reviewer",
+		},
+	})
+	if err != nil {
+		t.Fatalf("reviewer CallTool: %v", err)
+	}
+	toolErr := decodeStructuredToolError(t, res)
+	if toolErr.Code != ErrorUnsupportedOnPlatform || backend.listMyCalls != 1 {
+		t.Fatalf("reviewer error = %+v, backend calls = %d", toolErr, backend.listMyCalls)
+	}
+}
+
+func TestListMyPullRequestsToolRequiresRoleAndCloudScope(t *testing.T) {
+	backend := &fakeC2ABackend{}
+	session := connectPair(t, newServer(&Snapshot{Platform: "cloud", HostLabel: "cloud"}, "test", backend))
+
+	for _, args := range []map[string]any{
+		{},
+		{"role": "author"},
+	} {
+		res, err := session.CallTool(context.Background(), &mcp.CallToolParams{Name: "bkt_list_my_pull_requests", Arguments: args})
+		if err != nil {
+			t.Fatalf("CallTool(%v): %v", args, err)
+		}
+		got := decodeStructuredToolError(t, res)
+		if got.Code != ErrorInvalidInput {
+			t.Fatalf("CallTool(%v) error = %+v", args, got)
+		}
+	}
+	if backend.listMyCalls != 0 {
+		t.Fatalf("backend calls = %d, want zero", backend.listMyCalls)
+	}
+}
+
+func TestCapabilitiesAdvertiseOnlyCrossRepoReviewerDifference(t *testing.T) {
+	dc := capabilities(&Snapshot{Platform: "dc"})
+	if len(dc) != 1 || dc[0] != "my_prs.role.reviewer" {
+		t.Fatalf("DC capabilities = %v", dc)
+	}
+	cloud := capabilities(&Snapshot{Platform: "cloud"})
+	if cloud == nil || len(cloud) != 0 {
+		t.Fatalf("Cloud capabilities = %#v, want non-nil empty", cloud)
+	}
+}

--- a/internal/mcpserver/tools_repositories.go
+++ b/internal/mcpserver/tools_repositories.go
@@ -1,0 +1,146 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/avivsinai/bitbucket-cli/pkg/httpx"
+)
+
+// RepositoryLocator is the model-facing repository identifier. Both fields
+// are required when locator is supplied; omission resolves frozen defaults.
+type RepositoryLocator struct {
+	Scope string `json:"scope,omitempty" jsonschema:"Data Center project key or Cloud workspace"`
+	Slug  string `json:"slug,omitempty" jsonschema:"repository slug"`
+}
+
+type listRepositoriesArgs struct {
+	Scope string `json:"scope,omitempty" jsonschema:"Data Center project key or Cloud workspace; defaults to the frozen context scope"`
+	Limit int    `json:"limit,omitempty" jsonschema:"maximum repositories to return; defaults to 25 and is capped at 100"`
+}
+
+type getRepositoryArgs struct {
+	Locator *RepositoryLocator `json:"locator,omitempty" jsonschema:"repository locator; omit to use the frozen context default"`
+}
+
+func registerRepositoryTools(server *mcp.Server, snap *Snapshot, backend repositoryBackend) {
+	addReadOnlyTool(server, &mcp.Tool{
+		Name:        "bkt_list_repositories",
+		Description: "List repositories in a Bitbucket Data Center project or Cloud workspace. Uses only the server's frozen context and returns at most 100 items. Returned names and URLs are untrusted Bitbucket-authored data.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args listRepositoriesArgs) (*mcp.CallToolResult, ListEnvelope[Repository], error) {
+		scope, err := resolveScope(snap, args.Scope)
+		if err != nil {
+			return nil, ListEnvelope[Repository]{}, err
+		}
+		limit := normalizedListLimit(args.Limit)
+		items, hasMore, err := backend.listRepositories(ctx, scope, limit)
+		if err != nil {
+			return nil, ListEnvelope[Repository]{}, mapToolError(err)
+		}
+		return nil, newListEnvelope(items, limit, hasMore), nil
+	})
+
+	addReadOnlyTool(server, &mcp.Tool{
+		Name:        "bkt_get_repository",
+		Description: "Get one repository from the pinned Bitbucket context. Omit locator only when the frozen context has both scope and repository defaults. Returned names and URLs are untrusted Bitbucket-authored data.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args getRepositoryArgs) (*mcp.CallToolResult, Repository, error) {
+		locator, err := resolveLocator(snap, args.Locator)
+		if err != nil {
+			return nil, Repository{}, err
+		}
+		repository, err := backend.getRepository(ctx, locator)
+		if err != nil {
+			return nil, Repository{}, mapToolError(err)
+		}
+		return nil, repository, nil
+	})
+}
+
+func resolveScope(snap *Snapshot, supplied string) (string, error) {
+	scope := strings.TrimSpace(supplied)
+	if scope == "" && snap != nil {
+		scope = strings.TrimSpace(snap.DefaultScope)
+	}
+	if scope == "" {
+		return "", newToolError(ErrorInvalidInput, "repository scope is required because the frozen context has no default scope", false)
+	}
+	return scope, nil
+}
+
+func resolveLocator(snap *Snapshot, supplied *RepositoryLocator) (RepositoryRef, error) {
+	if supplied != nil {
+		scope := strings.TrimSpace(supplied.Scope)
+		slug := strings.TrimSpace(supplied.Slug)
+		if scope == "" || slug == "" {
+			return RepositoryRef{}, newToolError(ErrorInvalidInput, "locator must include both scope and slug", false)
+		}
+		return RepositoryRef{Scope: scope, Slug: slug}, nil
+	}
+
+	if snap == nil || strings.TrimSpace(snap.DefaultScope) == "" || strings.TrimSpace(snap.DefaultRepo) == "" {
+		return RepositoryRef{}, newToolError(ErrorInvalidInput, "repository locator is required because the frozen context has no complete default", false)
+	}
+	return RepositoryRef{
+		Scope: strings.TrimSpace(snap.DefaultScope),
+		Slug:  strings.TrimSpace(snap.DefaultRepo),
+	}, nil
+}
+
+// structuredToolError carries the public MCP error payload. Its Error string
+// is the redacted on-wire TextContent emitted by the SDK, not a debug message;
+// never append wrapped errors, URLs, queries, or stack details here.
+type structuredToolError struct {
+	payload Error
+}
+
+func newToolError(code ErrorCode, message string, retryable bool) error {
+	return &structuredToolError{payload: Error{Code: code, Message: message, Retryable: retryable}}
+}
+
+func (e *structuredToolError) Error() string {
+	raw, err := json.Marshal(e.payload)
+	if err != nil {
+		return `{"code":"upstream_error","message":"tool failed","retryable":false}`
+	}
+	return string(raw)
+}
+
+func mapToolError(err error) error {
+	if errors.Is(err, context.Canceled) {
+		return context.Canceled
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return context.DeadlineExceeded
+	}
+
+	var toolErr *structuredToolError
+	if errors.As(err, &toolErr) {
+		// Return the redacted payload itself, not a wrapper that may contain
+		// debug-only URLs, queries, or credential material.
+		return toolErr
+	}
+
+	var httpErr *httpx.HTTPError
+	if !errors.As(err, &httpErr) {
+		var transportErr net.Error
+		retryable := errors.As(err, &transportErr) && transportErr.Timeout()
+		return newToolError(ErrorUpstream, "Bitbucket request failed", retryable)
+	}
+
+	switch httpErr.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return newToolError(ErrorAuthFailed, "Bitbucket authentication failed", false)
+	case http.StatusNotFound:
+		return newToolError(ErrorNotFound, "Bitbucket resource not found", false)
+	case http.StatusTooManyRequests:
+		return newToolError(ErrorRateLimited, "Bitbucket rate limit exceeded", true)
+	default:
+		return newToolError(ErrorUpstream, "Bitbucket request failed", httpErr.StatusCode >= 500)
+	}
+}

--- a/internal/mcpserver/tools_repositories_test.go
+++ b/internal/mcpserver/tools_repositories_test.go
@@ -1,0 +1,324 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/avivsinai/bitbucket-cli/pkg/httpx"
+)
+
+type fakeRepositoryBackend struct {
+	listScope string
+	listLimit int
+	listItems []Repository
+	listMore  bool
+	listErr   error
+
+	getLocator RepositoryRef
+	getResult  Repository
+	getErr     error
+	getCalls   int
+
+	listEntered  chan struct{}
+	listCanceled chan struct{}
+}
+
+func (f *fakeRepositoryBackend) listRepositories(ctx context.Context, scope string, limit int) ([]Repository, bool, error) {
+	f.listScope = scope
+	f.listLimit = limit
+	if f.listEntered != nil {
+		close(f.listEntered)
+		<-ctx.Done()
+		close(f.listCanceled)
+		return nil, false, ctx.Err()
+	}
+	return f.listItems, f.listMore, f.listErr
+}
+
+func (f *fakeRepositoryBackend) getRepository(_ context.Context, locator RepositoryRef) (Repository, error) {
+	f.getCalls++
+	f.getLocator = locator
+	return f.getResult, f.getErr
+}
+
+func (f *fakeRepositoryBackend) listPullRequests(context.Context, RepositoryRef, string, string, int) ([]PullRequest, bool, error) {
+	return []PullRequest{}, false, nil
+}
+
+func (f *fakeRepositoryBackend) listMyPullRequests(context.Context, string, string, string, int) ([]PullRequest, bool, error) {
+	return []PullRequest{}, false, nil
+}
+
+func TestListRepositoriesToolUsesFrozenScopeAndBoundedPage(t *testing.T) {
+	backend := &fakeRepositoryBackend{
+		listItems: []Repository{
+			{Scope: "PROJ", Slug: "one", Name: "One"},
+			{Scope: "PROJ", Slug: "two", Name: "Two"},
+		},
+		listMore: true,
+	}
+	snap := &Snapshot{Platform: "dc", HostLabel: "dc", DefaultScope: "PROJ"}
+	session := connectPair(t, newServer(snap, "test", backend))
+
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "bkt_list_repositories",
+		Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool error: %+v", res.Content)
+	}
+	if backend.listScope != "PROJ" || backend.listLimit != DefaultListLimit {
+		t.Fatalf("backend args = scope %q limit %d", backend.listScope, backend.listLimit)
+	}
+
+	var got ListEnvelope[Repository]
+	decodeStructuredContent(t, res, &got)
+	if got.Count != 2 || got.Limit != DefaultListLimit || !got.Truncated || len(got.Items) != 2 {
+		t.Fatalf("result = %+v", got)
+	}
+}
+
+func TestListRepositoriesToolPreservesEmptyUpstreamContinuation(t *testing.T) {
+	backend := &fakeRepositoryBackend{listMore: true}
+	session := connectPair(t, newServer(
+		&Snapshot{Platform: "dc", HostLabel: "dc", DefaultScope: "PROJ"},
+		"test",
+		backend,
+	))
+
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "bkt_list_repositories",
+		Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	var got ListEnvelope[Repository]
+	decodeStructuredContent(t, res, &got)
+	if got.Items == nil || got.Count != 0 || !got.Truncated {
+		t.Fatalf("result = %#v, want non-nil empty items with continuation", got)
+	}
+}
+
+func TestListRepositoriesToolRejectsMissingScope(t *testing.T) {
+	backend := &fakeRepositoryBackend{}
+	session := connectPair(t, newServer(&Snapshot{Platform: "cloud", HostLabel: "cloud"}, "test", backend))
+
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "bkt_list_repositories",
+		Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	got := decodeStructuredToolError(t, res)
+	if got.Code != ErrorInvalidInput || got.Retryable {
+		t.Fatalf("error = %+v", got)
+	}
+}
+
+func TestListRepositoriesToolPropagatesCancellation(t *testing.T) {
+	backend := &fakeRepositoryBackend{
+		listEntered:  make(chan struct{}),
+		listCanceled: make(chan struct{}),
+	}
+	session := connectPair(t, newServer(&Snapshot{Platform: "dc", HostLabel: "dc", DefaultScope: "PROJ"}, "test", backend))
+	ctx, cancel := context.WithCancel(context.Background())
+	callErr := make(chan error, 1)
+	go func() {
+		_, err := session.CallTool(ctx, &mcp.CallToolParams{Name: "bkt_list_repositories", Arguments: map[string]any{}})
+		callErr <- err
+	}()
+
+	select {
+	case <-backend.listEntered:
+	case <-time.After(time.Second):
+		t.Fatal("backend did not receive tool call")
+	}
+	cancel()
+	select {
+	case <-backend.listCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("backend context was not canceled")
+	}
+	select {
+	case err := <-callErr:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("CallTool error = %T %v, want context.Canceled", err, err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("tool call did not return after cancellation")
+	}
+}
+
+func TestGetRepositoryToolResolvesDefaultAndRejectsPartialLocator(t *testing.T) {
+	backend := &fakeRepositoryBackend{
+		getResult: Repository{Scope: "PROJ", Slug: "api", Name: "API"},
+	}
+	snap := &Snapshot{Platform: "dc", HostLabel: "dc", DefaultScope: "PROJ", DefaultRepo: "api"}
+	session := connectPair(t, newServer(snap, "test", backend))
+
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "bkt_get_repository",
+		Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("default CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("default tool error: %+v", res.Content)
+	}
+	if backend.getLocator != (RepositoryRef{Scope: "PROJ", Slug: "api"}) {
+		t.Fatalf("default locator = %+v", backend.getLocator)
+	}
+	var got Repository
+	decodeStructuredContent(t, res, &got)
+	if got.Slug != "api" {
+		t.Fatalf("repository = %+v", got)
+	}
+
+	res, err = session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "bkt_get_repository",
+		Arguments: map[string]any{
+			"locator": map[string]any{"scope": "OTHER"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("partial locator CallTool: %v", err)
+	}
+	toolErr := decodeStructuredToolError(t, res)
+	if toolErr.Code != ErrorInvalidInput || backend.getCalls != 1 {
+		t.Fatalf("partial locator error = %+v, backend calls = %d", toolErr, backend.getCalls)
+	}
+}
+
+func TestMapToolErrorUsesTypedHTTPStatusAndRedactsUpstreamText(t *testing.T) {
+	tests := []struct {
+		name          string
+		err           error
+		wantCode      ErrorCode
+		wantRetryable bool
+	}{
+		{name: "unauthorized", err: &httpx.HTTPError{StatusCode: http.StatusUnauthorized}, wantCode: ErrorAuthFailed},
+		{name: "forbidden", err: &httpx.HTTPError{StatusCode: http.StatusForbidden}, wantCode: ErrorAuthFailed},
+		{name: "not found", err: &httpx.HTTPError{StatusCode: http.StatusNotFound}, wantCode: ErrorNotFound},
+		{name: "rate limited", err: &httpx.HTTPError{StatusCode: http.StatusTooManyRequests}, wantCode: ErrorRateLimited, wantRetryable: true},
+		{name: "server error", err: &httpx.HTTPError{StatusCode: http.StatusBadGateway}, wantCode: ErrorUpstream, wantRetryable: true},
+		{name: "other client error", err: &httpx.HTTPError{StatusCode: http.StatusBadRequest}, wantCode: ErrorUpstream},
+		{name: "transport error", err: &url.Error{Op: "GET", URL: "https://example.test?token=secret", Err: &net.DNSError{IsTimeout: true}}, wantCode: ErrorUpstream, wantRetryable: true},
+		{name: "permanent network error", err: &url.Error{Op: "GET", URL: "https://example.test?token=secret", Err: errors.New("x509: certificate signed by unknown authority")}, wantCode: ErrorUpstream},
+		{name: "local adaptation error", err: errors.New("request https://example.test?token=secret failed"), wantCode: ErrorUpstream},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mapped := mapToolError(tt.err)
+			var got Error
+			if err := json.Unmarshal([]byte(mapped.Error()), &got); err != nil {
+				t.Fatalf("mapped error is not JSON: %v", err)
+			}
+			if got.Code != tt.wantCode || got.Retryable != tt.wantRetryable {
+				t.Fatalf("mapped = %+v, want code=%q retryable=%v", got, tt.wantCode, tt.wantRetryable)
+			}
+			if strings.Contains(mapped.Error(), "secret") || strings.Contains(mapped.Error(), "example.test") {
+				t.Fatalf("mapped error leaked upstream details: %s", mapped)
+			}
+		})
+	}
+}
+
+func TestMapToolErrorPreservesStructuredPayloadWithoutWrapperText(t *testing.T) {
+	want := newToolError(ErrorInvalidInput, "frozen context is missing required identity", false)
+	mapped := mapToolError(fmt.Errorf("debug secret wrapper: %w", want))
+	var got *structuredToolError
+	if !errors.As(mapped, &got) {
+		t.Fatalf("mapped error = %T %v, want structuredToolError", mapped, mapped)
+	}
+	if got.payload.Code != ErrorInvalidInput || got.payload.Retryable {
+		t.Fatalf("mapped payload = %+v", got.payload)
+	}
+	if strings.Contains(mapped.Error(), "secret") {
+		t.Fatalf("mapped error leaked wrapper text: %s", mapped)
+	}
+}
+
+func TestMapToolErrorPreservesContextCancellation(t *testing.T) {
+	for _, want := range []error{context.Canceled, context.DeadlineExceeded} {
+		if got := mapToolError(want); !errors.Is(got, want) {
+			t.Fatalf("mapToolError(%v) = %T %v, want original context error", want, got, got)
+		}
+	}
+}
+
+func TestGetRepositoryToolEmitsOnlyRedactedErrorDTOText(t *testing.T) {
+	backend := &fakeRepositoryBackend{
+		getErr: fmt.Errorf("GET https://example.test/repo?token=secret: %w", &httpx.HTTPError{StatusCode: http.StatusNotFound}),
+	}
+	snap := &Snapshot{Platform: "dc", HostLabel: "dc", DefaultScope: "PROJ", DefaultRepo: "api"}
+	session := connectPair(t, newServer(snap, "test", backend))
+
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "bkt_get_repository",
+		Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	got := decodeStructuredToolError(t, res)
+	if got.Code != ErrorNotFound || got.Retryable {
+		t.Fatalf("error = %+v", got)
+	}
+	text := res.Content[0].(*mcp.TextContent).Text
+	want, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text != string(want) {
+		t.Fatalf("error text = %q, want only Error DTO JSON %q", text, want)
+	}
+	if strings.Contains(text, "secret") || strings.Contains(text, "example.test") {
+		t.Fatalf("tool error leaked upstream details: %s", text)
+	}
+}
+
+func decodeStructuredContent(t *testing.T, res *mcp.CallToolResult, out any) {
+	t.Helper()
+	raw, err := json.Marshal(res.StructuredContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		t.Fatalf("decode structured content: %v\n%s", err, raw)
+	}
+}
+
+func decodeStructuredToolError(t *testing.T, res *mcp.CallToolResult) Error {
+	t.Helper()
+	if !res.IsError {
+		t.Fatalf("result IsError=false: %+v", res)
+	}
+	if len(res.Content) != 1 {
+		t.Fatalf("error content = %+v", res.Content)
+	}
+	text, ok := res.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("error content type = %T", res.Content[0])
+	}
+	var got Error
+	if err := json.Unmarshal([]byte(text.Text), &got); err != nil {
+		t.Fatalf("error is not Error JSON: %v\n%s", err, text.Text)
+	}
+	return got
+}

--- a/pkg/bbcloud/client.go
+++ b/pkg/bbcloud/client.go
@@ -262,32 +262,25 @@ type repositoryListPage struct {
 	Next   string       `json:"next"`
 }
 
+// RepositoriesPage is one bounded page of repositories. Next is an opaque
+// reference to the following page; empty means the last page.
+type RepositoriesPage struct {
+	Values []Repository
+	Next   string
+}
+
 // ListRepositories enumerates repositories for the workspace.
 func (c *Client) ListRepositories(ctx context.Context, workspace string, limit int) ([]Repository, error) {
-	if workspace == "" {
-		return nil, fmt.Errorf("workspace is required")
-	}
-
 	pageLen := limit
 	if pageLen <= 0 || pageLen > 100 {
 		pageLen = 20
 	}
 
-	path := fmt.Sprintf("/repositories/%s?pagelen=%d",
-		url.PathEscape(workspace),
-		pageLen,
-	)
-
 	var repos []Repository
-
-	for path != "" {
-		req, err := c.http.NewRequest(ctx, "GET", path, nil)
+	next := ""
+	for {
+		page, err := c.ListRepositoriesPage(ctx, workspace, pageLen, next)
 		if err != nil {
-			return nil, err
-		}
-
-		var page repositoryListPage
-		if err := c.http.Do(req, &page); err != nil {
 			return nil, err
 		}
 
@@ -301,16 +294,52 @@ func (c *Client) ListRepositories(ctx context.Context, workspace string, limit i
 		if page.Next == "" {
 			break
 		}
-
-		// Bitbucket returns absolute URLs for next; reuse as-is.
-		pathURL, err := url.Parse(page.Next)
-		if err != nil {
-			return nil, err
-		}
-		path = pathURL.RequestURI()
+		next = page.Next
 	}
 
 	return repos, nil
+}
+
+// ListRepositoriesPage fetches one repository page and preserves the opaque
+// upstream continuation reference for bounded consumers.
+func (c *Client) ListRepositoriesPage(ctx context.Context, workspace string, limit int, next string) (*RepositoriesPage, error) {
+	if workspace == "" {
+		return nil, fmt.Errorf("workspace is required")
+	}
+
+	endpoint := fmt.Sprintf("/repositories/%s", url.PathEscape(workspace))
+	path := ""
+	if next != "" {
+		normalized, err := normalizeNextRef(next, endpoint)
+		if err != nil {
+			return nil, err
+		}
+		path = normalized
+	} else {
+		if limit <= 0 || limit > 100 {
+			limit = 20
+		}
+		path = fmt.Sprintf("%s?pagelen=%d", endpoint, limit)
+	}
+
+	req, err := c.http.NewRequest(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var page repositoryListPage
+	if err := c.http.Do(req, &page); err != nil {
+		return nil, err
+	}
+
+	nextRef := ""
+	if page.Next != "" {
+		nextURL, err := url.Parse(page.Next)
+		if err != nil {
+			return nil, err
+		}
+		nextRef = nextURL.RequestURI()
+	}
+	return &RepositoriesPage{Values: page.Values, Next: nextRef}, nil
 }
 
 // GetRepository retrieves repository details.
@@ -737,9 +766,7 @@ func (c *Client) ListWorkspacePullRequestsPage(ctx context.Context, workspace, u
 
 	var params []string
 	params = append(params, fmt.Sprintf("pagelen=%d", pageLen))
-	if state := strings.TrimSpace(opts.State); state != "" && !strings.EqualFold(state, "all") {
-		params = append(params, "state="+url.QueryEscape(strings.ToUpper(state)))
-	}
+	params = append(params, pullRequestStateParams(opts.State)...)
 
 	path := fmt.Sprintf("/workspaces/%s/pullrequests/%s?%s",
 		url.PathEscape(workspace),

--- a/pkg/bbcloud/client_test.go
+++ b/pkg/bbcloud/client_test.go
@@ -692,6 +692,62 @@ func TestListRepositoriesPaginates(t *testing.T) {
 	}
 }
 
+func TestListRepositoriesPageReturnsOpaqueContinuation(t *testing.T) {
+	var hits int32
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		switch count {
+		case 1:
+			if r.URL.Path != "/repositories/ws" || r.URL.Query().Get("pagelen") != "2" {
+				t.Fatalf("first request = %s?%s", r.URL.Path, r.URL.RawQuery)
+			}
+			_ = json.NewEncoder(w).Encode(repositoryListPage{
+				Values: []Repository{{Slug: "repo1"}, {Slug: "repo2"}},
+				Next:   serverURL + "/repositories/ws?pagelen=2&page=2",
+			})
+		case 2:
+			if r.URL.Path != "/repositories/ws" || r.URL.Query().Get("page") != "2" {
+				t.Fatalf("second request = %s?%s", r.URL.Path, r.URL.RawQuery)
+			}
+			_ = json.NewEncoder(w).Encode(repositoryListPage{Values: []Repository{{Slug: "repo3"}}})
+		default:
+			t.Fatalf("unexpected request %d", count)
+		}
+	}))
+	serverURL = server.URL
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{BaseURL: server.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := client.ListRepositoriesPage(context.Background(), "ws", 2, "")
+	if err != nil {
+		t.Fatalf("first ListRepositoriesPage: %v", err)
+	}
+	if len(first.Values) != 2 || first.Next == "" {
+		t.Fatalf("first page = %+v", first)
+	}
+	second, err := client.ListRepositoriesPage(context.Background(), "ws", 2, first.Next)
+	if err != nil {
+		t.Fatalf("second ListRepositoriesPage: %v", err)
+	}
+	if len(second.Values) != 1 || second.Values[0].Slug != "repo3" || second.Next != "" {
+		t.Fatalf("second page = %+v", second)
+	}
+}
+
+func TestListRepositoriesPageRejectsWrongEndpoint(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("unexpected request")
+	}))
+	if _, err := client.ListRepositoriesPage(context.Background(), "ws", 2, "/2.0/user?page=2"); err == nil || !strings.Contains(err.Error(), "does not target") {
+		t.Fatalf("error = %v, want wrong-endpoint rejection", err)
+	}
+}
+
 func TestListRepositoriesRespectsLimit(t *testing.T) {
 	var hits int32
 	var serverURL string

--- a/pkg/bbcloud/pullrequests.go
+++ b/pkg/bbcloud/pullrequests.go
@@ -147,9 +147,7 @@ func (c *Client) ListRepoPullRequestsPage(ctx context.Context, workspace, repoSl
 
 	var params []string
 	params = append(params, fmt.Sprintf("pagelen=%d", pageLen))
-	if state := strings.TrimSpace(opts.State); state != "" && !strings.EqualFold(state, "all") {
-		params = append(params, "state="+url.QueryEscape(strings.ToUpper(state)))
-	}
+	params = append(params, pullRequestStateParams(opts.State)...)
 	if q := pullRequestQFilter(opts); q != "" {
 		params = append(params, "q="+url.QueryEscape(q))
 	}
@@ -161,6 +159,17 @@ func (c *Client) ListRepoPullRequestsPage(ctx context.Context, workspace, repoSl
 	)
 
 	return c.fetchPullRequestsPage(ctx, path)
+}
+
+func pullRequestStateParams(raw string) []string {
+	state := strings.ToUpper(strings.TrimSpace(raw))
+	if state == "" {
+		return nil
+	}
+	if state == "ALL" {
+		return []string{"state=OPEN", "state=MERGED", "state=DECLINED"}
+	}
+	return []string{"state=" + url.QueryEscape(state)}
 }
 
 // pullRequestQFilter builds the upstream BBQL q parameter from the identity

--- a/pkg/bbcloud/pullrequests_test.go
+++ b/pkg/bbcloud/pullrequests_test.go
@@ -1787,6 +1787,27 @@ func TestListRepoPullRequestsPageNextRoundTrip(t *testing.T) {
 	}
 }
 
+func TestPullRequestPagesStateAllRepeatsEverySupportedState(t *testing.T) {
+	var gotStates [][]string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotStates = append(gotStates, r.URL.Query()["state"])
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"values": []any{}})
+	}))
+
+	if _, err := client.ListRepoPullRequestsPage(context.Background(), "ws", "repo", bbcloud.PullRequestListOptions{State: "ALL", Limit: 25}, ""); err != nil {
+		t.Fatalf("ListRepoPullRequestsPage: %v", err)
+	}
+	if _, err := client.ListWorkspacePullRequestsPage(context.Background(), "ws", "alice", bbcloud.WorkspacePullRequestsOptions{State: "all", Limit: 25}, ""); err != nil {
+		t.Fatalf("ListWorkspacePullRequestsPage: %v", err)
+	}
+	for i, states := range gotStates {
+		if got := strings.Join(states, ","); got != "OPEN,MERGED,DECLINED" {
+			t.Fatalf("request %d states = %q, want repeated OPEN,MERGED,DECLINED", i+1, got)
+		}
+	}
+}
+
 func TestListWorkspacePullRequestsPageIsAuthorScoped(t *testing.T) {
 	var gotPath string
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/bbdc/client.go
+++ b/pkg/bbdc/client.go
@@ -159,6 +159,13 @@ type paged[T any] struct {
 	Values        []T  `json:"values"`
 }
 
+// RepositoriesPage is one bounded page of repositories.
+type RepositoriesPage struct {
+	Values    []Repository
+	IsLast    bool
+	NextStart int
+}
+
 // CurrentUser fetches the user identified by slug.
 func (c *Client) CurrentUser(ctx context.Context, userSlug string) (*User, error) {
 	req, err := c.http.NewRequest(ctx, "GET", fmt.Sprintf("/rest/api/1.0/users/%s", url.PathEscape(userSlug)), nil)
@@ -174,10 +181,6 @@ func (c *Client) CurrentUser(ctx context.Context, userSlug string) (*User, error
 
 // ListRepositories enumerates repositories for a project, handling pagination.
 func (c *Client) ListRepositories(ctx context.Context, projectKey string, limit int) ([]Repository, error) {
-	if projectKey == "" {
-		return nil, fmt.Errorf("project key is required")
-	}
-
 	const defaultPageSize = 25
 
 	var (
@@ -197,31 +200,52 @@ func (c *Client) ListRepositories(ctx context.Context, projectKey string, limit 
 			}
 		}
 
-		u := fmt.Sprintf("/rest/api/1.0/projects/%s/repos?limit=%d&start=%d", url.PathEscape(projectKey), pageSize, start)
-		req, err := c.http.NewRequest(ctx, "GET", u, nil)
+		page, err := c.ListRepositoriesPage(ctx, projectKey, pageSize, start)
 		if err != nil {
 			return nil, err
 		}
 
-		var resp paged[Repository]
-		if err := c.http.Do(req, &resp); err != nil {
-			return nil, err
-		}
-
-		found = append(found, resp.Values...)
+		found = append(found, page.Values...)
 
 		if limit > 0 && len(found) >= limit {
 			found = found[:limit]
 			break
 		}
 
-		if resp.IsLastPage || len(resp.Values) == 0 {
+		if page.IsLast || len(page.Values) == 0 {
 			break
 		}
-		start = resp.NextPageStart
+		start = page.NextStart
 	}
 
 	return found, nil
+}
+
+// ListRepositoriesPage fetches one repository page and preserves upstream
+// continuation metadata for bounded consumers.
+func (c *Client) ListRepositoriesPage(ctx context.Context, projectKey string, limit, start int) (*RepositoriesPage, error) {
+	if projectKey == "" {
+		return nil, fmt.Errorf("project key is required")
+	}
+	if limit <= 0 || limit > 100 {
+		limit = 25
+	}
+
+	u := fmt.Sprintf("/rest/api/1.0/projects/%s/repos?limit=%d&start=%d", url.PathEscape(projectKey), limit, start)
+	req, err := c.http.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp paged[Repository]
+	if err := c.http.Do(req, &resp); err != nil {
+		return nil, err
+	}
+	return &RepositoriesPage{
+		Values:    resp.Values,
+		IsLast:    resp.IsLastPage,
+		NextStart: resp.NextPageStart,
+	}, nil
 }
 
 // GetRepository fetches details for a repository.
@@ -308,7 +332,7 @@ func (c *Client) ListRepoPullRequestsPage(ctx context.Context, projectKey, repoS
 
 	return &PullRequestsPage{
 		Values:    resp.Values,
-		IsLast:    resp.IsLastPage || len(resp.Values) == 0,
+		IsLast:    resp.IsLastPage,
 		NextStart: resp.NextPageStart,
 	}, nil
 }
@@ -373,7 +397,7 @@ func (c *Client) ListPullRequests(ctx context.Context, projectKey, repoSlug, sta
 
 		all = append(all, page.Values...)
 
-		if page.IsLast {
+		if page.IsLast || len(page.Values) == 0 {
 			break
 		}
 		start = page.NextStart
@@ -446,7 +470,7 @@ func (c *Client) ListDashboardPullRequestsPage(ctx context.Context, opts Dashboa
 
 	return &PullRequestsPage{
 		Values:    resp.Values,
-		IsLast:    resp.IsLastPage || len(resp.Values) == 0,
+		IsLast:    resp.IsLastPage,
 		NextStart: resp.NextPageStart,
 	}, nil
 }
@@ -481,7 +505,7 @@ func (c *Client) ListDashboardPullRequests(ctx context.Context, opts DashboardPu
 
 		all = append(all, page.Values...)
 
-		if page.IsLast {
+		if page.IsLast || len(page.Values) == 0 {
 			break
 		}
 		start = page.NextStart

--- a/pkg/bbdc/client_test.go
+++ b/pkg/bbdc/client_test.go
@@ -101,6 +101,56 @@ func TestListRepositoriesPaginates(t *testing.T) {
 	}
 }
 
+func TestListRepositoriesPageReturnsContinuation(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rest/api/1.0/projects/PROJ/repos" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("limit"); got != "2" {
+			t.Fatalf("limit = %q, want 2", got)
+		}
+		if got := r.URL.Query().Get("start"); got != "7" {
+			t.Fatalf("start = %q, want 7", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(paged[Repository]{
+			Values:        []Repository{{Slug: "repo1"}, {Slug: "repo2"}},
+			IsLastPage:    false,
+			NextPageStart: 9,
+		})
+	}))
+
+	page, err := client.ListRepositoriesPage(context.Background(), "PROJ", 2, 7)
+	if err != nil {
+		t.Fatalf("ListRepositoriesPage: %v", err)
+	}
+	if len(page.Values) != 2 || page.Values[0].Slug != "repo1" {
+		t.Fatalf("values = %+v", page.Values)
+	}
+	if page.IsLast || page.NextStart != 9 {
+		t.Fatalf("continuation = isLast:%v next:%d, want false/9", page.IsLast, page.NextStart)
+	}
+}
+
+func TestListRepositoriesPagePreservesEmptyNonFinalContinuation(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(paged[Repository]{
+			Values:        []Repository{},
+			IsLastPage:    false,
+			NextPageStart: 9,
+		})
+	}))
+
+	page, err := client.ListRepositoriesPage(context.Background(), "PROJ", 2, 7)
+	if err != nil {
+		t.Fatalf("ListRepositoriesPage: %v", err)
+	}
+	if page.IsLast || page.NextStart != 9 {
+		t.Fatalf("empty continuation = isLast:%v next:%d, want false/9", page.IsLast, page.NextStart)
+	}
+}
+
 func TestListRepositoriesRespectsLimit(t *testing.T) {
 	var hits int32
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/bbdc/pullrequests_test.go
+++ b/pkg/bbdc/pullrequests_test.go
@@ -1032,6 +1032,33 @@ func TestListRepoPullRequestsPageRoleValidation(t *testing.T) {
 	}
 }
 
+func TestPullRequestPagesPreserveEmptyNonFinalContinuation(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"values":        []any{},
+			"isLastPage":    false,
+			"nextPageStart": 25,
+		})
+	}))
+
+	repoPage, err := client.ListRepoPullRequestsPage(context.Background(), "PROJ", "repo", bbdc.RepoPullRequestsOptions{Limit: 25})
+	if err != nil {
+		t.Fatalf("ListRepoPullRequestsPage: %v", err)
+	}
+	if repoPage.IsLast || repoPage.NextStart != 25 {
+		t.Fatalf("repo page = %+v, want empty non-final continuation", repoPage)
+	}
+
+	dashboardPage, err := client.ListDashboardPullRequestsPage(context.Background(), bbdc.DashboardPullRequestsOptions{Role: "AUTHOR", Limit: 25}, 0)
+	if err != nil {
+		t.Fatalf("ListDashboardPullRequestsPage: %v", err)
+	}
+	if dashboardPage.IsLast || dashboardPage.NextStart != 25 {
+		t.Fatalf("dashboard page = %+v, want empty non-final continuation", dashboardPage)
+	}
+}
+
 func TestListDashboardPullRequestsPageEncodesRole(t *testing.T) {
 	var gotQuery string
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/cmd/mcp/mcp.go
+++ b/pkg/cmd/mcp/mcp.go
@@ -43,6 +43,10 @@ a named context, otherwise the active context is used. The working directory
 never influences the served target, and configuration changes require a
 restart. Tool calls cannot switch hosts, contexts, or tokens.
 
+For a Cloud OAuth context, the access token is frozen at startup and is not
+refreshed from the credential store. After it expires, tool calls return
+auth_failed until the MCP server is restarted.
+
 v1 is read-only and registers tools only for capabilities the pinned platform
 supports; call bkt_get_context to discover the target and capabilities.
 
@@ -75,7 +79,13 @@ func runServe(cmd *cobra.Command, f *cmdutil.Factory, transport sdk.Transport) e
 		return err
 	}
 
-	// Startup banner goes to stderr: stdout is reserved for the protocol.
+	server, err := mcpserver.New(snap, f.AppVersion)
+	if err != nil {
+		return err
+	}
+
+	// Startup banner goes to stderr after construction succeeds: stdout is
+	// reserved for the protocol, and a failed server never claims to be running.
 	label := snap.ContextName
 	if label == "" {
 		label = "(env)"
@@ -83,7 +93,6 @@ func runServe(cmd *cobra.Command, f *cmdutil.Factory, transport sdk.Transport) e
 	fmt.Fprintf(ios.ErrOut, "bkt mcp serve: context %s, platform %s, host %s (read-only; Ctrl-C to stop)\n",
 		label, snap.Platform, snap.HostLabel)
 
-	server := mcpserver.New(snap, f.AppVersion)
 	if transport == nil {
 		transport = &sdk.StdioTransport{}
 	}

--- a/pkg/cmd/mcp/mcp_test.go
+++ b/pkg/cmd/mcp/mcp_test.go
@@ -112,8 +112,10 @@ func TestServeCommandStdoutCarriesOnlyJSONRPC(t *testing.T) {
 			t.Fatalf("protocol frame %d lacks jsonrpc 2.0 envelope: %q", i+1, line)
 		}
 	}
-	if !strings.Contains(listResp, "bkt_get_context") {
-		t.Fatalf("tools/list response missing bkt_get_context: %q", listResp)
+	for _, tool := range []string{"bkt_get_context", "bkt_list_repositories", "bkt_get_repository", "bkt_list_pull_requests", "bkt_list_my_pull_requests"} {
+		if !strings.Contains(listResp, tool) {
+			t.Fatalf("tools/list response missing %s: %q", tool, listResp)
+		}
 	}
 	if !strings.Contains(listResp, `"readOnlyHint":true`) {
 		t.Fatalf("tools/list must advertise readOnlyHint: %q", listResp)
@@ -128,6 +130,44 @@ func TestServeCommandStdoutCarriesOnlyJSONRPC(t *testing.T) {
 	banner := stderr.String()
 	if !strings.Contains(banner, "bkt mcp serve: context work, platform dc, host dc-host") {
 		t.Fatalf("startup banner missing or wrong on stderr: %q", banner)
+	}
+}
+
+func TestServeCommandDoesNotPrintRunningBannerBeforeBackendConstruction(t *testing.T) {
+	cfg := &config.Config{
+		ActiveContext: "broken",
+		Contexts: map[string]*config.Context{
+			"broken": {Host: "dc-host", ProjectKey: "PROJ"},
+		},
+		Hosts: map[string]*config.Host{
+			"dc-host": {Kind: "dc", BaseURL: "://invalid", Username: "u", Token: "t"},
+		},
+	}
+
+	var stderr bytes.Buffer
+	f := &cmdutil.Factory{
+		AppVersion:     "test",
+		ExecutableName: "bkt",
+		IOStreams:      &iostreams.IOStreams{Out: &failIfWritten{t: t}, ErrOut: &stderr},
+		Config:         func() (*config.Config, error) { return cfg, nil },
+	}
+	cmd := newServeCmdWithTransport(f, nil)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	if err := cmd.ExecuteContext(context.Background()); err == nil {
+		t.Fatal("expected backend construction error")
+	}
+	if strings.Contains(stderr.String(), "Ctrl-C to stop") {
+		t.Fatalf("running banner printed before backend construction succeeded: %q", stderr.String())
+	}
+}
+
+func TestServeCommandDocumentsFrozenCloudOAuthCredential(t *testing.T) {
+	cmd := newServeCmdWithTransport(&cmdutil.Factory{}, nil)
+	for _, want := range []string{"Cloud OAuth", "frozen at startup", "auth_failed", "restarted"} {
+		if !strings.Contains(cmd.Long, want) {
+			t.Fatalf("serve help missing %q:\n%s", want, cmd.Long)
+		}
 	}
 }
 

--- a/pkg/cmdutil/client.go
+++ b/pkg/cmdutil/client.go
@@ -44,6 +44,21 @@ func NewDCClient(host *config.Host) (*bbdc.Client, error) {
 // When the host uses OAuth authentication, a TokenRefresher is wired to
 // transparently refresh expired tokens on 401.
 func NewCloudClient(host *config.Host) (*bbcloud.Client, error) {
+	return newCloudClient(host, true)
+}
+
+// NewFrozenCloudClient constructs a Bitbucket Cloud client that uses exactly
+// the supplied credential for its lifetime. OAuth credentials use bearer auth,
+// but the client never reopens the credential store or refreshes on 401.
+func NewFrozenCloudClient(host *config.Host) (*bbcloud.Client, error) {
+	if host == nil {
+		return nil, fmt.Errorf("missing host configuration")
+	}
+	frozen := *host
+	return newCloudClient(&frozen, false)
+}
+
+func newCloudClient(host *config.Host, enableOAuthRefresh bool) (*bbcloud.Client, error) {
 	if host == nil {
 		return nil, fmt.Errorf("missing host configuration")
 	}
@@ -62,11 +77,13 @@ func NewCloudClient(host *config.Host) (*bbcloud.Client, error) {
 		},
 	}
 
-	if host.AuthMethod == "oauth" && secret.TokenFromEnv() == "" {
+	if host.AuthMethod == "oauth" && (!enableOAuthRefresh || secret.TokenFromEnv() == "") {
+		opts.AuthMethod = "bearer"
+	}
+	if enableOAuthRefresh && host.AuthMethod == "oauth" && secret.TokenFromEnv() == "" {
 		// Keyring-stored OAuth tokens use Bearer auth + auto-refresh.
 		// When BKT_TOKEN overrides, the caller controls the token type
 		// and auth method defaults to basic (matching API-token behavior).
-		opts.AuthMethod = "bearer"
 		hostKey, err := HostKeyFromURL(host.BaseURL)
 		if err != nil {
 			return nil, fmt.Errorf("resolve host key: %w", err)

--- a/pkg/cmdutil/client_test.go
+++ b/pkg/cmdutil/client_test.go
@@ -3,14 +3,17 @@ package cmdutil
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/avivsinai/bitbucket-cli/internal/config"
 	"github.com/avivsinai/bitbucket-cli/internal/secret"
+	"github.com/avivsinai/bitbucket-cli/pkg/httpx"
 	"github.com/avivsinai/bitbucket-cli/pkg/oauth"
 )
 
@@ -95,6 +98,74 @@ func TestNewCloudClientOAuthExpiredMissingCredsPreflight(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "bkt auth login https://bitbucket.org --kind cloud --web-token") {
 		t.Errorf("error = %q, want API-token recovery command", err)
+	}
+}
+
+func TestNewFrozenCloudClientOAuthNeverRefreshes(t *testing.T) {
+	t.Setenv(secret.EnvToken, "")
+	t.Setenv("BKT_OAUTH_CLIENT_ID", "")
+	t.Setenv("BKT_OAUTH_CLIENT_SECRET", "")
+	t.Setenv("BKT_ALLOW_INSECURE_STORE", "1")
+	t.Setenv("BKT_KEYRING_PASSPHRASE", "test-pass")
+	t.Setenv("KEYRING_BACKEND", "file")
+	fileDir := t.TempDir()
+	t.Setenv("KEYRING_FILE_DIR", fileDir)
+	var requests atomic.Int32
+	var refreshedRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		switch got := r.Header.Get("Authorization"); got {
+		case "Bearer frozen-access":
+		case "Bearer newer-keyring-access":
+			refreshedRequests.Add(1)
+		default:
+			t.Errorf("Authorization = %q, want frozen bearer token", got)
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(server.Close)
+	hostKey, err := HostKeyFromURL(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newer := oauth.FromResponse("newer-keyring-access", "newer-refresh", 7200)
+	blob, err := newer.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := secret.Open(secret.WithAllowFileFallback(true), secret.WithPassphrase("test-pass"), secret.WithFileDir(fileDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set(secret.TokenKey(hostKey), blob); err != nil {
+		t.Fatal(err)
+	}
+	host := &config.Host{
+		Kind:               "cloud",
+		BaseURL:            server.URL,
+		AuthMethod:         "oauth",
+		Token:              "frozen-access",
+		OAuthExpiresAt:     time.Now().Add(time.Hour),
+		AllowInsecureStore: true,
+	}
+
+	client, err := NewFrozenCloudClient(host)
+	if err != nil {
+		t.Fatalf("NewFrozenCloudClient: %v", err)
+	}
+	_, err = client.CurrentUser(context.Background())
+	var httpErr *httpx.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("CurrentUser error = %T %v, want frozen 401 HTTPError", err, err)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("requests = %d, want one request with no refresh retry", got)
+	}
+	if got := refreshedRequests.Load(); got != 0 {
+		t.Fatalf("requests with refreshed keyring token = %d, want zero", got)
+	}
+	if host.Token != "frozen-access" {
+		t.Fatalf("host token mutated to %q", host.Token)
 	}
 }
 

--- a/pkg/httpx/client.go
+++ b/pkg/httpx/client.go
@@ -401,7 +401,10 @@ func (c *Client) Do(req *http.Request, v any) error {
 		}
 
 		c.updateRateLimit(resp)
-		c.applyAdaptiveThrottle()
+		if err := c.applyAdaptiveThrottle(req.Context()); err != nil {
+			_ = resp.Body.Close()
+			return err
+		}
 
 		if c.debug {
 			fmt.Fprintf(os.Stderr, "<-- %d %s\n", resp.StatusCode, http.StatusText(resp.StatusCode))
@@ -533,18 +536,37 @@ func decodeError(resp *http.Response) error {
 			msg = "CAPTCHA verification required: " + msg
 		}
 		msg = withBitbucketCloudAuthHint(msg)
-		return fmt.Errorf("%s: %s", resp.Status, msg)
+		return newHTTPError(resp, msg)
 	}
 
 	if msg := strings.TrimSpace(cloudPayload.Error.Message); msg != "" {
-		return fmt.Errorf("%s: %s", resp.Status, withBitbucketCloudAuthHint(msg))
+		return newHTTPError(resp, withBitbucketCloudAuthHint(msg))
 	}
 
 	if err == nil && len(data) > 0 {
-		return fmt.Errorf("%s: %s", resp.Status, strings.TrimSpace(string(data)))
+		return newHTTPError(resp, strings.TrimSpace(string(data)))
 	}
 
-	return fmt.Errorf("%s", resp.Status)
+	return newHTTPError(resp)
+}
+
+// HTTPError preserves the response status code for callers that need stable
+// classification while keeping the historical error text unchanged.
+type HTTPError struct {
+	StatusCode int
+	text       string
+}
+
+func (e *HTTPError) Error() string {
+	return e.text
+}
+
+func newHTTPError(resp *http.Response, message ...string) *HTTPError {
+	text := resp.Status
+	if len(message) > 0 {
+		text += ": " + message[0]
+	}
+	return &HTTPError{StatusCode: resp.StatusCode, text: text}
 }
 
 // isCaptchaException checks if the exception name indicates a CAPTCHA-locked account.
@@ -778,23 +800,30 @@ func (c *Client) updateRateLimit(resp *http.Response) {
 	c.rateMu.Unlock()
 }
 
-func (c *Client) applyAdaptiveThrottle() {
+func (c *Client) applyAdaptiveThrottle(ctx context.Context) error {
 	c.rateMu.RLock()
 	rl := c.rate
 	c.rateMu.RUnlock()
 
 	if rl.Remaining > 1 || rl.Reset.IsZero() {
-		return
+		return nil
 	}
 
 	sleep := time.Until(rl.Reset)
 	if sleep <= 0 {
-		return
+		return nil
 	}
 	if sleep > 5*time.Second {
 		sleep = 5 * time.Second
 	}
-	time.Sleep(sleep)
+	timer := time.NewTimer(sleep)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 // MultipartFile represents a file for multipart/form-data upload.

--- a/pkg/httpx/client_test.go
+++ b/pkg/httpx/client_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -206,6 +207,37 @@ func TestClientBackoffRespectsContextCancellation(t *testing.T) {
 	}
 }
 
+func TestAdaptiveThrottleRespectsContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-RateLimit-Limit", "100")
+		w.Header().Set("X-RateLimit-Remaining", "1")
+		w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(time.Now().Add(2*time.Second).Unix(), 10))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(server.Close)
+	client, err := New(Options{BaseURL: server.URL})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, err := client.NewRequest(ctx, http.MethodGet, "/throttled", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	time.AfterFunc(25*time.Millisecond, cancel)
+	start := time.Now()
+	err = client.Do(req, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Do error = %T %v, want context.Canceled", err, err)
+	}
+	if elapsed := time.Since(start); elapsed >= 250*time.Millisecond {
+		t.Fatalf("cancellation did not interrupt adaptive throttle: %v", elapsed)
+	}
+}
+
 func TestClientNewRequestNoDoubledBasePath(t *testing.T) {
 	client, err := New(Options{BaseURL: "https://api.bitbucket.org/2.0"})
 	if err != nil {
@@ -379,6 +411,12 @@ func TestDecodeErrorPrioritizesCaptchaException(t *testing.T) {
 			body:    "",
 			wantMsg: "403 Forbidden",
 		},
+		{
+			name:    "whitespace body preserves historical separator",
+			status:  http.StatusForbidden,
+			body:    " \n",
+			wantMsg: "403 Forbidden: ",
+		},
 	}
 
 	for _, tt := range tests {
@@ -477,6 +515,10 @@ func TestDecodeErrorBitbucketCloudTokenHint(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "Atlassian account email") {
 		t.Fatalf("expected username hint, got %v", err)
+	}
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("error = %T %v, want typed HTTPError status 401", err, err)
 	}
 }
 
@@ -1220,6 +1262,10 @@ func TestTokenRefresherNotCalledTwice(t *testing.T) {
 	err = client.Do(req, nil)
 	if err == nil {
 		t.Fatal("expected error after two 401s")
+	}
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("error after refresh = %T %v, want typed HTTPError status 401", err, err)
 	}
 	if refreshCalls != 1 {
 		t.Fatalf("expected TokenRefresher called once, got %d", refreshCalls)

--- a/skills/bkt/rules/mcp.md
+++ b/skills/bkt/rules/mcp.md
@@ -23,6 +23,10 @@ a named context, otherwise the active context is used. The working directory
 never influences the served target, and configuration changes require a
 restart. Tool calls cannot switch hosts, contexts, or tokens.
 
+For a Cloud OAuth context, the access token is frozen at startup and is not
+refreshed from the credential store. After it expires, tool calls return
+auth_failed until the MCP server is restarted.
+
 v1 is read-only and registers tools only for capabilities the pinned platform
 supports; call bkt_get_context to discover the target and capabilities.
 


### PR DESCRIPTION
## Summary

- add read-only repository and pull-request listing MCP tools over a narrow normalized backend
- preserve bounded page continuation and apply Data Center and Cloud role/state filters upstream
- emit typed redacted tool errors with cancellation and transient-failure classification
- freeze Cloud OAuth credentials for the MCP server lifetime and document restart-on-expiry behavior

## Verification

- `go test ./...`
- `go test -race ./pkg/cmdutil ./internal/mcpserver ./pkg/httpx ./pkg/bbcloud ./pkg/bbdc ./pkg/cmd/mcp`
- `go vet ./...`
- `golangci-lint run --new-from-rev=44591b3755d647873d4c3f0406bf23d42fde1bf1` (0 issues)
- `make build check-skills check-generated-skill`

Full-repository lint still reports six pre-existing SA5011 findings in untouched context tests.
