### PR TITLE
feat(pr): add --reviewer to pr list

### DIFF
--- a/pkg/bbdc/client.go
+++ b/pkg/bbdc/client.go
@@ -367,17 +367,25 @@ func repoPullRequestParams(opts RepoPullRequestsOptions) ([]string, error) {
 // ListPullRequests lists pull requests for a repository, flattening pages up
 // to limit.
 func (c *Client) ListPullRequests(ctx context.Context, projectKey, repoSlug, state string, limit int) ([]PullRequest, error) {
+	return c.ListPullRequestsWithOptions(ctx, projectKey, repoSlug, RepoPullRequestsOptions{State: state, Limit: limit})
+}
+
+// ListPullRequestsWithOptions flattens repository pull requests up to
+// opts.Limit, applying the state, participant role, and username filters
+// upstream on every page so they are honored before the limit. Here opts.Limit
+// is the total result cap (not a per-page size); paging is managed internally
+// and terminates on the last or an empty page. opts.Start is the initial page
+// offset.
+func (c *Client) ListPullRequestsWithOptions(ctx context.Context, projectKey, repoSlug string, opts RepoPullRequestsOptions) ([]PullRequest, error) {
 	const defaultPageSize = 25
 
-	var (
-		start = 0
-		all   []PullRequest
-	)
+	var all []PullRequest
+	start := opts.Start
 
 	for {
 		pageSize := defaultPageSize
-		if limit > 0 {
-			remaining := limit - len(all)
+		if opts.Limit > 0 {
+			remaining := opts.Limit - len(all)
 			if remaining <= 0 {
 				break
 			}
@@ -387,9 +395,11 @@ func (c *Client) ListPullRequests(ctx context.Context, projectKey, repoSlug, sta
 		}
 
 		page, err := c.ListRepoPullRequestsPage(ctx, projectKey, repoSlug, RepoPullRequestsOptions{
-			State: state,
-			Limit: pageSize,
-			Start: start,
+			State:    opts.State,
+			Role:     opts.Role,
+			Username: opts.Username,
+			Limit:    pageSize,
+			Start:    start,
 		})
 		if err != nil {
 			return nil, err
@@ -403,8 +413,8 @@ func (c *Client) ListPullRequests(ctx context.Context, projectKey, repoSlug, sta
 		start = page.NextStart
 	}
 
-	if limit > 0 && len(all) > limit {
-		all = all[:limit]
+	if opts.Limit > 0 && len(all) > opts.Limit {
+		all = all[:opts.Limit]
 	}
 
 	return all, nil

--- a/pkg/bbdc/pullrequests_test.go
+++ b/pkg/bbdc/pullrequests_test.go
@@ -1108,3 +1108,77 @@ func TestListDashboardPullRequestsPageEncodesRole(t *testing.T) {
 		}
 	}
 }
+
+func TestListPullRequestsWithOptionsAppliesFiltersAndPaginates(t *testing.T) {
+	var queries []string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queries = append(queries, r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("start") {
+		case "0":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values":        []map[string]any{{"id": 1}, {"id": 2}},
+				"isLastPage":    false,
+				"nextPageStart": 2,
+			})
+		case "2":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values":     []map[string]any{{"id": 3}},
+				"isLastPage": true,
+			})
+		default:
+			t.Fatalf("unexpected start in query %q", r.URL.RawQuery)
+		}
+	}))
+
+	prs, err := client.ListPullRequestsWithOptions(context.Background(), "PROJ", "repo", bbdc.RepoPullRequestsOptions{
+		State:    "OPEN",
+		Role:     "REVIEWER",
+		Username: "alice",
+		Limit:    10,
+	})
+	if err != nil {
+		t.Fatalf("ListPullRequestsWithOptions: %v", err)
+	}
+	if len(prs) != 3 || prs[0].ID != 1 || prs[2].ID != 3 {
+		t.Fatalf("prs = %+v, want three flattened across pages", prs)
+	}
+	if len(queries) != 2 {
+		t.Fatalf("made %d requests, want 2 pages", len(queries))
+	}
+	for i, q := range queries {
+		for _, want := range []string{"role.1=REVIEWER", "username.1=alice", "state=OPEN"} {
+			if !strings.Contains(q, want) {
+				t.Fatalf("page %d query %q missing %q (filters must be sent on every page)", i, q, want)
+			}
+		}
+	}
+}
+
+func TestListPullRequestsWithOptionsTerminatesOnEmptyNonFinalPage(t *testing.T) {
+	var requests int32
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		w.Header().Set("Content-Type", "application/json")
+		// isLastPage=false but no values and a non-advancing nextPageStart: a
+		// naive loop would spin forever. Termination must not depend on IsLast.
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"values":        []map[string]any{},
+			"isLastPage":    false,
+			"nextPageStart": 0,
+		})
+	}))
+
+	prs, err := client.ListPullRequestsWithOptions(context.Background(), "PROJ", "repo", bbdc.RepoPullRequestsOptions{
+		Role: "REVIEWER", Username: "alice", Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("ListPullRequestsWithOptions: %v", err)
+	}
+	if len(prs) != 0 {
+		t.Fatalf("prs = %+v, want empty", prs)
+	}
+	if got := atomic.LoadInt32(&requests); got != 1 {
+		t.Fatalf("made %d requests, want exactly 1 (empty page must terminate)", got)
+	}
+}

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -90,6 +90,7 @@ type listOptions struct {
 	State     string
 	Limit     int
 	Mine      bool
+	Reviewer  bool
 }
 
 func newListCmd(f *cmdutil.Factory) *cobra.Command {
@@ -104,7 +105,13 @@ On Cloud, the workspace and repo are used instead.
 
 When --mine is set without a specific repository, the command lists pull
 requests authored by the authenticated user across all repositories. On Data
-Center this uses the dashboard API; on Cloud it queries the workspace.`,
+Center this uses the dashboard API; on Cloud it queries the workspace.
+
+--reviewer is the reviewer-facing counterpart: it shows pull requests where the
+authenticated user is a requested reviewer. Without a repository, Data Center
+lists them across all repositories via the dashboard API; Bitbucket Cloud has
+no workspace-wide reviewer endpoint, so --reviewer there requires a repository.
+--mine and --reviewer cannot be combined.`,
 		Example: `  # List open pull requests
   bkt pr list
 
@@ -114,9 +121,19 @@ Center this uses the dashboard API; on Cloud it queries the workspace.`,
   # List your own pull requests across all repositories
   bkt pr list --mine
 
+  # List pull requests awaiting your review (Data Center: across all
+  # repositories; Bitbucket Cloud: add --repo)
+  bkt pr list --reviewer
+
+  # List pull requests awaiting your review in a specific repository
+  bkt pr list --reviewer --repo my-repo
+
   # List pull requests with a limit
   bkt pr list --limit 50 --state OPEN`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Mine && opts.Reviewer {
+				return fmt.Errorf("--mine and --reviewer cannot be combined")
+			}
 			return runList(cmd, f, opts)
 		},
 	}
@@ -127,6 +144,7 @@ Center this uses the dashboard API; on Cloud it queries the workspace.`,
 	cmd.Flags().StringVar(&opts.State, "state", opts.State, "Filter by state (OPEN, MERGED, DECLINED)")
 	cmd.Flags().IntVar(&opts.Limit, "limit", opts.Limit, "Maximum pull requests to list (0 for all)")
 	cmd.Flags().BoolVar(&opts.Mine, "mine", false, "Show pull requests authored by the authenticated user")
+	cmd.Flags().BoolVar(&opts.Reviewer, "reviewer", false, "Show pull requests where the authenticated user is a requested reviewer")
 
 	return cmd
 }
@@ -148,10 +166,10 @@ func runList(cmd *cobra.Command, f *cmdutil.Factory, opts *listOptions) error {
 		projectKey := cmdutil.FirstNonEmpty(opts.Project, ctxCfg.ProjectKey)
 		repoSlug := cmdutil.FirstNonEmpty(opts.Repo, ctxCfg.DefaultRepo)
 
-		// If no repo specified, use the dashboard endpoint (requires --mine)
+		// If no repo specified, use the dashboard endpoint (requires --mine or --reviewer)
 		if repoSlug == "" {
-			if !opts.Mine {
-				return fmt.Errorf("--mine is required when not specifying a repository")
+			if !opts.Mine && !opts.Reviewer {
+				return fmt.Errorf("--mine or --reviewer is required when not specifying a repository")
 			}
 			return runListDashboardDC(cmd, f, ios, host, opts)
 		}
@@ -168,24 +186,42 @@ func runList(cmd *cobra.Command, f *cmdutil.Factory, opts *listOptions) error {
 		ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
 		defer cancel()
 
-		prs, err := client.ListPullRequests(ctx, projectKey, repoSlug, opts.State, opts.Limit)
-		if err != nil {
-			return err
-		}
-
-		if opts.Mine {
+		var prs []bbdc.PullRequest
+		if opts.Reviewer {
 			if host.Username == "" {
-				return fmt.Errorf("--mine requires a username; bearer-only logins must re-authenticate with --username or use the dashboard endpoint (omit --project and --repo)")
+				return fmt.Errorf("--reviewer requires a username; bearer-only logins must re-authenticate with --username or use the dashboard endpoint (omit --project and --repo)")
 			}
-			filtered := prs[:0]
-			current := strings.ToLower(host.Username)
-			for _, pr := range prs {
-				author := strings.ToLower(cmdutil.FirstNonEmpty(pr.Author.User.Name, pr.Author.User.Slug))
-				if author == current {
-					filtered = append(filtered, pr)
+			// Apply the REVIEWER participant filter upstream (before the limit)
+			// rather than filtering a limited page client-side.
+			prs, err = client.ListPullRequestsWithOptions(ctx, projectKey, repoSlug, bbdc.RepoPullRequestsOptions{
+				State:    opts.State,
+				Role:     "REVIEWER",
+				Username: host.Username,
+				Limit:    opts.Limit,
+			})
+			if err != nil {
+				return err
+			}
+		} else {
+			prs, err = client.ListPullRequests(ctx, projectKey, repoSlug, opts.State, opts.Limit)
+			if err != nil {
+				return err
+			}
+
+			if opts.Mine {
+				if host.Username == "" {
+					return fmt.Errorf("--mine requires a username; bearer-only logins must re-authenticate with --username or use the dashboard endpoint (omit --project and --repo)")
 				}
+				filtered := prs[:0]
+				current := strings.ToLower(host.Username)
+				for _, pr := range prs {
+					author := strings.ToLower(cmdutil.FirstNonEmpty(pr.Author.User.Name, pr.Author.User.Slug))
+					if author == current {
+						filtered = append(filtered, pr)
+					}
+				}
+				prs = filtered
 			}
-			prs = filtered
 		}
 
 		payload := map[string]any{
@@ -217,8 +253,13 @@ func runList(cmd *cobra.Command, f *cmdutil.Factory, opts *listOptions) error {
 		workspace := cmdutil.FirstNonEmpty(opts.Workspace, ctxCfg.Workspace)
 		repoSlug := cmdutil.FirstNonEmpty(opts.Repo, ctxCfg.DefaultRepo)
 
-		// If no repo specified, use the workspace endpoint (requires --mine)
+		// If no repo specified, use the workspace endpoint (requires --mine).
+		// Bitbucket Cloud has no workspace-wide reviewer endpoint, so --reviewer
+		// needs a specific repository.
 		if repoSlug == "" {
+			if opts.Reviewer {
+				return fmt.Errorf("--reviewer requires a repository on Bitbucket Cloud; the workspace pull request endpoint filters by author only. Use --reviewer with --repo")
+			}
 			if !opts.Mine {
 				return fmt.Errorf("--mine is required when not specifying a repository")
 			}
@@ -241,21 +282,28 @@ func runList(cmd *cobra.Command, f *cmdutil.Factory, opts *listOptions) error {
 		defer cancel()
 
 		mine := ""
-		if opts.Mine {
+		reviewer := ""
+		if opts.Mine || opts.Reviewer {
 			currentUser, err := client.CurrentUser(ctx)
 			if err != nil {
-				return fmt.Errorf("resolve current Bitbucket Cloud user for --mine: %w", err)
+				return fmt.Errorf("resolve current Bitbucket Cloud user: %w", err)
 			}
-			mine, err = cloudRepositoryMineIdentity(*currentUser)
+			identity, err := cloudRepositoryUserIdentity(*currentUser)
 			if err != nil {
 				return err
+			}
+			if opts.Mine {
+				mine = identity
+			} else {
+				reviewer = identity
 			}
 		}
 
 		prs, err := client.ListPullRequests(ctx, workspace, repoSlug, bbcloud.PullRequestListOptions{
-			State: opts.State,
-			Limit: opts.Limit,
-			Mine:  mine,
+			State:    opts.State,
+			Limit:    opts.Limit,
+			Mine:     mine,
+			Reviewer: reviewer,
 		})
 		if err != nil {
 			return err
@@ -301,9 +349,13 @@ func runListDashboardDC(cmd *cobra.Command, f *cmdutil.Factory, ios *iostreams.I
 	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 	defer cancel()
 
+	role := "AUTHOR"
+	if opts.Reviewer {
+		role = "REVIEWER"
+	}
 	prs, err := client.ListDashboardPullRequests(ctx, bbdc.DashboardPullRequestsOptions{
 		State: opts.State,
-		Role:  "AUTHOR",
+		Role:  role,
 		Limit: opts.Limit,
 	})
 	if err != nil {
@@ -415,14 +467,14 @@ func runListWorkspaceCloud(cmd *cobra.Command, f *cmdutil.Factory, ios *iostream
 	})
 }
 
-func cloudRepositoryMineIdentity(user bbcloud.User) (string, error) {
+func cloudRepositoryUserIdentity(user bbcloud.User) (string, error) {
 	if normalized := bbcloud.NormalizeUUID(user.UUID); normalized != "" {
 		return normalized, nil
 	}
 	if accountID := strings.TrimSpace(user.AccountID); accountID != "" {
 		return accountID, nil
 	}
-	return "", fmt.Errorf("could not determine stable Bitbucket Cloud user identity for --mine; /user returned no UUID or account ID")
+	return "", fmt.Errorf("could not determine a stable Bitbucket Cloud user identity; /user returned no UUID or account ID")
 }
 
 func cloudWorkspaceMineIdentity(user bbcloud.User, host *config.Host) (string, error) {

--- a/pkg/cmd/pr/pr_test.go
+++ b/pkg/cmd/pr/pr_test.go
@@ -102,7 +102,7 @@ func TestListRequiresMineWithoutRepo(t *testing.T) {
 			},
 			args:          []string{},
 			expectError:   true,
-			errorContains: "--mine is required when not specifying a repository",
+			errorContains: "--mine or --reviewer is required when not specifying a repository",
 		},
 		{
 			name: "cloud without repo and without mine",
@@ -6180,5 +6180,195 @@ func TestCreateCloudWithDefaultReviewersCurrentUserError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "resolving current user") {
 		t.Errorf("error = %q, want it to contain 'resolving current user'", err.Error())
+	}
+}
+
+func newReviewerTestFactory(cfg *config.Config, stdout, stderr *strings.Builder) *cmdutil.Factory {
+	return &cmdutil.Factory{
+		AppVersion:     "test",
+		ExecutableName: "bkt",
+		IOStreams:      &iostreams.IOStreams{Out: stdout, ErrOut: stderr},
+		Config:         func() (*config.Config, error) { return cfg, nil },
+	}
+}
+
+func TestListReviewerAndMineAreMutuallyExclusive(t *testing.T) {
+	cfg := &config.Config{
+		ActiveContext: "default",
+		Contexts:      map[string]*config.Context{"default": {Host: "main", ProjectKey: "PROJ", DefaultRepo: "repo1"}},
+		Hosts:         map[string]*config.Host{"main": {Kind: "dc", BaseURL: "https://example.invalid", Username: "u", Token: "t"}},
+	}
+	var out, errb strings.Builder
+	cmd := newListCmd(newReviewerTestFactory(cfg, &out, &errb))
+	cmd.SilenceErrors, cmd.SilenceUsage = true, true
+	cmd.SetArgs([]string{"--mine", "--reviewer"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "cannot be combined") {
+		t.Fatalf("err = %v, want mutual-exclusivity error", err)
+	}
+}
+
+func TestListDashboardDCReviewerUsesReviewerRole(t *testing.T) {
+	var gotRole string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/dashboard/pull-requests") {
+			gotRole = r.URL.Query().Get("role")
+			_ = json.NewEncoder(w).Encode(map[string]any{"values": []bbdc.PullRequest{{ID: 5, Title: "Review me", State: "OPEN"}}, "isLastPage": true})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ActiveContext: "default",
+		Contexts:      map[string]*config.Context{"default": {Host: "main", ProjectKey: "PROJ"}},
+		Hosts:         map[string]*config.Host{"main": {Kind: "dc", BaseURL: server.URL, Username: "testuser", Token: "t"}},
+	}
+	var out, errb strings.Builder
+	cmd := newListCmd(newReviewerTestFactory(cfg, &out, &errb))
+	cmd.SilenceErrors, cmd.SilenceUsage = true, true
+	cmd.SetArgs([]string{"--reviewer"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotRole != "REVIEWER" {
+		t.Fatalf("dashboard role = %q, want REVIEWER (upstream filter)", gotRole)
+	}
+	if !strings.Contains(out.String(), "#5") {
+		t.Fatalf("output missing PR #5: %s", out.String())
+	}
+}
+
+func TestListReviewerRequiresRepositoryOnCloud(t *testing.T) {
+	cfg := &config.Config{
+		ActiveContext: "default",
+		Contexts:      map[string]*config.Context{"default": {Host: "cloud", Workspace: "workspace"}},
+		Hosts:         map[string]*config.Host{"cloud": {Kind: "cloud", BaseURL: "https://example.invalid", Username: "u", Token: "t"}},
+	}
+	var out, errb strings.Builder
+	cmd := newListCmd(newReviewerTestFactory(cfg, &out, &errb))
+	cmd.SilenceErrors, cmd.SilenceUsage = true, true
+	cmd.SetArgs([]string{"--reviewer"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "requires a repository") {
+		t.Fatalf("err = %v, want Cloud reviewer-requires-repo error", err)
+	}
+}
+
+func TestListRepositoryCloudReviewerUsesReviewerBBQL(t *testing.T) {
+	origWd, _ := os.Getwd()
+	tmpDir := t.TempDir()
+	_ = os.Chdir(tmpDir)
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	const userUUID = "{550e8400-e29b-41d4-a716-446655440000}"
+	var gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/user":
+			_ = json.NewEncoder(w).Encode(map[string]any{"uuid": userUUID, "account_id": "557058:12345678-1234-1234-1234-123456789abc"})
+		case "/repositories/workspace/repo1/pullrequests":
+			gotQuery = r.URL.Query().Get("q")
+			_ = json.NewEncoder(w).Encode(map[string]any{"values": []map[string]any{}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ActiveContext: "default",
+		Contexts:      map[string]*config.Context{"default": {Host: "cloud", Workspace: "workspace", DefaultRepo: "repo1"}},
+		Hosts:         map[string]*config.Host{"cloud": {Kind: "cloud", BaseURL: server.URL, Username: "email@example.com", Token: "t"}},
+	}
+	var out, errb strings.Builder
+	cmd := newListCmd(newReviewerTestFactory(cfg, &out, &errb))
+	cmd.SilenceErrors, cmd.SilenceUsage = true, true
+	cmd.SetArgs([]string{"--reviewer"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotQuery != `reviewers.uuid = "`+userUUID+`"` {
+		t.Fatalf("q = %q, want reviewers.uuid upstream filter", gotQuery)
+	}
+}
+
+func TestListRepositoryDCReviewerFiltersUpstreamBeforeLimit(t *testing.T) {
+	var gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/pull-requests") {
+			gotQuery = r.URL.RawQuery
+			// The server applies the participant filter, so it returns only the
+			// reviewer's PRs; the CLI must not re-filter or truncate before it.
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values":     []bbdc.PullRequest{{ID: 1, Title: "Review me", State: "OPEN"}},
+				"isLastPage": true,
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ActiveContext: "default",
+		Contexts:      map[string]*config.Context{"default": {Host: "main", ProjectKey: "PROJ", DefaultRepo: "repo1"}},
+		Hosts:         map[string]*config.Host{"main": {Kind: "dc", BaseURL: server.URL, Username: "testuser", Token: "t"}},
+	}
+	var out, errb strings.Builder
+	cmd := newListCmd(newReviewerTestFactory(cfg, &out, &errb))
+	cmd.SilenceErrors, cmd.SilenceUsage = true, true
+	cmd.SetArgs([]string{"--reviewer", "--limit", "5"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The REVIEWER participant filter and username must be encoded in the
+	// upstream request, applied by Bitbucket before the limit.
+	for _, want := range []string{"role.1=REVIEWER", "username.1=testuser", "limit=5"} {
+		if !strings.Contains(gotQuery, want) {
+			t.Fatalf("upstream query %q missing %q", gotQuery, want)
+		}
+	}
+	if !strings.Contains(out.String(), "#1") {
+		t.Fatalf("output missing PR #1: %s", out.String())
+	}
+}
+
+func TestListRepositoryCloudReviewerMissingIdentityError(t *testing.T) {
+	origWd, _ := os.Getwd()
+	tmpDir := t.TempDir()
+	_ = os.Chdir(tmpDir)
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/user" {
+			// No uuid or account_id — cannot form a stable reviewer identity.
+			_ = json.NewEncoder(w).Encode(map[string]any{"username": "legacy-name"})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		ActiveContext: "default",
+		Contexts:      map[string]*config.Context{"default": {Host: "cloud", Workspace: "workspace", DefaultRepo: "repo1"}},
+		Hosts:         map[string]*config.Host{"cloud": {Kind: "cloud", BaseURL: server.URL, Username: "email@example.com", Token: "t"}},
+	}
+	var out, errb strings.Builder
+	cmd := newListCmd(newReviewerTestFactory(cfg, &out, &errb))
+	cmd.SilenceErrors, cmd.SilenceUsage = true, true
+	cmd.SetArgs([]string{"--reviewer"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "stable Bitbucket Cloud user identity") {
+		t.Fatalf("err = %v, want stable-identity error", err)
+	}
+	if strings.Contains(err.Error(), "--mine") {
+		t.Fatalf("reviewer error must not reference --mine: %v", err)
 	}
 }

--- a/skills/bkt/rules/pr.md
+++ b/skills/bkt/rules/pr.md
@@ -848,6 +848,12 @@ When --mine is set without a specific repository, the command lists pull
 requests authored by the authenticated user across all repositories. On Data
 Center this uses the dashboard API; on Cloud it queries the workspace.
 
+--reviewer is the reviewer-facing counterpart: it shows pull requests where the
+authenticated user is a requested reviewer. Without a repository, Data Center
+lists them across all repositories via the dashboard API; Bitbucket Cloud has
+no workspace-wide reviewer endpoint, so --reviewer there requires a repository.
+--mine and --reviewer cannot be combined.
+
 **Alias:** `ls`
 
 ### Usage
@@ -864,6 +870,7 @@ bkt pr list [flags]
 | `--mine` |  | Show pull requests authored by the authenticated user |
 | `--project` |  | Bitbucket project key override |
 | `--repo` |  | Repository slug override |
+| `--reviewer` |  | Show pull requests where the authenticated user is a requested reviewer |
 | `--state` |  | Filter by state (OPEN, MERGED, DECLINED) |
 | `--workspace` |  | Bitbucket workspace override (Cloud) |
 
@@ -889,6 +896,13 @@ bkt pr list [flags]
 
   # List your own pull requests across all repositories
   bkt pr list --mine
+
+  # List pull requests awaiting your review (Data Center: across all
+  # repositories; Bitbucket Cloud: add --repo)
+  bkt pr list --reviewer
+
+  # List pull requests awaiting your review in a specific repository
+  bkt pr list --reviewer --repo my-repo
 
   # List pull requests with a limit
   bkt pr list --limit 50 --state OPEN


### PR DESCRIPTION
Adds `bkt pr list --reviewer`, the reviewer-facing counterpart to `--mine`: list pull requests where the authenticated user is a requested reviewer. Closes #253.

- **Data Center, no repo:** dashboard API with `role=REVIEWER` (upstream) — the "what do I need to review today" daily loop the issue asks for.
- **Data Center, repo-scoped:** upstream participant filter (`role.1=REVIEWER` + `username.1`) applied by Bitbucket *before* the limit, via the new `bbdc.ListPullRequestsWithOptions` (existing `ListPullRequests` is now a thin wrapper).
- **Cloud, repo-scoped:** reviewers BBQL filter upstream (`reviewers.uuid|account_id|nickname`), resolved to the authenticated user.
- **Cloud, no repo:** clear error — Bitbucket Cloud has no workspace-wide reviewer endpoint, so `--reviewer` there requires `--repo`.
- `--mine` and `--reviewer` are mutually exclusive.

## Testing
- Command tests: mutual exclusion, DC dashboard role assertion, DC repo-scoped upstream query (role.1/username.1/limit), Cloud repo BBQL q, Cloud no-repo error, Cloud reviewer missing-identity error
- bbdc tests: multi-page filter propagation + empty-page termination
- `go test ./...`, `-race` on bbdc+pr, vet, golangci-lint, `make check-generated-skill` — all green
- Peer-reviewed by codex (three rounds; upstream-before-limit and pagination-ownership fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)