### PR TITLE
fix(httpx): surface Bitbucket error details[] and all errors[] entries

### DIFF
--- a/pkg/httpx/client.go
+++ b/pkg/httpx/client.go
@@ -587,15 +587,22 @@ const (
 // details[] to b, indented under the message. Individual detail strings may
 // themselves contain embedded newlines (Bitbucket frequently formats multi-step
 // guidance this way), so each embedded line is indented consistently and blank
-// lines within an entry are preserved. Entirely empty/whitespace-only entries
-// are skipped (they would otherwise emit a stray blank line), and CR is trimmed
-// so CRLF-delimited details do not leave a trailing \r on the stable stderr output.
+// lines within an entry are preserved. Leading and trailing blank lines are
+// ignored, entirely empty/whitespace-only entries are skipped, and CR is
+// trimmed so CRLF-delimited details do not leave a trailing \r on the stable
+// stderr output.
 func appendErrorDetails(b *strings.Builder, details []string) {
 	for _, d := range details {
-		if strings.TrimSpace(d) == "" {
-			continue
+		lines := strings.Split(d, "\n")
+		start := 0
+		for start < len(lines) && strings.TrimSpace(lines[start]) == "" {
+			start++
 		}
-		for _, line := range strings.Split(d, "\n") {
+		end := len(lines)
+		for end > start && strings.TrimSpace(lines[end-1]) == "" {
+			end--
+		}
+		for _, line := range lines[start:end] {
 			line = strings.TrimRight(line, " \t\r")
 			if line == "" {
 				b.WriteString("\n")

--- a/pkg/httpx/client.go
+++ b/pkg/httpx/client.go
@@ -498,8 +498,9 @@ func (c *Client) Do(req *http.Request, v any) error {
 
 func decodeError(resp *http.Response) error {
 	type apiErrEntry struct {
-		Message       string `json:"message"`
-		ExceptionName string `json:"exceptionName"`
+		Message       string   `json:"message"`
+		ExceptionName string   `json:"exceptionName"`
+		Details       []string `json:"details"`
 	}
 	type apiErr struct {
 		Errors []apiErrEntry `json:"errors"`
@@ -521,14 +522,18 @@ func decodeError(resp *http.Response) error {
 	}
 
 	if len(payload.Errors) > 0 {
-		// Prioritize user-actionable errors like CAPTCHA over generic ones
-		bestErr := payload.Errors[0]
-		for _, e := range payload.Errors {
+		// Prioritize user-actionable errors like CAPTCHA over generic ones.
+		// Track the index so the second loop below can skip the already-printed
+		// best entry positionally; apiErrEntry is non-comparable now (it has a
+		// slice field), so we cannot skip it by value.
+		bestIdx := 0
+		for i, e := range payload.Errors {
 			if isCaptchaException(e.ExceptionName) {
-				bestErr = e
+				bestIdx = i
 				break
 			}
 		}
+		bestErr := payload.Errors[bestIdx]
 
 		msg := bestErr.Message
 		// Add hint for CAPTCHA-locked accounts
@@ -536,7 +541,27 @@ func decodeError(resp *http.Response) error {
 			msg = "CAPTCHA verification required: " + msg
 		}
 		msg = withBitbucketCloudAuthHint(msg)
-		return newHTTPError(resp, msg)
+
+		// Preserve the historical single-line "<status>: <message>" prefix so
+		// scripts that grep the first line keep working, then append any
+		// actionable details and additional errors on indented continuation
+		// lines. Bitbucket's details[] often carry the real remediation (e.g.
+		// "create the pull request as draft instead"), which was previously
+		// dropped.
+		var b strings.Builder
+		b.WriteString(msg)
+		appendErrorDetails(&b, bestErr.Details)
+		for j, e := range payload.Errors {
+			if j == bestIdx {
+				continue
+			}
+			if m := strings.TrimSpace(e.Message); m != "" {
+				b.WriteString(errorContinuationIndent)
+				b.WriteString(m)
+			}
+			appendErrorDetails(&b, e.Details)
+		}
+		return newHTTPError(resp, b.String())
 	}
 
 	if msg := strings.TrimSpace(cloudPayload.Error.Message); msg != "" {
@@ -548,6 +573,38 @@ func decodeError(resp *http.Response) error {
 	}
 
 	return newHTTPError(resp)
+}
+
+// Indentation for continuation lines rendered under the primary error message:
+// a secondary error message sits at 2 spaces and its detail lines at 4, forming
+// a small tree. Kept as constants so the spacing is defined in one place.
+const (
+	errorContinuationIndent = "\n  "
+	errorDetailIndent       = "\n    "
+)
+
+// appendErrorDetails writes each non-empty line from a Bitbucket error entry's
+// details[] to b, indented under the message. Individual detail strings may
+// themselves contain embedded newlines (Bitbucket frequently formats multi-step
+// guidance this way), so each embedded line is indented consistently and blank
+// lines within an entry are preserved. Entirely empty/whitespace-only entries
+// are skipped (they would otherwise emit a stray blank line), and CR is trimmed
+// so CRLF-delimited details do not leave a trailing \r on the stable stderr output.
+func appendErrorDetails(b *strings.Builder, details []string) {
+	for _, d := range details {
+		if strings.TrimSpace(d) == "" {
+			continue
+		}
+		for _, line := range strings.Split(d, "\n") {
+			line = strings.TrimRight(line, " \t\r")
+			if line == "" {
+				b.WriteString("\n")
+				continue
+			}
+			b.WriteString(errorDetailIndent)
+			b.WriteString(line)
+		}
+	}
 }
 
 // HTTPError preserves the response status code for callers that need stable

--- a/pkg/httpx/client_test.go
+++ b/pkg/httpx/client_test.go
@@ -630,6 +630,62 @@ func TestDecodeErrorTrimsCRLFAndSkipsEmptyDetails(t *testing.T) {
 	}
 }
 
+func TestDecodeErrorTrimsBoundaryBlankLinesFromDetails(t *testing.T) {
+	tests := []struct {
+		name   string
+		detail string
+		want   string
+	}{
+		{
+			name:   "trailing LF",
+			detail: "step one\n",
+			want:   "400 Bad Request: Blocked\n    step one",
+		},
+		{
+			name:   "trailing CRLF",
+			detail: "step one\r\n",
+			want:   "400 Bad Request: Blocked\n    step one",
+		},
+		{
+			name:   "boundary blank lines with internal blank line",
+			detail: "\r\n \t\r\nstep one\r\n\r\nstep two\r\n \t\r\n",
+			want:   "400 Bad Request: Blocked\n    step one\n\n    step two",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"errors": []map[string]any{
+						{"message": "Blocked", "details": []string{tt.detail}},
+					},
+				})
+			}))
+			t.Cleanup(server.Close)
+
+			client, err := New(Options{BaseURL: server.URL, Retry: RetryPolicy{MaxAttempts: 1}})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			req, err := client.NewRequest(context.Background(), http.MethodPost, "/api", nil)
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+
+			err = client.Do(req, nil)
+			if err == nil {
+				t.Fatal("expected error for 400 response")
+			}
+			if got := err.Error(); got != tt.want {
+				t.Fatalf("error = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDecodeErrorBitbucketCloudTokenHint(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/httpx/client_test.go
+++ b/pkg/httpx/client_test.go
@@ -397,7 +397,7 @@ func TestDecodeErrorPrioritizesCaptchaException(t *testing.T) {
 			name:    "captcha exception prioritized over generic error",
 			status:  http.StatusForbidden,
 			body:    `{"errors":[{"message":"XSRF check failed","exceptionName":""},{"message":"Account locked","exceptionName":"com.atlassian.bitbucket.auth.CaptchaRequiredAuthenticationException"}]}`,
-			wantMsg: "403 Forbidden: CAPTCHA verification required: Account locked",
+			wantMsg: "403 Forbidden: CAPTCHA verification required: Account locked\n  XSRF check failed",
 		},
 		{
 			name:    "normal error without captcha",
@@ -480,6 +480,153 @@ func TestDecodeErrorStructuredMessage(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "Invalid project key") {
 		t.Fatalf("expected structured error message, got %v", err)
+	}
+}
+
+func TestDecodeErrorRendersDetails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"errors": []map[string]any{
+				{
+					"context":       nil,
+					"message":       "Pull request creation was canceled.",
+					"exceptionName": "com.atlassian.bitbucket.pull.PullRequestOpenCanceledException",
+					"details": []string{
+						"Pull requests must open in draft state - non-draft creation is blocked.\n\n1. Create the pull request as draft instead",
+					},
+				},
+			},
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{BaseURL: server.URL, Retry: RetryPolicy{MaxAttempts: 1}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodPost, "/api", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	err = client.Do(req, nil)
+	if err == nil {
+		t.Fatal("expected error for 400 response")
+	}
+
+	got := err.Error()
+	// First line preserves the historical "<status>: <message>" format so
+	// scripts that grep the first line keep working.
+	firstLine := strings.SplitN(got, "\n", 2)[0]
+	if !strings.HasSuffix(firstLine, "Pull request creation was canceled.") {
+		t.Fatalf("first line = %q, want it to end with the primary message", firstLine)
+	}
+	// details[] must now be surfaced (previously dropped).
+	if !strings.Contains(got, "Pull requests must open in draft state") {
+		t.Fatalf("expected details to be rendered, got %q", got)
+	}
+	if !strings.Contains(got, "Create the pull request as draft instead") {
+		t.Fatalf("expected multi-line detail to be rendered, got %q", got)
+	}
+}
+
+func TestDecodeErrorRendersAllErrorsAndDetails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"errors": []map[string]any{
+				{"message": "First problem", "details": []string{"fix the first thing"}},
+				{"message": "Second problem", "details": []string{"fix the second thing"}},
+			},
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{BaseURL: server.URL, Retry: RetryPolicy{MaxAttempts: 1}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "/api", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	err = client.Do(req, nil)
+	if err == nil {
+		t.Fatal("expected error for 400 response")
+	}
+
+	got := err.Error()
+	// Assert structure, not just presence: the prioritized (first) error is the
+	// primary line; the second is a secondary continuation. Check ordering plus
+	// the 2-space indent for secondary messages and 4-space indent for details.
+	firstLine := strings.SplitN(got, "\n", 2)[0]
+	if !strings.HasSuffix(firstLine, "First problem") {
+		t.Fatalf("first line = %q, want it to end with the primary message", firstLine)
+	}
+	if !strings.Contains(got, "\n    fix the first thing") {
+		t.Fatalf("expected primary detail indented 4 spaces, got %q", got)
+	}
+	if !strings.Contains(got, "\n  Second problem") {
+		t.Fatalf("expected secondary message indented 2 spaces, got %q", got)
+	}
+	if !strings.Contains(got, "\n    fix the second thing") {
+		t.Fatalf("expected secondary detail indented 4 spaces, got %q", got)
+	}
+	prev := -1
+	for _, s := range []string{"First problem", "fix the first thing", "Second problem", "fix the second thing"} {
+		idx := strings.Index(got, s)
+		if idx <= prev {
+			t.Fatalf("expected %q to appear in order after the previous item; got %q", s, got)
+		}
+		prev = idx
+	}
+}
+
+func TestDecodeErrorTrimsCRLFAndSkipsEmptyDetails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"errors": []map[string]any{
+				{
+					"message": "Blocked",
+					// A CRLF-delimited multi-line detail, plus a whitespace-only entry.
+					"details": []string{"line one\r\nline two", "   "},
+				},
+			},
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Options{BaseURL: server.URL, Retry: RetryPolicy{MaxAttempts: 1}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	req, err := client.NewRequest(context.Background(), http.MethodPost, "/api", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	got := client.Do(req, nil)
+	if got == nil {
+		t.Fatal("expected error for 400 response")
+	}
+	out := got.Error()
+	if strings.Contains(out, "\r") {
+		t.Fatalf("expected CR to be trimmed from CRLF details, got %q", out)
+	}
+	if !strings.Contains(out, "\n    line one") || !strings.Contains(out, "\n    line two") {
+		t.Fatalf("expected both CRLF detail lines rendered indented, got %q", out)
+	}
+	// The whitespace-only detail entry must be skipped: no stray blank line.
+	if strings.Contains(out, "\n    \n") || strings.HasSuffix(out, "\n") {
+		t.Fatalf("expected no stray blank line from empty detail entry, got %q", out)
 	}
 }
 


### PR DESCRIPTION
## What
`decodeError` now renders `errors[].details[]` and every `errors[]` entry, not just `errors[0].message`.

## Why
Bitbucket Data Center puts actionable remediation in `details[]` — e.g. a repo that vetoes non-draft PR creation returns "create the pull request as draft instead". `bkt` was dropping it, leaving users and CLI/agent callers with a dead-end message. Fixes #269.

## How
- Add `Details []string` to the error-envelope struct.
- Keep the first output line (`<status>: <message>`) byte-for-byte so scripts that grep line 1 keep working. Details render indented 4 spaces; any secondary `errors[]` entry renders its message indented 2 spaces followed by its own details.
- Trim CRLF and skip whitespace-only detail entries so stderr output stays clean.
- Track the best-error index instead of copying the struct (it now carries a slice field).

## Behavior change to note
On the CAPTCHA-prioritization path, the generic secondary message is now appended after the prioritized message (previously only the best message showed). Intended and informative.

## Deliberately not included (possible follow-ups)
- The MCP path (`internal/mcpserver` `mapToolError`) intentionally redacts upstream text to fixed by-status messages; surfacing details there is a separate, security-sensitive decision, left untouched.
- Server-provided error text is written to the terminal without stripping control/ANSI escapes. This is pre-existing (it already applied to `message`); a uniform sanitizer could be added separately.
- Errors have no machine-readable channel (matching gh, whose `--json` covers success only). A structured error envelope could be a future enhancement.

## Tests
`go build`, `go vet`, and `go test ./pkg/httpx/` pass (68 tests). Added tests for details rendering, all-errors ordering/indentation, and CRLF/empty-entry handling; updated one CAPTCHA-case expectation to reflect the appended secondary message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
