### PR TITLE
feat(pr): support Data Center fork pull requests

### DIFF
--- a/pkg/bbdc/pullrequests.go
+++ b/pkg/bbdc/pullrequests.go
@@ -376,13 +376,15 @@ func flattenComments(c PullRequestComment, depth int) []PullRequestComment {
 
 // CreatePROptions configures pull request creation.
 type CreatePROptions struct {
-	Title        string
-	Description  string
-	SourceBranch string
-	TargetBranch string
-	Reviewers    []string
-	CloseSource  bool
-	Draft        bool
+	Title            string
+	Description      string
+	SourceBranch     string
+	TargetBranch     string
+	SourceProjectKey string
+	SourceRepoSlug   string
+	Reviewers        []string
+	CloseSource      bool
+	Draft            bool
 }
 
 // CreatePullRequest creates a pull request between branches.
@@ -397,14 +399,23 @@ func (c *Client) CreatePullRequest(ctx context.Context, projectKey, repoSlug str
 		return nil, fmt.Errorf("title is required")
 	}
 
+	sourceProjectKey := projectKey
+	if opts.SourceProjectKey != "" {
+		sourceProjectKey = opts.SourceProjectKey
+	}
+	sourceRepoSlug := repoSlug
+	if opts.SourceRepoSlug != "" {
+		sourceRepoSlug = opts.SourceRepoSlug
+	}
+
 	body := map[string]any{
 		"title":       opts.Title,
 		"description": opts.Description,
 		"fromRef": map[string]any{
 			"id": ensureRef(opts.SourceBranch),
 			"repository": map[string]any{
-				"slug":    repoSlug,
-				"project": map[string]any{"key": strings.ToUpper(projectKey)},
+				"slug":    sourceRepoSlug,
+				"project": map[string]any{"key": strings.ToUpper(sourceProjectKey)},
 			},
 		},
 		"toRef": map[string]any{

--- a/pkg/bbdc/pullrequests_create_test.go
+++ b/pkg/bbdc/pullrequests_create_test.go
@@ -1,0 +1,129 @@
+package bbdc_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/avivsinai/bitbucket-cli/pkg/bbdc"
+)
+
+func TestCreatePullRequestRepositoryMapping(t *testing.T) {
+	tests := []struct {
+		name              string
+		opts              bbdc.CreatePROptions
+		wantSourceProject string
+		wantSourceRepo    string
+	}{
+		{
+			name: "defaults source repository to destination",
+			opts: bbdc.CreatePROptions{
+				Title:        "Same repository",
+				SourceBranch: "feature",
+				TargetBranch: "main",
+			},
+			wantSourceProject: "DEST",
+			wantSourceRepo:    "upstream",
+		},
+		{
+			name: "uses independent source repository",
+			opts: bbdc.CreatePROptions{
+				Title:            "Fork pull request",
+				SourceBranch:     "feature",
+				TargetBranch:     "main",
+				SourceProjectKey: "fork",
+				SourceRepoSlug:   "contributor-fork",
+			},
+			wantSourceProject: "FORK",
+			wantSourceRepo:    "contributor-fork",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotBody map[string]any
+			client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/rest/api/1.0/projects/dest/repos/upstream/pull-requests" {
+					t.Fatalf("path = %q", r.URL.Path)
+				}
+				if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+					t.Fatalf("decode request body: %v", err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{"id": 1, "title": tt.opts.Title})
+			}))
+
+			if _, err := client.CreatePullRequest(context.Background(), "dest", "upstream", tt.opts); err != nil {
+				t.Fatalf("CreatePullRequest: %v", err)
+			}
+
+			assertRequestRepository(t, gotBody, "fromRef", tt.wantSourceProject, tt.wantSourceRepo)
+			assertRequestRepository(t, gotBody, "toRef", "DEST", "upstream")
+		})
+	}
+}
+
+func TestGetDefaultReviewersForRepositoriesUsesBothRepositoryIDs(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/rest/api/1.0/projects/DEST/repos/upstream":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 202, "slug": "upstream"})
+		case "/rest/api/1.0/projects/FORK/repos/contributor-fork":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 101, "slug": "contributor-fork"})
+		case "/rest/default-reviewers/1.0/projects/DEST/repos/upstream/reviewers":
+			query := r.URL.Query()
+			if got := query.Get("sourceRepoId"); got != "101" {
+				t.Fatalf("sourceRepoId = %q, want 101", got)
+			}
+			if got := query.Get("targetRepoId"); got != "202" {
+				t.Fatalf("targetRepoId = %q, want 202", got)
+			}
+			if got := query.Get("sourceRefId"); got != "feature" {
+				t.Fatalf("sourceRefId = %q, want feature", got)
+			}
+			if got := query.Get("targetRefId"); got != "main" {
+				t.Fatalf("targetRefId = %q, want main", got)
+			}
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"name": "alice"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	reviewers, err := client.GetDefaultReviewersForRepositories(
+		context.Background(),
+		"DEST", "upstream",
+		"FORK", "contributor-fork",
+		"feature", "main",
+	)
+	if err != nil {
+		t.Fatalf("GetDefaultReviewersForRepositories: %v", err)
+	}
+	if len(reviewers) != 1 || reviewers[0].Name != "alice" {
+		t.Fatalf("reviewers = %#v, want alice", reviewers)
+	}
+}
+
+func assertRequestRepository(t *testing.T, body map[string]any, ref, wantProject, wantRepo string) {
+	t.Helper()
+	refBody, ok := body[ref].(map[string]any)
+	if !ok {
+		t.Fatalf("%s = %#v, want object", ref, body[ref])
+	}
+	repository, ok := refBody["repository"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s.repository = %#v, want object", ref, refBody["repository"])
+	}
+	if got := repository["slug"]; got != wantRepo {
+		t.Errorf("%s.repository.slug = %v, want %q", ref, got, wantRepo)
+	}
+	project, ok := repository["project"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s.repository.project = %#v, want object", ref, repository["project"])
+	}
+	if got := project["key"]; got != wantProject {
+		t.Errorf("%s.repository.project.key = %v, want %q", ref, got, wantProject)
+	}
+}

--- a/pkg/bbdc/reviewers.go
+++ b/pkg/bbdc/reviewers.go
@@ -40,7 +40,24 @@ func (c *Client) ListReviewerGroups(ctx context.Context, projectKey, repoSlug st
 // GetDefaultReviewers returns the users required as reviewers for a pull request
 // from sourceRef to targetRef in the given repository.
 func (c *Client) GetDefaultReviewers(ctx context.Context, projectKey, repoSlug, sourceRef, targetRef string) ([]User, error) {
-	if projectKey == "" || repoSlug == "" {
+	return c.GetDefaultReviewersForRepositories(
+		ctx,
+		projectKey, repoSlug,
+		projectKey, repoSlug,
+		sourceRef, targetRef,
+	)
+}
+
+// GetDefaultReviewersForRepositories returns the users required as reviewers
+// for a pull request whose source and target refs may live in different
+// repositories. The target repository owns the default-reviewer rules.
+func (c *Client) GetDefaultReviewersForRepositories(
+	ctx context.Context,
+	targetProjectKey, targetRepoSlug string,
+	sourceProjectKey, sourceRepoSlug string,
+	sourceRef, targetRef string,
+) ([]User, error) {
+	if targetProjectKey == "" || targetRepoSlug == "" || sourceProjectKey == "" || sourceRepoSlug == "" {
 		return nil, fmt.Errorf("project key and repository slug are required")
 	}
 	sourceRef = strings.TrimSpace(sourceRef)
@@ -49,19 +66,26 @@ func (c *Client) GetDefaultReviewers(ctx context.Context, projectKey, repoSlug, 
 		return nil, fmt.Errorf("source and target refs are required")
 	}
 
-	repo, err := c.GetRepository(ctx, projectKey, repoSlug)
+	targetRepo, err := c.GetRepository(ctx, targetProjectKey, targetRepoSlug)
 	if err != nil {
-		return nil, fmt.Errorf("fetch repository: %w", err)
+		return nil, fmt.Errorf("fetch target repository: %w", err)
+	}
+	sourceRepo := targetRepo
+	if !strings.EqualFold(sourceProjectKey, targetProjectKey) || !strings.EqualFold(sourceRepoSlug, targetRepoSlug) {
+		sourceRepo, err = c.GetRepository(ctx, sourceProjectKey, sourceRepoSlug)
+		if err != nil {
+			return nil, fmt.Errorf("fetch source repository: %w", err)
+		}
 	}
 
 	endpoint := fmt.Sprintf("/rest/default-reviewers/1.0/projects/%s/repos/%s/reviewers",
-		url.PathEscape(projectKey),
-		url.PathEscape(repoSlug),
+		url.PathEscape(targetProjectKey),
+		url.PathEscape(targetRepoSlug),
 	)
 
 	params := url.Values{}
-	params.Set("sourceRepoId", fmt.Sprintf("%d", repo.ID))
-	params.Set("targetRepoId", fmt.Sprintf("%d", repo.ID))
+	params.Set("sourceRepoId", fmt.Sprintf("%d", sourceRepo.ID))
+	params.Set("targetRepoId", fmt.Sprintf("%d", targetRepo.ID))
 	params.Set("sourceRefId", defaultReviewerRefID(sourceRef))
 	params.Set("targetRefId", defaultReviewerRefID(targetRef))
 	endpoint += "?" + params.Encode()

--- a/pkg/cmd/pr/create_fork_test.go
+++ b/pkg/cmd/pr/create_fork_test.go
@@ -1,0 +1,183 @@
+package pr
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/bitbucket-cli/internal/config"
+	"github.com/avivsinai/bitbucket-cli/pkg/cmdutil"
+	"github.com/avivsinai/bitbucket-cli/pkg/iostreams"
+)
+
+func TestCreateCommandDefinesSourceRepositoryFlags(t *testing.T) {
+	cmd := newCreateCmd(nil)
+	for _, name := range []string{"source-project", "source-repo"} {
+		flag := cmd.Flags().Lookup(name)
+		if flag == nil {
+			t.Fatalf("flag --%s is not defined", name)
+		}
+		if flag.DefValue != "" {
+			t.Errorf("--%s default = %q, want empty", name, flag.DefValue)
+		}
+	}
+}
+
+func TestCreateDataCenterCrossRepositoryRequest(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/rest/api/1.0/projects/DEST/repos/upstream/pull-requests" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 17, "title": "Fork PR"})
+	}))
+	t.Cleanup(server.Close)
+
+	cmd := newCreateCmd(newForkCreateFactory(server.URL, "dc"))
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetContext(context.Background())
+	cmd.SetArgs([]string{
+		"--title", "Fork PR",
+		"--source", "feature",
+		"--target", "main",
+		"--source-project", "FORK",
+		"--source-repo", "contributor-fork",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	assertCommandRequestRepository(t, gotBody, "fromRef", "FORK", "contributor-fork")
+	assertCommandRequestRepository(t, gotBody, "toRef", "DEST", "upstream")
+}
+
+func TestCreateDataCenterCrossRepositoryDefaultReviewers(t *testing.T) {
+	var gotCreateBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/rest/api/1.0/projects/DEST/repos/upstream":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 202, "slug": "upstream"})
+		case "/rest/api/1.0/projects/FORK/repos/contributor-fork":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 101, "slug": "contributor-fork"})
+		case "/rest/default-reviewers/1.0/projects/DEST/repos/upstream/reviewers":
+			query := r.URL.Query()
+			if query.Get("sourceRepoId") != "101" || query.Get("targetRepoId") != "202" {
+				t.Fatalf("default reviewer repo IDs = source %q, target %q", query.Get("sourceRepoId"), query.Get("targetRepoId"))
+			}
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"name": "alice"}})
+		case "/rest/api/1.0/projects/DEST/repos/upstream/pull-requests":
+			if err := json.NewDecoder(r.Body).Decode(&gotCreateBody); err != nil {
+				t.Fatalf("decode create body: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 17, "title": "Fork PR"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	cmd := newCreateCmd(newForkCreateFactory(server.URL, "dc"))
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetContext(context.Background())
+	cmd.SetArgs([]string{
+		"--title", "Fork PR",
+		"--source", "feature",
+		"--target", "main",
+		"--source-project", "FORK",
+		"--source-repo", "contributor-fork",
+		"--with-default-reviewers",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	assertCommandRequestRepository(t, gotCreateBody, "fromRef", "FORK", "contributor-fork")
+	reviewers, ok := gotCreateBody["reviewers"].([]any)
+	if !ok || len(reviewers) != 1 {
+		t.Fatalf("reviewers = %#v, want one reviewer", gotCreateBody["reviewers"])
+	}
+	reviewer, ok := reviewers[0].(map[string]any)
+	if !ok {
+		t.Fatalf("reviewer = %#v, want object", reviewers[0])
+	}
+	user, ok := reviewer["user"].(map[string]any)
+	if !ok || user["name"] != "alice" {
+		t.Fatalf("reviewer user = %#v, want alice", reviewer["user"])
+	}
+}
+
+func TestCreateCloudRejectsSourceRepositoryFlags(t *testing.T) {
+	t.Chdir(t.TempDir())
+	for _, args := range [][]string{
+		{"--source-project", "FORK"},
+		{"--source-repo", "contributor-fork"},
+	} {
+		t.Run(args[0], func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Fatalf("unexpected Cloud request: %s %s", r.Method, r.URL.Path)
+			}))
+			t.Cleanup(server.Close)
+
+			cmd := newCreateCmd(newForkCreateFactory(server.URL, "cloud"))
+			cmd.SilenceErrors = true
+			cmd.SilenceUsage = true
+			cmd.SetContext(context.Background())
+			cmd.SetArgs(args)
+
+			err := cmd.Execute()
+			if err == nil || !strings.Contains(err.Error(), "only supported on Bitbucket Data Center") {
+				t.Fatalf("error = %v, want explicit Data Center-only rejection", err)
+			}
+		})
+	}
+}
+
+func newForkCreateFactory(baseURL, kind string) *cmdutil.Factory {
+	ctx := &config.Context{Host: "test", ProjectKey: "DEST", Workspace: "workspace", DefaultRepo: "upstream"}
+	host := &config.Host{Kind: kind, BaseURL: baseURL, Username: "user", Token: "token"}
+	return &cmdutil.Factory{
+		AppVersion:     "test",
+		ExecutableName: "bkt",
+		IOStreams:      &iostreams.IOStreams{Out: &strings.Builder{}, ErrOut: &strings.Builder{}},
+		Config: func() (*config.Config, error) {
+			return &config.Config{
+				ActiveContext: "default",
+				Contexts:      map[string]*config.Context{"default": ctx},
+				Hosts:         map[string]*config.Host{"test": host},
+			}, nil
+		},
+	}
+}
+
+func assertCommandRequestRepository(t *testing.T, body map[string]any, ref, wantProject, wantRepo string) {
+	t.Helper()
+	refBody, ok := body[ref].(map[string]any)
+	if !ok {
+		t.Fatalf("%s = %#v, want object", ref, body[ref])
+	}
+	repository, ok := refBody["repository"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s.repository = %#v, want object", ref, refBody["repository"])
+	}
+	if got := repository["slug"]; got != wantRepo {
+		t.Errorf("%s.repository.slug = %v, want %q", ref, got, wantRepo)
+	}
+	project, ok := repository["project"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s.repository.project = %#v, want object", ref, repository["project"])
+	}
+	if got := project["key"]; got != wantProject {
+		t.Errorf("%s.repository.project.key = %v, want %q", ref, got, wantProject)
+	}
+}

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -747,6 +747,8 @@ type createOptions struct {
 	Project              string
 	Workspace            string
 	Repo                 string
+	SourceProject        string
+	SourceRepo           string
 	Title                string
 	Source               string
 	Target               string
@@ -1018,6 +1020,10 @@ Reviewers can be added with repeatable --reviewer flags.
 --with-default-reviewers merges the repository's configured default reviewers
 into the reviewer list. On Cloud, the current user is automatically excluded.
 
+On Data Center, --source-project and --source-repo select a fork repository for
+the source branch. Each defaults to the destination project or repository when
+omitted. These flags are rejected on Bitbucket Cloud.
+
 Draft pull requests are supported on Cloud (always) and on Data Center 8.18+
 via the --draft flag.`,
 		Example: `  # Create a pull request with auto-detected title
@@ -1030,7 +1036,11 @@ via the --draft flag.`,
   bkt pr create -t "Fix login bug" --reviewer alice --reviewer bob --close-source
 
   # Create a draft pull request
-  bkt pr create --title "WIP: new feature" --draft`,
+  bkt pr create --title "WIP: new feature" --draft
+
+  # Create from a Data Center fork into an upstream repository
+  bkt pr create --source-project FORK --source-repo contributor-fork \
+    --project DEST --repo upstream --source feature --target main`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// --body and --description are mutually exclusive aliases
 			if cmd.Flags().Changed("body") && cmd.Flags().Changed("description") {
@@ -1059,6 +1069,8 @@ via the --draft flag.`,
 	cmd.Flags().StringVar(&opts.Project, "project", "", "Bitbucket project key override")
 	cmd.Flags().StringVar(&opts.Workspace, "workspace", "", "Bitbucket workspace override (Cloud)")
 	cmd.Flags().StringVar(&opts.Repo, "repo", "", "Repository slug override")
+	cmd.Flags().StringVar(&opts.SourceProject, "source-project", "", "Source project key (Data Center only; defaults to --project)")
+	cmd.Flags().StringVar(&opts.SourceRepo, "source-repo", "", "Source repository slug (Data Center only; defaults to --repo)")
 	cmd.Flags().StringVar(&opts.Title, "title", "", "Pull request title (defaults to the first unique commit subject)")
 	cmd.Flags().StringVar(&opts.Description, "description", "", "Pull request description")
 	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "Pull request description (alias for --description)")
@@ -1084,6 +1096,9 @@ func runCreate(cmd *cobra.Command, f *cmdutil.Factory, opts *createOptions) erro
 	if err != nil {
 		return err
 	}
+	if host.Kind == "cloud" && (cmd.Flags().Changed("source-project") || cmd.Flags().Changed("source-repo")) {
+		return fmt.Errorf("--source-project and --source-repo are only supported on Bitbucket Data Center")
+	}
 
 	if err := applyCreateDefaults(cmd.Context(), opts, host); err != nil {
 		return err
@@ -1104,10 +1119,17 @@ func runCreate(cmd *cobra.Command, f *cmdutil.Factory, opts *createOptions) erro
 
 		ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
 		defer cancel()
+		sourceProjectKey := cmdutil.FirstNonEmpty(opts.SourceProject, projectKey)
+		sourceRepoSlug := cmdutil.FirstNonEmpty(opts.SourceRepo, repoSlug)
 
 		reviewers := opts.Reviewers
 		if opts.WithDefaultReviewers {
-			defaultUsers, err := getDCDefaultReviewers(ctx, client, projectKey, repoSlug, opts.Source, opts.Target)
+			defaultUsers, err := getDCDefaultReviewersForRepositories(
+				ctx, client,
+				projectKey, repoSlug,
+				sourceProjectKey, sourceRepoSlug,
+				opts.Source, opts.Target,
+			)
 			if err != nil {
 				return err
 			}
@@ -1115,13 +1137,15 @@ func runCreate(cmd *cobra.Command, f *cmdutil.Factory, opts *createOptions) erro
 		}
 
 		pr, err := client.CreatePullRequest(ctx, projectKey, repoSlug, bbdc.CreatePROptions{
-			Title:        opts.Title,
-			Description:  opts.Description,
-			SourceBranch: opts.Source,
-			TargetBranch: opts.Target,
-			Reviewers:    reviewers,
-			CloseSource:  opts.CloseSource,
-			Draft:        opts.Draft,
+			Title:            opts.Title,
+			Description:      opts.Description,
+			SourceBranch:     opts.Source,
+			TargetBranch:     opts.Target,
+			SourceProjectKey: sourceProjectKey,
+			SourceRepoSlug:   sourceRepoSlug,
+			Reviewers:        reviewers,
+			CloseSource:      opts.CloseSource,
+			Draft:            opts.Draft,
 		})
 		if err != nil {
 			return err
@@ -1550,7 +1574,27 @@ func cloudReviewerIDs(reviewers []bbcloud.User) []string {
 }
 
 func getDCDefaultReviewers(ctx context.Context, client *bbdc.Client, projectKey, repoSlug, sourceRef, targetRef string) ([]bbdc.User, error) {
-	defaultUsers, err := client.GetDefaultReviewers(ctx, projectKey, repoSlug, sourceRef, targetRef)
+	return getDCDefaultReviewersForRepositories(
+		ctx, client,
+		projectKey, repoSlug,
+		projectKey, repoSlug,
+		sourceRef, targetRef,
+	)
+}
+
+func getDCDefaultReviewersForRepositories(
+	ctx context.Context,
+	client *bbdc.Client,
+	targetProjectKey, targetRepoSlug string,
+	sourceProjectKey, sourceRepoSlug string,
+	sourceRef, targetRef string,
+) ([]bbdc.User, error) {
+	defaultUsers, err := client.GetDefaultReviewersForRepositories(
+		ctx,
+		targetProjectKey, targetRepoSlug,
+		sourceProjectKey, sourceRepoSlug,
+		sourceRef, targetRef,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("fetching default reviewers: %w", err)
 	}

--- a/skills/bkt/rules/pr.md
+++ b/skills/bkt/rules/pr.md
@@ -622,6 +622,10 @@ Reviewers can be added with repeatable --reviewer flags.
 --with-default-reviewers merges the repository's configured default reviewers
 into the reviewer list. On Cloud, the current user is automatically excluded.
 
+On Data Center, --source-project and --source-repo select a fork repository for
+the source branch. Each defaults to the destination project or repository when
+omitted. These flags are rejected on Bitbucket Cloud.
+
 Draft pull requests are supported on Cloud (always) and on Data Center 8.18+
 via the --draft flag.
 
@@ -644,6 +648,8 @@ bkt pr create [flags]
 | `--repo` |  | Repository slug override |
 | `--reviewer` |  | Reviewer username or {UUID} (repeatable) |
 | `--source` |  | Source branch (defaults to the current branch) |
+| `--source-project` |  | Source project key (Data Center only; defaults to --project) |
+| `--source-repo` |  | Source repository slug (Data Center only; defaults to --repo) |
 | `--target` |  | Target branch (defaults to the remote's default branch) |
 | `--title` |  | Pull request title (defaults to the first unique commit subject) |
 | `--with-default-reviewers` |  | Add repository default reviewers |
@@ -674,6 +680,10 @@ bkt pr create [flags]
 
   # Create a draft pull request
   bkt pr create --title "WIP: new feature" --draft
+
+  # Create from a Data Center fork into an upstream repository
+  bkt pr create --source-project FORK --source-repo contributor-fork \
+    --project DEST --repo upstream --source feature --target main
 ```
 
 ## bkt pr decline


### PR DESCRIPTION
## Summary

- add Data Center pr create flags for an independent source project and repository
- keep the request URL and toRef on the destination while mapping fromRef to the fork
- preserve same-repository defaults when either source flag is omitted
- resolve default reviewers with the real sourceRepoId and targetRepoId
- reject the Data Center-only source repository flags on Bitbucket Cloud
- regenerate the bkt skill reference

## API contract

- Atlassian documents that Data Center pull-request source and target refs may live in different repositories within the same repository hierarchy: https://docs.atlassian.com/bitbucket-server/rest/7.14.0/bitbucket-rest.html
- Atlassian documents separate sourceRepoId and targetRepoId parameters for default reviewers: https://docs.atlassian.com/bitbucket-server/rest/7.5.0/bitbucket-default-reviewers-rest.html

## Testing

- go test ./pkg/bbdc ./pkg/cmd/pr -count=1
- go test ./... -count=1
- go vet ./...
- make build
- GOOS=windows GOARCH=amd64 go build ./cmd/bkt
- make check-generated-skill
- go run ./cmd/bkt pr create --help

Fixes #268
