### PR TITLE
feat(mcp): freeze tool registry contract

### DIFF
--- a/internal/docgen/generate.go
+++ b/internal/docgen/generate.go
@@ -39,6 +39,11 @@ func GenerateAll(root *cobra.Command, binName, outDir string) error {
 		if err := writeFile(path, binName, cmd); err != nil {
 			return err
 		}
+		if cmd.Name() == "mcp" {
+			if err := appendMCPRegistry(path); err != nil {
+				return err
+			}
+		}
 	}
 
 	if len(standalones) > 0 {

--- a/internal/docgen/mcp.go
+++ b/internal/docgen/mcp.go
@@ -1,0 +1,145 @@
+package docgen
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/avivsinai/bitbucket-cli/internal/mcpserver"
+)
+
+func appendMCPRegistry(path string) error {
+	var content bytes.Buffer
+	if err := writeMCPRegistry(&content, mcpserver.InventorySnapshot()); err != nil {
+		return err
+	}
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("open %s for MCP registry: %w", path, err)
+	}
+	if _, err := file.Write(content.Bytes()); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("append MCP registry to %s: %w", path, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", path, err)
+	}
+	return nil
+}
+
+func writeMCPRegistry(file io.Writer, inventory mcpserver.Inventory) error {
+	fmt.Fprintln(file, "## MCP tool registry")
+	fmt.Fprintln(file)
+	fmt.Fprintln(file, "The read-only v1 server registers eight Bitbucket read tools plus `bkt_get_context`.")
+	fmt.Fprintln(file, "Every tool below is available on Data Center and Cloud unless a capability note says otherwise.")
+	fmt.Fprintln(file)
+
+	fmt.Fprintln(file, "### Platform capabilities")
+	fmt.Fprintln(file)
+	fmt.Fprintln(file, "| Platform | Capabilities |")
+	fmt.Fprintln(file, "|---|---|")
+	for _, platform := range []mcpserver.PlatformInventoryItem{inventory.Platforms.DataCenter, inventory.Platforms.Cloud} {
+		capabilities := "None"
+		if len(platform.Capabilities) > 0 {
+			quoted := make([]string, 0, len(platform.Capabilities))
+			for _, capability := range platform.Capabilities {
+				quoted = append(quoted, "`"+capability+"`")
+			}
+			capabilities = strings.Join(quoted, ", ")
+		}
+		fmt.Fprintf(file, "| %s | %s |\n", platform.Name, capabilities)
+	}
+	fmt.Fprintln(file)
+
+	fmt.Fprintln(file, "### Frozen bounds")
+	fmt.Fprintln(file)
+	fmt.Fprintln(file, "| Bound | Value | Meaning |")
+	fmt.Fprintln(file, "|---|---:|---|")
+	for _, bound := range inventory.Bounds {
+		fmt.Fprintf(file, "| `%s` | %s | %s |\n", bound.Name, formatBound(bound.Value, bound.Unit), bound.Description)
+	}
+	fmt.Fprintln(file)
+
+	fmt.Fprintln(file, "### Structured error codes")
+	fmt.Fprintln(file)
+	fmt.Fprintln(file, "| Code | Meaning |")
+	fmt.Fprintln(file, "|---|---|")
+	for _, toolError := range inventory.Errors {
+		fmt.Fprintf(file, "| `%s` | %s |\n", toolError.Code, toolError.Description)
+	}
+	fmt.Fprintln(file)
+
+	fmt.Fprintln(file, "### Tools")
+	fmt.Fprintln(file)
+	for _, tool := range inventory.Tools {
+		fmt.Fprintf(file, "#### `%s`\n\n", tool.Name)
+		fmt.Fprintln(file, tool.Description)
+		fmt.Fprintln(file)
+		fmt.Fprintf(file, "- Availability: %s\n", formatPlatforms(tool.Platforms))
+		fmt.Fprintf(file, "- Read-only: %t\n", tool.ReadOnly)
+		fmt.Fprintf(file, "- Structured errors: %s\n", formatErrorCodes(tool.Errors))
+		for _, note := range tool.Notes {
+			fmt.Fprintf(file, "- Note: %s\n", note)
+		}
+		fmt.Fprintln(file)
+		if err := writeSchema(file, "Input schema", tool.InputSchema); err != nil {
+			return fmt.Errorf("render input schema for %s: %w", tool.Name, err)
+		}
+		if err := writeSchema(file, "Output schema", tool.OutputSchema); err != nil {
+			return fmt.Errorf("render output schema for %s: %w", tool.Name, err)
+		}
+	}
+	return nil
+}
+
+func formatBound(value int, unit string) string {
+	if unit == "bytes" && value%(1024) == 0 {
+		return fmt.Sprintf("%d KiB", value/1024)
+	}
+	return fmt.Sprintf("%d %s", value, unit)
+}
+
+func formatPlatforms(platforms []string) string {
+	if len(platforms) == 2 && platforms[0] == "dc" && platforms[1] == "cloud" {
+		return "Data Center and Cloud"
+	}
+	labels := make([]string, 0, len(platforms))
+	for _, platform := range platforms {
+		switch platform {
+		case "dc":
+			labels = append(labels, "Data Center")
+		case "cloud":
+			labels = append(labels, "Cloud")
+		default:
+			labels = append(labels, platform)
+		}
+	}
+	return strings.Join(labels, " and ")
+}
+
+func formatErrorCodes(codes []mcpserver.ErrorCode) string {
+	if len(codes) == 0 {
+		return "None"
+	}
+	formatted := make([]string, 0, len(codes))
+	for _, code := range codes {
+		formatted = append(formatted, "`"+string(code)+"`")
+	}
+	return strings.Join(formatted, ", ")
+}
+
+func writeSchema(file io.Writer, title string, schema json.RawMessage) error {
+	formatted := make([]byte, 0, len(schema)+64)
+	formatted = append(formatted, []byte("##### "+title+"\n\n```json\n")...)
+	var indented bytes.Buffer
+	if err := json.Indent(&indented, schema, "", "  "); err != nil {
+		return err
+	}
+	formatted = append(formatted, indented.String()...)
+	formatted = append(formatted, []byte("\n```\n\n")...)
+	_, err := file.Write(formatted)
+	return err
+}

--- a/internal/docgen/mcp_test.go
+++ b/internal/docgen/mcp_test.go
@@ -1,0 +1,51 @@
+package docgen
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestGenerateAllAddsSelfContainedMCPRegistryReference(t *testing.T) {
+	root := &cobra.Command{Use: "bkt"}
+	mcpCommand := &cobra.Command{Use: "mcp", Short: "Serve Bitbucket tools to MCP clients"}
+	mcpCommand.AddCommand(&cobra.Command{Use: "serve", Short: "Serve MCP over stdio"})
+	root.AddCommand(mcpCommand)
+
+	skillDir := t.TempDir()
+	outDir := filepath.Join(skillDir, "rules")
+	writeTestFile(t, filepath.Join(skillDir, "SKILL.md"), "# Test\n")
+	if err := GenerateAll(root, "bkt", outDir); err != nil {
+		t.Fatalf("GenerateAll: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(outDir, "mcp.md"))
+	if err != nil {
+		t.Fatalf("read mcp.md: %v", err)
+	}
+	got := string(content)
+	for _, want := range []string{
+		"## MCP tool registry",
+		"eight Bitbucket read tools plus `bkt_get_context`",
+		"`bkt_get_context`",
+		"`bkt_get_pull_request_checks`",
+		"`bkt_list_repositories`",
+		"Data Center and Cloud",
+		"`my_prs.role.reviewer`",
+		"`unsupported_on_platform`",
+		"256 KiB",
+		"Input schema",
+		"Output schema",
+		"role",
+		"restart the MCP server",
+		"bearer-only",
+		"Content-Length",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("generated mcp.md missing %q", want)
+		}
+	}
+}

--- a/internal/mcpserver/backend.go
+++ b/internal/mcpserver/backend.go
@@ -244,7 +244,9 @@ func (b *cloudBackend) getPullRequestChecks(ctx context.Context, locator Reposit
 		return nil, false, fmt.Errorf("pull request source commit is required")
 	}
 	sourceScope, sourceSlug, ok := strings.Cut(strings.TrimSpace(pr.Source.Repository.FullName), "/")
-	if !ok || strings.TrimSpace(sourceScope) == "" || strings.TrimSpace(sourceSlug) == "" {
+	sourceScope = strings.TrimSpace(sourceScope)
+	sourceSlug = strings.TrimSpace(sourceSlug)
+	if !ok || sourceScope == "" || sourceSlug == "" {
 		return nil, false, fmt.Errorf("pull request source repository identity is incomplete")
 	}
 	if slug := strings.TrimSpace(pr.Source.Repository.Slug); slug != "" {
@@ -258,7 +260,7 @@ func (b *cloudBackend) getPullRequestChecks(ctx context.Context, locator Reposit
 	for _, raw := range page.Values {
 		items = append(items, adaptCloudCheck(raw))
 	}
-	return items, page.Next != "" || len(items) > MaxListLimit, nil
+	return items, page.Next != "", nil
 }
 
 type boundedTextSink struct {

--- a/internal/mcpserver/c3_cleanups_test.go
+++ b/internal/mcpserver/c3_cleanups_test.go
@@ -1,0 +1,50 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/avivsinai/bitbucket-cli/pkg/bbcloud"
+	"github.com/avivsinai/bitbucket-cli/pkg/httpx"
+)
+
+func TestCloudBackendChecksTrimsSourceRepositoryLocator(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repositories/team/api/pullrequests/7":
+			payload := cloudPullRequestPayload()
+			payload["source"].(map[string]any)["repository"] = map[string]any{
+				"full_name": "  contributor  /  fork  ",
+			}
+			_ = json.NewEncoder(w).Encode(payload)
+		case "/repositories/contributor/fork/commit/source-sha/statuses":
+			_ = json.NewEncoder(w).Encode(map[string]any{"values": []any{}})
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := bbcloud.New(bbcloud.Options{
+		BaseURL: server.URL,
+		Token:   "token",
+		Retry:   httpx.RetryPolicy{MaxAttempts: 1},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checks, hasMore, err := (&cloudBackend{client: client}).getPullRequestChecks(
+		context.Background(), RepositoryRef{Scope: "team", Slug: "api"}, 7,
+	)
+	if err != nil {
+		t.Fatalf("getPullRequestChecks: %v", err)
+	}
+	if len(checks) != 0 || hasMore {
+		t.Fatalf("checks=%v hasMore=%v, want empty terminal page", checks, hasMore)
+	}
+}

--- a/internal/mcpserver/registry.go
+++ b/internal/mcpserver/registry.go
@@ -1,0 +1,182 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"slices"
+	"sort"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+var allPlatforms = []string{"dc", "cloud"}
+
+type toolDocumentation struct {
+	Platforms []string
+	Errors    []ErrorCode
+	Notes     []string
+}
+
+type registeredTool struct {
+	tool          *mcp.Tool
+	documentation toolDocumentation
+}
+
+type toolRegistry struct {
+	server *mcp.Server
+	tools  []registeredTool
+}
+
+func newToolRegistry(server *mcp.Server) *toolRegistry {
+	return &toolRegistry{server: server}
+}
+
+func standardReadErrors() []ErrorCode {
+	return []ErrorCode{
+		ErrorInvalidInput,
+		ErrorNotFound,
+		ErrorAuthFailed,
+		ErrorRateLimited,
+		ErrorUpstream,
+	}
+}
+
+func schemaFor[T any]() *jsonschema.Schema {
+	typeOf := reflect.TypeFor[T]()
+	if typeOf.Kind() == reflect.Pointer {
+		typeOf = typeOf.Elem()
+	}
+	schema, err := jsonschema.ForType(typeOf, &jsonschema.ForOptions{})
+	if err != nil {
+		panic(fmt.Sprintf("infer MCP schema for %s: %v", typeOf, err))
+	}
+	return schema
+}
+
+// addReadOnlyTool is the single registration path for v1 tools. It materializes
+// the inferred schemas before handing the tool to the SDK so runtime serving,
+// schema goldens, and generated documentation share one typed registry.
+func addReadOnlyTool[In, Out any](registry *toolRegistry, tool *mcp.Tool, documentation toolDocumentation, handler mcp.ToolHandlerFor[In, Out]) {
+	if tool.Annotations == nil {
+		tool.Annotations = &mcp.ToolAnnotations{}
+	}
+	tool.Annotations.ReadOnlyHint = true
+	if tool.InputSchema == nil {
+		tool.InputSchema = schemaFor[In]()
+	}
+	if tool.OutputSchema == nil {
+		tool.OutputSchema = schemaFor[Out]()
+	}
+	if len(documentation.Platforms) == 0 {
+		documentation.Platforms = slices.Clone(allPlatforms)
+	}
+	if documentation.Errors == nil {
+		documentation.Errors = []ErrorCode{}
+	}
+	if documentation.Notes == nil {
+		documentation.Notes = []string{}
+	}
+	registry.tools = append(registry.tools, registeredTool{tool: tool, documentation: documentation})
+	if registry.server != nil {
+		mcp.AddTool(registry.server, tool, handler)
+	}
+}
+
+// Inventory is a serializable snapshot of the complete MCP registry. It is the
+// source for both schema drift tests and the generated standalone skill rule.
+type Inventory struct {
+	Platforms PlatformInventory   `json:"platforms"`
+	Bounds    []BoundInventory    `json:"bounds"`
+	Errors    []ErrorInventory    `json:"errors"`
+	Tools     []ToolInventoryItem `json:"tools"`
+}
+
+type PlatformInventory struct {
+	DataCenter PlatformInventoryItem `json:"data_center"`
+	Cloud      PlatformInventoryItem `json:"cloud"`
+}
+
+type PlatformInventoryItem struct {
+	Name         string   `json:"name"`
+	Capabilities []string `json:"capabilities"`
+}
+
+type BoundInventory struct {
+	Name        string `json:"name"`
+	Value       int    `json:"value"`
+	Unit        string `json:"unit"`
+	Description string `json:"description"`
+}
+
+type ErrorInventory struct {
+	Code        ErrorCode `json:"code"`
+	Description string    `json:"description"`
+}
+
+type ToolInventoryItem struct {
+	Name         string          `json:"name"`
+	Description  string          `json:"description"`
+	Platforms    []string        `json:"platforms"`
+	ReadOnly     bool            `json:"read_only"`
+	Errors       []ErrorCode     `json:"errors"`
+	Notes        []string        `json:"notes"`
+	InputSchema  json.RawMessage `json:"input_schema"`
+	OutputSchema json.RawMessage `json:"output_schema"`
+}
+
+// InventorySnapshot returns the nine-tool v1 registry without constructing a
+// platform client or reading user configuration.
+func InventorySnapshot() Inventory {
+	registry := newToolRegistry(nil)
+	snapshot := &Snapshot{Platform: "dc"}
+	var backend fullPlatformBackend
+	registerFullTools(registry, snapshot, backend)
+
+	tools := make([]ToolInventoryItem, 0, len(registry.tools))
+	for _, registered := range registry.tools {
+		inputSchema, err := json.Marshal(registered.tool.InputSchema)
+		if err != nil {
+			panic(fmt.Sprintf("marshal input schema for %s: %v", registered.tool.Name, err))
+		}
+		outputSchema, err := json.Marshal(registered.tool.OutputSchema)
+		if err != nil {
+			panic(fmt.Sprintf("marshal output schema for %s: %v", registered.tool.Name, err))
+		}
+		tools = append(tools, ToolInventoryItem{
+			Name:         registered.tool.Name,
+			Description:  registered.tool.Description,
+			Platforms:    slices.Clone(registered.documentation.Platforms),
+			ReadOnly:     registered.tool.Annotations != nil && registered.tool.Annotations.ReadOnlyHint,
+			Errors:       slices.Clone(registered.documentation.Errors),
+			Notes:        slices.Clone(registered.documentation.Notes),
+			InputSchema:  inputSchema,
+			OutputSchema: outputSchema,
+		})
+	}
+	sort.Slice(tools, func(i, j int) bool { return tools[i].Name < tools[j].Name })
+
+	return Inventory{
+		Platforms: PlatformInventory{
+			DataCenter: PlatformInventoryItem{Name: "Data Center", Capabilities: capabilities(&Snapshot{Platform: "dc"})},
+			Cloud:      PlatformInventoryItem{Name: "Cloud", Capabilities: capabilities(&Snapshot{Platform: "cloud"})},
+		},
+		Bounds: []BoundInventory{
+			{Name: "default_list_limit", Value: DefaultListLimit, Unit: "items", Description: "default page size for bounded list tools"},
+			{Name: "max_list_limit", Value: MaxListLimit, Unit: "items", Description: "maximum returned items for bounded list and check tools"},
+			{Name: "comment_body_limit", Value: CommentBodyLimit, Unit: "bytes", Description: "maximum retained comment body"},
+			{Name: "pull_request_description_limit", Value: PullRequestDescriptionLimit, Unit: "bytes", Description: "maximum retained pull request description"},
+			{Name: "diff_content_limit", Value: DiffContentLimit, Unit: "bytes", Description: "maximum retained unified diff content"},
+		},
+		Errors: []ErrorInventory{
+			{Code: ErrorInvalidInput, Description: "the tool arguments or frozen context are incomplete or invalid"},
+			{Code: ErrorNotFound, Description: "the requested Bitbucket resource was not found"},
+			{Code: ErrorAuthFailed, Description: "Bitbucket rejected the frozen credential"},
+			{Code: ErrorUnsupportedOnPlatform, Description: "the requested operation is unavailable on the pinned platform"},
+			{Code: ErrorRateLimited, Description: "Bitbucket rate-limited the request; retryable is true"},
+			{Code: ErrorUpstream, Description: "Bitbucket or the transport failed; retryable reflects the failure class"},
+		},
+		Tools: tools,
+	}
+}

--- a/internal/mcpserver/registry_test.go
+++ b/internal/mcpserver/registry_test.go
@@ -1,0 +1,93 @@
+package mcpserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"slices"
+	"testing"
+)
+
+func TestInventorySnapshotMatchesGolden(t *testing.T) {
+	inventory := InventorySnapshot()
+
+	wantNames := []string{
+		"bkt_get_context",
+		"bkt_get_pull_request",
+		"bkt_get_pull_request_checks",
+		"bkt_get_pull_request_diff",
+		"bkt_get_repository",
+		"bkt_list_my_pull_requests",
+		"bkt_list_pull_request_comments",
+		"bkt_list_pull_requests",
+		"bkt_list_repositories",
+	}
+	if len(inventory.Tools) != len(wantNames) {
+		t.Fatalf("registered tool count = %d, want %d", len(inventory.Tools), len(wantNames))
+	}
+
+	gotNames := make([]string, 0, len(inventory.Tools))
+	for _, tool := range inventory.Tools {
+		gotNames = append(gotNames, tool.Name)
+		if !tool.ReadOnly {
+			t.Errorf("tool %q readOnly = false, want true", tool.Name)
+		}
+		if len(tool.InputSchema) == 0 || len(tool.OutputSchema) == 0 {
+			t.Errorf("tool %q must freeze both input and output schemas", tool.Name)
+		}
+	}
+	if !slices.Equal(gotNames, wantNames) {
+		t.Fatalf("registered tool names = %v, want %v", gotNames, wantNames)
+	}
+
+	data, err := json.MarshalIndent(inventory, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal inventory: %v", err)
+	}
+	data = append(data, '\n')
+	if os.Getenv("UPDATE_GOLDEN") == "1" {
+		if err := os.MkdirAll("testdata", 0o755); err != nil {
+			t.Fatalf("create testdata: %v", err)
+		}
+		if err := os.WriteFile("testdata/tool_registry.golden.json", data, 0o644); err != nil {
+			t.Fatalf("update registry golden: %v", err)
+		}
+	}
+	want, err := os.ReadFile("testdata/tool_registry.golden.json")
+	if err != nil {
+		t.Fatalf("read registry golden: %v", err)
+	}
+	if !bytes.Equal(data, want) {
+		t.Fatalf("tool registry drifted; review the schema change and update testdata/tool_registry.golden.json\n--- got ---\n%s\n--- want ---\n%s", data, want)
+	}
+}
+
+func TestInventoryKeepsSDKValidatedRoleOptional(t *testing.T) {
+	inventory := InventorySnapshot()
+	for _, tool := range inventory.Tools {
+		if tool.Name != "bkt_list_my_pull_requests" {
+			continue
+		}
+		var schema struct {
+			Required []string `json:"required"`
+		}
+		if err := json.Unmarshal(tool.InputSchema, &schema); err != nil {
+			t.Fatalf("decode input schema: %v", err)
+		}
+		if slices.Contains(schema.Required, "role") {
+			t.Fatalf("role must stay optional in the SDK input schema; the handler returns structured invalid_input when it is omitted")
+		}
+		return
+	}
+	t.Fatal("bkt_list_my_pull_requests missing from inventory")
+}
+
+func TestInventoryPinsPlatformCapabilities(t *testing.T) {
+	inventory := InventorySnapshot()
+	if !slices.Equal(inventory.Platforms.DataCenter.Capabilities, []string{"my_prs.role.reviewer"}) {
+		t.Fatalf("Data Center capabilities = %v", inventory.Platforms.DataCenter.Capabilities)
+	}
+	if len(inventory.Platforms.Cloud.Capabilities) != 0 {
+		t.Fatalf("Cloud capabilities = %v, want none", inventory.Platforms.Cloud.Capabilities)
+	}
+}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -66,26 +66,26 @@ func New(snap *Snapshot, version string) (*mcp.Server, error) {
 
 func newServer(snap *Snapshot, version string, backend platformBackend) *mcp.Server {
 	server := mcp.NewServer(&mcp.Implementation{Name: "bkt", Version: version}, nil)
-	registerGetContext(server, snap)
-	registerRepositoryTools(server, snap, backend)
-	registerPullRequestListTools(server, snap, backend)
+	registry := newToolRegistry(server)
+	registerBaseTools(registry, snap, backend)
 	return server
+}
+
+func registerBaseTools(registry *toolRegistry, snap *Snapshot, backend platformBackend) {
+	registerGetContext(registry, snap)
+	registerRepositoryTools(registry, snap, backend)
+	registerPullRequestListTools(registry, snap, backend)
 }
 
 func newFullServer(snap *Snapshot, version string, backend fullPlatformBackend) *mcp.Server {
-	server := newServer(snap, version, backend)
-	registerPullRequestDetailTools(server, snap, backend)
+	server := mcp.NewServer(&mcp.Implementation{Name: "bkt", Version: version}, nil)
+	registerFullTools(newToolRegistry(server), snap, backend)
 	return server
 }
 
-// addReadOnlyTool registers a tool with truthful read-only annotations. Every
-// v1 tool must go through here; the write wave adds a separate gated path.
-func addReadOnlyTool[In, Out any](server *mcp.Server, tool *mcp.Tool, handler mcp.ToolHandlerFor[In, Out]) {
-	if tool.Annotations == nil {
-		tool.Annotations = &mcp.ToolAnnotations{}
-	}
-	tool.Annotations.ReadOnlyHint = true
-	mcp.AddTool(server, tool, handler)
+func registerFullTools(registry *toolRegistry, snap *Snapshot, backend fullPlatformBackend) {
+	registerBaseTools(registry, snap, backend)
+	registerPullRequestDetailTools(registry, snap, backend)
 }
 
 // capabilities enumerates only discriminating platform features. Universal
@@ -131,14 +131,16 @@ var contextInfoSchema = &jsonschema.Schema{
 
 type getContextArgs struct{}
 
-func registerGetContext(server *mcp.Server, snap *Snapshot) {
-	addReadOnlyTool(server, &mcp.Tool{
+func registerGetContext(registry *toolRegistry, snap *Snapshot) {
+	addReadOnlyTool(registry, &mcp.Tool{
 		Name: "bkt_get_context",
 		Description: "Describe the Bitbucket target this server is pinned to: " +
 			"platform (dc or cloud), host label, default repository scope/slug, " +
 			"and the capabilities available here. Never returns credentials. " +
 			"For Cloud OAuth, the access token is frozen at startup; restart the server after it expires.",
 		OutputSchema: contextInfoSchema,
+	}, toolDocumentation{
+		Notes: []string{"Cloud OAuth access tokens are frozen at startup; after expiry, restart the MCP server."},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args getContextArgs) (*mcp.CallToolResult, ContextInfo, error) {
 		return nil, ContextInfo{
 			Platform:     snap.Platform,

--- a/internal/mcpserver/testdata/tool_registry.golden.json
+++ b/internal/mcpserver/testdata/tool_registry.golden.json
@@ -1,0 +1,1266 @@
+{
+  "platforms": {
+    "data_center": {
+      "name": "Data Center",
+      "capabilities": [
+        "my_prs.role.reviewer"
+      ]
+    },
+    "cloud": {
+      "name": "Cloud",
+      "capabilities": []
+    }
+  },
+  "bounds": [
+    {
+      "name": "default_list_limit",
+      "value": 25,
+      "unit": "items",
+      "description": "default page size for bounded list tools"
+    },
+    {
+      "name": "max_list_limit",
+      "value": 100,
+      "unit": "items",
+      "description": "maximum returned items for bounded list and check tools"
+    },
+    {
+      "name": "comment_body_limit",
+      "value": 16384,
+      "unit": "bytes",
+      "description": "maximum retained comment body"
+    },
+    {
+      "name": "pull_request_description_limit",
+      "value": 16384,
+      "unit": "bytes",
+      "description": "maximum retained pull request description"
+    },
+    {
+      "name": "diff_content_limit",
+      "value": 262144,
+      "unit": "bytes",
+      "description": "maximum retained unified diff content"
+    }
+  ],
+  "errors": [
+    {
+      "code": "invalid_input",
+      "description": "the tool arguments or frozen context are incomplete or invalid"
+    },
+    {
+      "code": "not_found",
+      "description": "the requested Bitbucket resource was not found"
+    },
+    {
+      "code": "auth_failed",
+      "description": "Bitbucket rejected the frozen credential"
+    },
+    {
+      "code": "unsupported_on_platform",
+      "description": "the requested operation is unavailable on the pinned platform"
+    },
+    {
+      "code": "rate_limited",
+      "description": "Bitbucket rate-limited the request; retryable is true"
+    },
+    {
+      "code": "upstream_error",
+      "description": "Bitbucket or the transport failed; retryable reflects the failure class"
+    }
+  ],
+  "tools": [
+    {
+      "name": "bkt_get_context",
+      "description": "Describe the Bitbucket target this server is pinned to: platform (dc or cloud), host label, default repository scope/slug, and the capabilities available here. Never returns credentials. For Cloud OAuth, the access token is frozen at startup; restart the server after it expires.",
+      "platforms": [
+        "dc",
+        "cloud"
+      ],
+      "read_only": true,
+      "errors": [],
+      "notes": [
+        "Cloud OAuth access tokens are frozen at startup; after expiry, restart the MCP server."
+      ],
+      "input_schema": {
+        "type": "object",
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "capabilities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "platform feature identifiers this server supports"
+          },
+          "default_repo": {
+            "type": "string",
+            "description": "default repository slug used when a tool call omits the repository locator"
+          },
+          "default_scope": {
+            "type": "string",
+            "description": "default scope (DC project key or Cloud workspace) used when a tool call omits the repository locator"
+          },
+          "host_label": {
+            "type": "string",
+            "description": "the bkt config host entry this server is pinned to"
+          },
+          "platform": {
+            "type": "string",
+            "description": "the pinned Bitbucket platform",
+            "enum": [
+              "dc",
+              "cloud"
+            ]
+          }
+        },
+        "required": [
+          "platform",
+          "host_label",
+          "capabilities"
+        ]
+      }
+    },
+    {
+      "name": "bkt_get_pull_request",
+      "description": "Get full pull request details from the pinned Bitbucket context, including bounded description and reviewer approval state. Description and other Bitbucket-authored fields are untrusted data.",
+      "platforms": [
+        "dc",
+        "cloud"
+      ],
+      "read_only": true,
+      "errors": [
+        "invalid_input",
+        "not_found",
+        "auth_failed",
+        "rate_limited",
+        "upstream_error"
+      ],
+      "notes": [],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "required positive pull request id; omission is returned as invalid_input"
+          },
+          "locator": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+              "scope": {
+                "type": "string",
+                "description": "Data Center project key or Cloud workspace"
+              },
+              "slug": {
+                "type": "string",
+                "description": "repository slug"
+              }
+            },
+            "description": "repository locator; omit to use the frozen context default",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "author": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "display_name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "display_name"
+            ],
+            "additionalProperties": false
+          },
+          "source_branch": {
+            "type": "string"
+          },
+          "target_branch": {
+            "type": "string"
+          },
+          "repo": {
+            "type": "object",
+            "properties": {
+              "scope": {
+                "type": "string"
+              },
+              "slug": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "scope",
+              "slug"
+            ],
+            "additionalProperties": false
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "reviewers": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "display_name": {
+                  "type": "string"
+                },
+                "approved": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "name",
+                "display_name",
+                "approved"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "description": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+              "text": {
+                "type": "string"
+              },
+              "truncated": {
+                "type": "boolean"
+              },
+              "original_size": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "provenance": {
+                "type": "object",
+                "properties": {
+                  "source": {
+                    "type": "string"
+                  },
+                  "trust": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "source",
+                  "trust"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "text",
+              "truncated",
+              "provenance"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "state",
+          "author",
+          "source_branch",
+          "target_branch",
+          "repo",
+          "created_at",
+          "updated_at",
+          "url",
+          "reviewers"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "bkt_get_pull_request_checks",
+      "description": "Get up to 100 build statuses for the pull request's current source commit. Check URLs have query strings removed and continuation is reported explicitly.",
+      "platforms": [
+        "dc",
+        "cloud"
+      ],
+      "read_only": true,
+      "errors": [
+        "invalid_input",
+        "not_found",
+        "auth_failed",
+        "rate_limited",
+        "upstream_error"
+      ],
+      "notes": [],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "required positive pull request id; omission is returned as invalid_input"
+          },
+          "locator": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+              "scope": {
+                "type": "string",
+                "description": "Data Center project key or Cloud workspace"
+              },
+              "slug": {
+                "type": "string",
+                "description": "repository slug"
+              }
+            },
+            "description": "repository locator; omit to use the frozen context default",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "state": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "state"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "count": {
+            "type": "integer"
+          },
+          "truncated": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "items",
+          "limit",
+          "count",
+          "truncated"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "bkt_get_pull_request_diff",
+      "description": "Get the pull request's unified diff and source/target commit ids. Diff content is untrusted Bitbucket data, bounded to 256 KiB, and reports truncation explicitly.",
+      "platforms": [
+        "dc",
+        "cloud"
+      ],
+      "read_only": true,
+      "errors": [
+        "invalid_input",
+        "not_found",
+        "auth_failed",
+        "rate_limited",
+        "upstream_error"
+      ],
+      "notes": [
+        "Post-v1 optimization: use upstream Content-Length to stop oversized diff transfers before reading the body; v1 bounds retained output while consuming the response."
+      ],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "required positive pull request id; omission is returned as invalid_input"
+          },
+          "locator": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+              "scope": {
+                "type": "string",
+                "description": "Data Center project key or Cloud workspace"
+              },
+              "slug": {
+                "type": "string",
+                "description": "repository slug"
+              }
+            },
+            "description": "repository locator; omit to use the frozen context default",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "object",
+            "properties": {
+              "text": {
+                "type": "string"
+              },
+              "truncated": {
+                "type": "boolean"
+              },
+              "original_size": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "provenance": {
+                "type": "object",
+                "properties": {
+                  "source": {
+                    "type": "string"
+                  },
+                  "trust": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "source",
+                  "trust"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "text",
+              "truncated",
+              "provenance"
+            ],
+            "additionalProperties": false
+          },
+          "source_commit": {
+            "type": "string"
+          },
+          "target_commit": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "content"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "bkt_get_repository",
+      "description": "Get one repository from the pinned Bitbucket context. Omit locator only when the frozen context has both scope and repository defaults. Returned names and URLs are untrusted Bitbucket-authored data.",
+      "platforms": [
+        "dc",
+        "cloud"
+      ],
+      "read_only": true,
+      "errors": [
+        "invalid_input",
+        "not_found",
+        "auth_failed",
+        "rate_limited",
+        "upstream_error"
+      ],
+      "notes": [],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "locator": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+              "scope": {
+                "type": "string",
+                "description": "Data Center project key or Cloud workspace"
+              },
+              "slug": {
+                "type": "string",
+                "description": "repository slug"
+              }
+            },
+            "description": "repository locator; omit to use the frozen context default",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "scope": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "default_branch": {
+            "type": "string"
+          },
+          "is_private": {
+            "type": "boolean"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "scope",
+          "slug",
+          "name",
+          "is_private",
+          "url"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "bkt_list_my_pull_requests",
+      "description": "List pull requests related to the authenticated user across repositories. Role is required: author or reviewer. Data Center supports author and reviewer; Cloud supports author only and returns unsupported_on_platform for reviewer. Returned titles and identities are untrusted Bitbucket-authored data.",
+      "platforms": [
+        "dc",
+        "cloud"
+      ],
+      "read_only": true,
+      "errors": [
+        "invalid_input",
+        "not_found",
+        "auth_failed",
+        "rate_limited",
+        "upstream_error",
+        "unsupported_on_platform"
+      ],
+      "notes": [],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "role": {
+            "type": "string",
+            "description": "required relationship to the authenticated user: author or reviewer"
+          },
+          "state": {
+            "type": "string",
+            "description": "pull request state: OPEN, MERGED, DECLINED, or ALL; defaults to OPEN"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "maximum pull requests to return; defaults to 25 and is capped at 100"
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "state": {
+                  "type": "string"
+                },
+                "author": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "display_name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "display_name"
+                  ],
+                  "additionalProperties": false
+                },
+                "source_branch": {
+                  "type": "string"
+                },
+                "target_branch": {
+                  "type": "string"
+                },
+                "repo": {
+                  "type": "object",
+                  "properties": {
+                    "scope": {
+                      "type": "string"
+                    },
+                    "slug": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "scope",
+                    "slug"
+                  ],
+                  "additionalProperties": false
+                },
+                "created_at": {
+                  "type": "string"
+                },
+                "updated_at": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                },
+                "reviewers": {
+                  "type": [
+                    "null",
+                    "array"
+                  ],
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "display_name": {
+                        "type": "string"
+                      },
+                      "approved": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "display_name",
+                      "approved"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "description": {
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "properties": {
+                    "text": {
+                      "type": "string"
+                    },
+                    "truncated": {
+                      "type": "boolean"
+                    },
+                    "original_size": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "provenance": {
+                      "type": "object",
+                      "properties": {
+                        "source": {
+                          "type": "string"
+                        },
+                        "trust": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "source",
+                        "trust"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "text",
+                    "truncated",
+                    "provenance"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "id",
+                "title",
+                "state",
+                "author",
+                "source_branch",
+                "target_branch",
+                "repo",
+                "created_at",
+                "updated_at",
+                "url",
+                "reviewers"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "count": {
+            "type": "integer"
+          },
+          "truncated": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "items",
+          "limit",
+          "count",
+          "truncated"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "bkt_list_pull_request_comments",
+      "description": "List a bounded page of global, inline, and reply comments for one pull request. Comment bodies are bounded, untrusted Bitbucket-authored data.",
+      "platforms": [
+        "dc",
+        "cloud"
+      ],
+      "read_only": true,
+      "errors": [
+        "invalid_input",
+        "not_found",
+        "auth_failed",
+        "rate_limited",
+        "upstream_error"
+      ],
+      "notes": [],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "required positive pull request id; omission is returned as invalid_input"
+          },
+          "locator": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+              "scope": {
+                "type": "string",
+                "description": "Data Center project key or Cloud workspace"
+              },
+              "slug": {
+                "type": "string",
+                "description": "repository slug"
+              }
+            },
+            "description": "repository locator; omit to use the frozen context default",
+            "additionalProperties": false
+          },
+          "limit": {
+            "type": "integer",
+            "description": "maximum comments to return; defaults to 25 and is capped at 100"
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "author": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "display_name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "display_name"
+                  ],
+                  "additionalProperties": false
+                },
+                "body": {
+                  "type": "object",
+                  "properties": {
+                    "text": {
+                      "type": "string"
+                    },
+                    "truncated": {
+                      "type": "boolean"
+                    },
+                    "original_size": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "provenance": {
+                      "type": "object",
+                      "properties": {
+                        "source": {
+                          "type": "string"
+                        },
+                        "trust": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "source",
+                        "trust"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "text",
+                    "truncated",
+                    "provenance"
+                  ],
+                  "additionalProperties": false
+                },
+                "created_at": {
+                  "type": "string"
+                },
+                "parent_id": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "path": {
+                  "type": "string"
+                },
+                "line": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "author",
+                "body"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "count": {
+            "type": "integer"
+          },
+          "truncated": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "items",
+          "limit",
+          "count",
+          "truncated"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "bkt_list_pull_requests",
+      "description": "List pull requests in one repository from the pinned Bitbucket context. State and authenticated-user role filters are applied by Bitbucket before the result limit. Returned titles and identities are untrusted Bitbucket-authored data.",
+      "platforms": [
+        "dc",
+        "cloud"
+      ],
+      "read_only": true,
+      "errors": [
+        "invalid_input",
+        "not_found",
+        "auth_failed",
+        "rate_limited",
+        "upstream_error"
+      ],
+      "notes": [
+        "Data Center bearer-only contexts without a username cannot use repo-scoped role filters; use role=all or bkt_list_my_pull_requests."
+      ],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "locator": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+              "scope": {
+                "type": "string",
+                "description": "Data Center project key or Cloud workspace"
+              },
+              "slug": {
+                "type": "string",
+                "description": "repository slug"
+              }
+            },
+            "description": "repository locator; omit to use the frozen context default",
+            "additionalProperties": false
+          },
+          "state": {
+            "type": "string",
+            "description": "pull request state: OPEN, MERGED, DECLINED, or ALL; defaults to OPEN"
+          },
+          "role": {
+            "type": "string",
+            "description": "relationship to the authenticated user: all, author, or reviewer; defaults to all"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "maximum pull requests to return; defaults to 25 and is capped at 100"
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "state": {
+                  "type": "string"
+                },
+                "author": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "display_name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "display_name"
+                  ],
+                  "additionalProperties": false
+                },
+                "source_branch": {
+                  "type": "string"
+                },
+                "target_branch": {
+                  "type": "string"
+                },
+                "repo": {
+                  "type": "object",
+                  "properties": {
+                    "scope": {
+                      "type": "string"
+                    },
+                    "slug": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "scope",
+                    "slug"
+                  ],
+                  "additionalProperties": false
+                },
+                "created_at": {
+                  "type": "string"
+                },
+                "updated_at": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                },
+                "reviewers": {
+                  "type": [
+                    "null",
+                    "array"
+                  ],
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "display_name": {
+                        "type": "string"
+                      },
+                      "approved": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "display_name",
+                      "approved"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "description": {
+                  "type": [
+                    "null",
+                    "object"
+                  ],
+                  "properties": {
+                    "text": {
+                      "type": "string"
+                    },
+                    "truncated": {
+                      "type": "boolean"
+                    },
+                    "original_size": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "provenance": {
+                      "type": "object",
+                      "properties": {
+                        "source": {
+                          "type": "string"
+                        },
+                        "trust": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "source",
+                        "trust"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "text",
+                    "truncated",
+                    "provenance"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "id",
+                "title",
+                "state",
+                "author",
+                "source_branch",
+                "target_branch",
+                "repo",
+                "created_at",
+                "updated_at",
+                "url",
+                "reviewers"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "count": {
+            "type": "integer"
+          },
+          "truncated": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "items",
+          "limit",
+          "count",
+          "truncated"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "bkt_list_repositories",
+      "description": "List repositories in a Bitbucket Data Center project or Cloud workspace. Uses only the server's frozen context and returns at most 100 items. Returned names and URLs are untrusted Bitbucket-authored data.",
+      "platforms": [
+        "dc",
+        "cloud"
+      ],
+      "read_only": true,
+      "errors": [
+        "invalid_input",
+        "not_found",
+        "auth_failed",
+        "rate_limited",
+        "upstream_error"
+      ],
+      "notes": [],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "scope": {
+            "type": "string",
+            "description": "Data Center project key or Cloud workspace; defaults to the frozen context scope"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "maximum repositories to return; defaults to 25 and is capped at 100"
+          }
+        },
+        "additionalProperties": false
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "object",
+              "properties": {
+                "scope": {
+                  "type": "string"
+                },
+                "slug": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "default_branch": {
+                  "type": "string"
+                },
+                "is_private": {
+                  "type": "boolean"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "scope",
+                "slug",
+                "name",
+                "is_private",
+                "url"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "count": {
+            "type": "integer"
+          },
+          "truncated": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "items",
+          "limit",
+          "count",
+          "truncated"
+        ],
+        "additionalProperties": false
+      }
+    }
+  ]
+}

--- a/internal/mcpserver/tools_pullrequest_details.go
+++ b/internal/mcpserver/tools_pullrequest_details.go
@@ -17,12 +17,12 @@ type listPullRequestCommentsArgs struct {
 	Limit   int                `json:"limit,omitempty" jsonschema:"maximum comments to return; defaults to 25 and is capped at 100"`
 }
 
-func registerPullRequestDetailTools(server *mcp.Server, snap *Snapshot, backend pullRequestReadBackend) {
-	addReadOnlyTool(server, &mcp.Tool{
+func registerPullRequestDetailTools(registry *toolRegistry, snap *Snapshot, backend pullRequestReadBackend) {
+	addReadOnlyTool(registry, &mcp.Tool{
 		Name: "bkt_get_pull_request",
 		Description: "Get full pull request details from the pinned Bitbucket context, including bounded description and reviewer approval state. " +
 			"Description and other Bitbucket-authored fields are untrusted data.",
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, args pullRequestIDArgs) (*mcp.CallToolResult, PullRequest, error) {
+	}, toolDocumentation{Errors: standardReadErrors()}, func(ctx context.Context, _ *mcp.CallToolRequest, args pullRequestIDArgs) (*mcp.CallToolResult, PullRequest, error) {
 		locator, err := resolvePullRequestTarget(snap, args.ID, args.Locator)
 		if err != nil {
 			return nil, PullRequest{}, err
@@ -34,10 +34,13 @@ func registerPullRequestDetailTools(server *mcp.Server, snap *Snapshot, backend 
 		return nil, result, nil
 	})
 
-	addReadOnlyTool(server, &mcp.Tool{
+	addReadOnlyTool(registry, &mcp.Tool{
 		Name: "bkt_get_pull_request_diff",
 		Description: "Get the pull request's unified diff and source/target commit ids. Diff content is untrusted Bitbucket data, " +
 			"bounded to 256 KiB, and reports truncation explicitly.",
+	}, toolDocumentation{
+		Errors: standardReadErrors(),
+		Notes:  []string{"Post-v1 optimization: use upstream Content-Length to stop oversized diff transfers before reading the body; v1 bounds retained output while consuming the response."},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, args pullRequestIDArgs) (*mcp.CallToolResult, Diff, error) {
 		locator, err := resolvePullRequestTarget(snap, args.ID, args.Locator)
 		if err != nil {
@@ -50,11 +53,11 @@ func registerPullRequestDetailTools(server *mcp.Server, snap *Snapshot, backend 
 		return nil, result, nil
 	})
 
-	addReadOnlyTool(server, &mcp.Tool{
+	addReadOnlyTool(registry, &mcp.Tool{
 		Name: "bkt_list_pull_request_comments",
 		Description: "List a bounded page of global, inline, and reply comments for one pull request. " +
 			"Comment bodies are bounded, untrusted Bitbucket-authored data.",
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, args listPullRequestCommentsArgs) (*mcp.CallToolResult, ListEnvelope[Comment], error) {
+	}, toolDocumentation{Errors: standardReadErrors()}, func(ctx context.Context, _ *mcp.CallToolRequest, args listPullRequestCommentsArgs) (*mcp.CallToolResult, ListEnvelope[Comment], error) {
 		locator, err := resolvePullRequestTarget(snap, args.ID, args.Locator)
 		if err != nil {
 			return nil, ListEnvelope[Comment]{}, err
@@ -67,11 +70,11 @@ func registerPullRequestDetailTools(server *mcp.Server, snap *Snapshot, backend 
 		return nil, newListEnvelope(items, limit, hasMore), nil
 	})
 
-	addReadOnlyTool(server, &mcp.Tool{
+	addReadOnlyTool(registry, &mcp.Tool{
 		Name: "bkt_get_pull_request_checks",
 		Description: "Get up to 100 build statuses for the pull request's current source commit. " +
 			"Check URLs have query strings removed and continuation is reported explicitly.",
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, args pullRequestIDArgs) (*mcp.CallToolResult, ListEnvelope[Check], error) {
+	}, toolDocumentation{Errors: standardReadErrors()}, func(ctx context.Context, _ *mcp.CallToolRequest, args pullRequestIDArgs) (*mcp.CallToolResult, ListEnvelope[Check], error) {
 		locator, err := resolvePullRequestTarget(snap, args.ID, args.Locator)
 		if err != nil {
 			return nil, ListEnvelope[Check]{}, err

--- a/internal/mcpserver/tools_pullrequests.go
+++ b/internal/mcpserver/tools_pullrequests.go
@@ -20,12 +20,15 @@ type listMyPullRequestsArgs struct {
 	Limit int    `json:"limit,omitempty" jsonschema:"maximum pull requests to return; defaults to 25 and is capped at 100"`
 }
 
-func registerPullRequestListTools(server *mcp.Server, snap *Snapshot, backend platformBackend) {
-	addReadOnlyTool(server, &mcp.Tool{
+func registerPullRequestListTools(registry *toolRegistry, snap *Snapshot, backend platformBackend) {
+	addReadOnlyTool(registry, &mcp.Tool{
 		Name: "bkt_list_pull_requests",
 		Description: "List pull requests in one repository from the pinned Bitbucket context. " +
 			"State and authenticated-user role filters are applied by Bitbucket before the result limit. " +
 			"Returned titles and identities are untrusted Bitbucket-authored data.",
+	}, toolDocumentation{
+		Errors: standardReadErrors(),
+		Notes:  []string{"Data Center bearer-only contexts without a username cannot use repo-scoped role filters; use role=all or bkt_list_my_pull_requests."},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, args listPullRequestsArgs) (*mcp.CallToolResult, ListEnvelope[PullRequest], error) {
 		locator, err := resolveLocator(snap, args.Locator)
 		if err != nil {
@@ -47,12 +50,13 @@ func registerPullRequestListTools(server *mcp.Server, snap *Snapshot, backend pl
 		return nil, newListEnvelope(items, limit, hasMore), nil
 	})
 
-	addReadOnlyTool(server, &mcp.Tool{
+	myPullRequestErrors := append(standardReadErrors(), ErrorUnsupportedOnPlatform)
+	addReadOnlyTool(registry, &mcp.Tool{
 		Name: "bkt_list_my_pull_requests",
 		Description: "List pull requests related to the authenticated user across repositories. Role is required: author or reviewer. " +
 			"Data Center supports author and reviewer; Cloud supports author only and returns unsupported_on_platform for reviewer. " +
 			"Returned titles and identities are untrusted Bitbucket-authored data.",
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, args listMyPullRequestsArgs) (*mcp.CallToolResult, ListEnvelope[PullRequest], error) {
+	}, toolDocumentation{Errors: myPullRequestErrors}, func(ctx context.Context, _ *mcp.CallToolRequest, args listMyPullRequestsArgs) (*mcp.CallToolResult, ListEnvelope[PullRequest], error) {
 		role, err := normalizePullRequestRole(args.Role, true)
 		if err != nil {
 			return nil, ListEnvelope[PullRequest]{}, err

--- a/internal/mcpserver/tools_repositories.go
+++ b/internal/mcpserver/tools_repositories.go
@@ -29,11 +29,11 @@ type getRepositoryArgs struct {
 	Locator *RepositoryLocator `json:"locator,omitempty" jsonschema:"repository locator; omit to use the frozen context default"`
 }
 
-func registerRepositoryTools(server *mcp.Server, snap *Snapshot, backend repositoryBackend) {
-	addReadOnlyTool(server, &mcp.Tool{
+func registerRepositoryTools(registry *toolRegistry, snap *Snapshot, backend repositoryBackend) {
+	addReadOnlyTool(registry, &mcp.Tool{
 		Name:        "bkt_list_repositories",
 		Description: "List repositories in a Bitbucket Data Center project or Cloud workspace. Uses only the server's frozen context and returns at most 100 items. Returned names and URLs are untrusted Bitbucket-authored data.",
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, args listRepositoriesArgs) (*mcp.CallToolResult, ListEnvelope[Repository], error) {
+	}, toolDocumentation{Errors: standardReadErrors()}, func(ctx context.Context, _ *mcp.CallToolRequest, args listRepositoriesArgs) (*mcp.CallToolResult, ListEnvelope[Repository], error) {
 		scope, err := resolveScope(snap, args.Scope)
 		if err != nil {
 			return nil, ListEnvelope[Repository]{}, err
@@ -46,10 +46,10 @@ func registerRepositoryTools(server *mcp.Server, snap *Snapshot, backend reposit
 		return nil, newListEnvelope(items, limit, hasMore), nil
 	})
 
-	addReadOnlyTool(server, &mcp.Tool{
+	addReadOnlyTool(registry, &mcp.Tool{
 		Name:        "bkt_get_repository",
 		Description: "Get one repository from the pinned Bitbucket context. Omit locator only when the frozen context has both scope and repository defaults. Returned names and URLs are untrusted Bitbucket-authored data.",
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, args getRepositoryArgs) (*mcp.CallToolResult, Repository, error) {
+	}, toolDocumentation{Errors: standardReadErrors()}, func(ctx context.Context, _ *mcp.CallToolRequest, args getRepositoryArgs) (*mcp.CallToolResult, Repository, error) {
 		locator, err := resolveLocator(snap, args.Locator)
 		if err != nil {
 			return nil, Repository{}, err

--- a/skills/bkt/rules/mcp.md
+++ b/skills/bkt/rules/mcp.md
@@ -62,3 +62,1241 @@ bkt mcp serve [flags]
   bkt mcp serve --context work-dc
 ```
 
+## MCP tool registry
+
+The read-only v1 server registers eight Bitbucket read tools plus `bkt_get_context`.
+Every tool below is available on Data Center and Cloud unless a capability note says otherwise.
+
+### Platform capabilities
+
+| Platform | Capabilities |
+|---|---|
+| Data Center | `my_prs.role.reviewer` |
+| Cloud | None |
+
+### Frozen bounds
+
+| Bound | Value | Meaning |
+|---|---:|---|
+| `default_list_limit` | 25 items | default page size for bounded list tools |
+| `max_list_limit` | 100 items | maximum returned items for bounded list and check tools |
+| `comment_body_limit` | 16 KiB | maximum retained comment body |
+| `pull_request_description_limit` | 16 KiB | maximum retained pull request description |
+| `diff_content_limit` | 256 KiB | maximum retained unified diff content |
+
+### Structured error codes
+
+| Code | Meaning |
+|---|---|
+| `invalid_input` | the tool arguments or frozen context are incomplete or invalid |
+| `not_found` | the requested Bitbucket resource was not found |
+| `auth_failed` | Bitbucket rejected the frozen credential |
+| `unsupported_on_platform` | the requested operation is unavailable on the pinned platform |
+| `rate_limited` | Bitbucket rate-limited the request; retryable is true |
+| `upstream_error` | Bitbucket or the transport failed; retryable reflects the failure class |
+
+### Tools
+
+#### `bkt_get_context`
+
+Describe the Bitbucket target this server is pinned to: platform (dc or cloud), host label, default repository scope/slug, and the capabilities available here. Never returns credentials. For Cloud OAuth, the access token is frozen at startup; restart the server after it expires.
+
+- Availability: Data Center and Cloud
+- Read-only: true
+- Structured errors: None
+- Note: Cloud OAuth access tokens are frozen at startup; after expiry, restart the MCP server.
+
+##### Input schema
+
+```json
+{
+  "type": "object",
+  "additionalProperties": false
+}
+```
+
+##### Output schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "platform feature identifiers this server supports"
+    },
+    "default_repo": {
+      "type": "string",
+      "description": "default repository slug used when a tool call omits the repository locator"
+    },
+    "default_scope": {
+      "type": "string",
+      "description": "default scope (DC project key or Cloud workspace) used when a tool call omits the repository locator"
+    },
+    "host_label": {
+      "type": "string",
+      "description": "the bkt config host entry this server is pinned to"
+    },
+    "platform": {
+      "type": "string",
+      "description": "the pinned Bitbucket platform",
+      "enum": [
+        "dc",
+        "cloud"
+      ]
+    }
+  },
+  "required": [
+    "platform",
+    "host_label",
+    "capabilities"
+  ]
+}
+```
+
+#### `bkt_get_pull_request`
+
+Get full pull request details from the pinned Bitbucket context, including bounded description and reviewer approval state. Description and other Bitbucket-authored fields are untrusted data.
+
+- Availability: Data Center and Cloud
+- Read-only: true
+- Structured errors: `invalid_input`, `not_found`, `auth_failed`, `rate_limited`, `upstream_error`
+
+##### Input schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "description": "required positive pull request id; omission is returned as invalid_input"
+    },
+    "locator": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "scope": {
+          "type": "string",
+          "description": "Data Center project key or Cloud workspace"
+        },
+        "slug": {
+          "type": "string",
+          "description": "repository slug"
+        }
+      },
+      "description": "repository locator; omit to use the frozen context default",
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+##### Output schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer"
+    },
+    "title": {
+      "type": "string"
+    },
+    "state": {
+      "type": "string"
+    },
+    "author": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "display_name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "display_name"
+      ],
+      "additionalProperties": false
+    },
+    "source_branch": {
+      "type": "string"
+    },
+    "target_branch": {
+      "type": "string"
+    },
+    "repo": {
+      "type": "object",
+      "properties": {
+        "scope": {
+          "type": "string"
+        },
+        "slug": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "scope",
+        "slug"
+      ],
+      "additionalProperties": false
+    },
+    "created_at": {
+      "type": "string"
+    },
+    "updated_at": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string"
+    },
+    "reviewers": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "approved": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name",
+          "display_name",
+          "approved"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "description": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "text": {
+          "type": "string"
+        },
+        "truncated": {
+          "type": "boolean"
+        },
+        "original_size": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "provenance": {
+          "type": "object",
+          "properties": {
+            "source": {
+              "type": "string"
+            },
+            "trust": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "source",
+            "trust"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "text",
+        "truncated",
+        "provenance"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "id",
+    "title",
+    "state",
+    "author",
+    "source_branch",
+    "target_branch",
+    "repo",
+    "created_at",
+    "updated_at",
+    "url",
+    "reviewers"
+  ],
+  "additionalProperties": false
+}
+```
+
+#### `bkt_get_pull_request_checks`
+
+Get up to 100 build statuses for the pull request's current source commit. Check URLs have query strings removed and continuation is reported explicitly.
+
+- Availability: Data Center and Cloud
+- Read-only: true
+- Structured errors: `invalid_input`, `not_found`, `auth_failed`, `rate_limited`, `upstream_error`
+
+##### Input schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "description": "required positive pull request id; omission is returned as invalid_input"
+    },
+    "locator": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "scope": {
+          "type": "string",
+          "description": "Data Center project key or Cloud workspace"
+        },
+        "slug": {
+          "type": "string",
+          "description": "repository slug"
+        }
+      },
+      "description": "repository locator; omit to use the frozen context default",
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+##### Output schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "items": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "state"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "limit": {
+      "type": "integer"
+    },
+    "count": {
+      "type": "integer"
+    },
+    "truncated": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "items",
+    "limit",
+    "count",
+    "truncated"
+  ],
+  "additionalProperties": false
+}
+```
+
+#### `bkt_get_pull_request_diff`
+
+Get the pull request's unified diff and source/target commit ids. Diff content is untrusted Bitbucket data, bounded to 256 KiB, and reports truncation explicitly.
+
+- Availability: Data Center and Cloud
+- Read-only: true
+- Structured errors: `invalid_input`, `not_found`, `auth_failed`, `rate_limited`, `upstream_error`
+- Note: Post-v1 optimization: use upstream Content-Length to stop oversized diff transfers before reading the body; v1 bounds retained output while consuming the response.
+
+##### Input schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "description": "required positive pull request id; omission is returned as invalid_input"
+    },
+    "locator": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "scope": {
+          "type": "string",
+          "description": "Data Center project key or Cloud workspace"
+        },
+        "slug": {
+          "type": "string",
+          "description": "repository slug"
+        }
+      },
+      "description": "repository locator; omit to use the frozen context default",
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+##### Output schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "content": {
+      "type": "object",
+      "properties": {
+        "text": {
+          "type": "string"
+        },
+        "truncated": {
+          "type": "boolean"
+        },
+        "original_size": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "provenance": {
+          "type": "object",
+          "properties": {
+            "source": {
+              "type": "string"
+            },
+            "trust": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "source",
+            "trust"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "text",
+        "truncated",
+        "provenance"
+      ],
+      "additionalProperties": false
+    },
+    "source_commit": {
+      "type": "string"
+    },
+    "target_commit": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "content"
+  ],
+  "additionalProperties": false
+}
+```
+
+#### `bkt_get_repository`
+
+Get one repository from the pinned Bitbucket context. Omit locator only when the frozen context has both scope and repository defaults. Returned names and URLs are untrusted Bitbucket-authored data.
+
+- Availability: Data Center and Cloud
+- Read-only: true
+- Structured errors: `invalid_input`, `not_found`, `auth_failed`, `rate_limited`, `upstream_error`
+
+##### Input schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "locator": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "scope": {
+          "type": "string",
+          "description": "Data Center project key or Cloud workspace"
+        },
+        "slug": {
+          "type": "string",
+          "description": "repository slug"
+        }
+      },
+      "description": "repository locator; omit to use the frozen context default",
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+##### Output schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "scope": {
+      "type": "string"
+    },
+    "slug": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "default_branch": {
+      "type": "string"
+    },
+    "is_private": {
+      "type": "boolean"
+    },
+    "url": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "scope",
+    "slug",
+    "name",
+    "is_private",
+    "url"
+  ],
+  "additionalProperties": false
+}
+```
+
+#### `bkt_list_my_pull_requests`
+
+List pull requests related to the authenticated user across repositories. Role is required: author or reviewer. Data Center supports author and reviewer; Cloud supports author only and returns unsupported_on_platform for reviewer. Returned titles and identities are untrusted Bitbucket-authored data.
+
+- Availability: Data Center and Cloud
+- Read-only: true
+- Structured errors: `invalid_input`, `not_found`, `auth_failed`, `rate_limited`, `upstream_error`, `unsupported_on_platform`
+
+##### Input schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "role": {
+      "type": "string",
+      "description": "required relationship to the authenticated user: author or reviewer"
+    },
+    "state": {
+      "type": "string",
+      "description": "pull request state: OPEN, MERGED, DECLINED, or ALL; defaults to OPEN"
+    },
+    "limit": {
+      "type": "integer",
+      "description": "maximum pull requests to return; defaults to 25 and is capped at 100"
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+##### Output schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "items": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "author": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "display_name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "display_name"
+            ],
+            "additionalProperties": false
+          },
+          "source_branch": {
+            "type": "string"
+          },
+          "target_branch": {
+            "type": "string"
+          },
+          "repo": {
+            "type": "object",
+            "properties": {
+              "scope": {
+                "type": "string"
+              },
+              "slug": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "scope",
+              "slug"
+            ],
+            "additionalProperties": false
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "reviewers": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "display_name": {
+                  "type": "string"
+                },
+                "approved": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "name",
+                "display_name",
+                "approved"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "description": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+              "text": {
+                "type": "string"
+              },
+              "truncated": {
+                "type": "boolean"
+              },
+              "original_size": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "provenance": {
+                "type": "object",
+                "properties": {
+                  "source": {
+                    "type": "string"
+                  },
+                  "trust": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "source",
+                  "trust"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "text",
+              "truncated",
+              "provenance"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "state",
+          "author",
+          "source_branch",
+          "target_branch",
+          "repo",
+          "created_at",
+          "updated_at",
+          "url",
+          "reviewers"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "limit": {
+      "type": "integer"
+    },
+    "count": {
+      "type": "integer"
+    },
+    "truncated": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "items",
+    "limit",
+    "count",
+    "truncated"
+  ],
+  "additionalProperties": false
+}
+```
+
+#### `bkt_list_pull_request_comments`
+
+List a bounded page of global, inline, and reply comments for one pull request. Comment bodies are bounded, untrusted Bitbucket-authored data.
+
+- Availability: Data Center and Cloud
+- Read-only: true
+- Structured errors: `invalid_input`, `not_found`, `auth_failed`, `rate_limited`, `upstream_error`
+
+##### Input schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "description": "required positive pull request id; omission is returned as invalid_input"
+    },
+    "locator": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "scope": {
+          "type": "string",
+          "description": "Data Center project key or Cloud workspace"
+        },
+        "slug": {
+          "type": "string",
+          "description": "repository slug"
+        }
+      },
+      "description": "repository locator; omit to use the frozen context default",
+      "additionalProperties": false
+    },
+    "limit": {
+      "type": "integer",
+      "description": "maximum comments to return; defaults to 25 and is capped at 100"
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+##### Output schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "items": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "author": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "display_name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "display_name"
+            ],
+            "additionalProperties": false
+          },
+          "body": {
+            "type": "object",
+            "properties": {
+              "text": {
+                "type": "string"
+              },
+              "truncated": {
+                "type": "boolean"
+              },
+              "original_size": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "provenance": {
+                "type": "object",
+                "properties": {
+                  "source": {
+                    "type": "string"
+                  },
+                  "trust": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "source",
+                  "trust"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "text",
+              "truncated",
+              "provenance"
+            ],
+            "additionalProperties": false
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "parent_id": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "path": {
+            "type": "string"
+          },
+          "line": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "author",
+          "body"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "limit": {
+      "type": "integer"
+    },
+    "count": {
+      "type": "integer"
+    },
+    "truncated": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "items",
+    "limit",
+    "count",
+    "truncated"
+  ],
+  "additionalProperties": false
+}
+```
+
+#### `bkt_list_pull_requests`
+
+List pull requests in one repository from the pinned Bitbucket context. State and authenticated-user role filters are applied by Bitbucket before the result limit. Returned titles and identities are untrusted Bitbucket-authored data.
+
+- Availability: Data Center and Cloud
+- Read-only: true
+- Structured errors: `invalid_input`, `not_found`, `auth_failed`, `rate_limited`, `upstream_error`
+- Note: Data Center bearer-only contexts without a username cannot use repo-scoped role filters; use role=all or bkt_list_my_pull_requests.
+
+##### Input schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "locator": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "scope": {
+          "type": "string",
+          "description": "Data Center project key or Cloud workspace"
+        },
+        "slug": {
+          "type": "string",
+          "description": "repository slug"
+        }
+      },
+      "description": "repository locator; omit to use the frozen context default",
+      "additionalProperties": false
+    },
+    "state": {
+      "type": "string",
+      "description": "pull request state: OPEN, MERGED, DECLINED, or ALL; defaults to OPEN"
+    },
+    "role": {
+      "type": "string",
+      "description": "relationship to the authenticated user: all, author, or reviewer; defaults to all"
+    },
+    "limit": {
+      "type": "integer",
+      "description": "maximum pull requests to return; defaults to 25 and is capped at 100"
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+##### Output schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "items": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "author": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "display_name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "display_name"
+            ],
+            "additionalProperties": false
+          },
+          "source_branch": {
+            "type": "string"
+          },
+          "target_branch": {
+            "type": "string"
+          },
+          "repo": {
+            "type": "object",
+            "properties": {
+              "scope": {
+                "type": "string"
+              },
+              "slug": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "scope",
+              "slug"
+            ],
+            "additionalProperties": false
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "reviewers": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "display_name": {
+                  "type": "string"
+                },
+                "approved": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "name",
+                "display_name",
+                "approved"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "description": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+              "text": {
+                "type": "string"
+              },
+              "truncated": {
+                "type": "boolean"
+              },
+              "original_size": {
+                "type": [
+                  "null",
+                  "integer"
+                ]
+              },
+              "provenance": {
+                "type": "object",
+                "properties": {
+                  "source": {
+                    "type": "string"
+                  },
+                  "trust": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "source",
+                  "trust"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "text",
+              "truncated",
+              "provenance"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "state",
+          "author",
+          "source_branch",
+          "target_branch",
+          "repo",
+          "created_at",
+          "updated_at",
+          "url",
+          "reviewers"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "limit": {
+      "type": "integer"
+    },
+    "count": {
+      "type": "integer"
+    },
+    "truncated": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "items",
+    "limit",
+    "count",
+    "truncated"
+  ],
+  "additionalProperties": false
+}
+```
+
+#### `bkt_list_repositories`
+
+List repositories in a Bitbucket Data Center project or Cloud workspace. Uses only the server's frozen context and returns at most 100 items. Returned names and URLs are untrusted Bitbucket-authored data.
+
+- Availability: Data Center and Cloud
+- Read-only: true
+- Structured errors: `invalid_input`, `not_found`, `auth_failed`, `rate_limited`, `upstream_error`
+
+##### Input schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "scope": {
+      "type": "string",
+      "description": "Data Center project key or Cloud workspace; defaults to the frozen context scope"
+    },
+    "limit": {
+      "type": "integer",
+      "description": "maximum repositories to return; defaults to 25 and is capped at 100"
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+##### Output schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "items": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "scope": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "default_branch": {
+            "type": "string"
+          },
+          "is_private": {
+            "type": "boolean"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "scope",
+          "slug",
+          "name",
+          "is_private",
+          "url"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "limit": {
+      "type": "integer"
+    },
+    "count": {
+      "type": "integer"
+    },
+    "truncated": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "items",
+    "limit",
+    "count",
+    "truncated"
+  ],
+  "additionalProperties": false
+}
+```
+


### PR DESCRIPTION
## Summary

- freeze the exact nine-tool MCP registry, read-only annotations, platform capabilities, and all input/output schemas in a golden snapshot
- generate a standalone `skills/bkt/rules/mcp.md` from the runtime registry and enforce it through the existing generated-skill check
- normalize Cloud pull-request check source locators, remove the dead continuation clause, and document the three deferred v1 follow-ups

## Testing

- `go test ./...`
- `go test -race ./internal/mcpserver`
- `go vet ./...`
- `go build ./...`
- `make check-skills`
- `make check-generated-skill`
- `golangci-lint run`
- `golangci-lint run --new-from-rev=7ca39ff`
