### PR TITLE
fix: use valid DC default branch endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented here. The format follows
   the README now that the package is available in the catalog.
 
 ### Fixed
+- Creating a Bitbucket Data Center repository with a default branch no longer
+  reports a false 404 after the repository has already been created.
 - ChatGPT GitHub imports no longer fail on unsupported skill symlinks; the
   Claude and agent skill paths are now committed directory mirrors. (#279)
 - Corrected support and governance docs to point at GitHub Issues: removed a

--- a/pkg/bbdc/branches.go
+++ b/pkg/bbdc/branches.go
@@ -142,7 +142,7 @@ func (c *Client) SetDefaultBranch(ctx context.Context, projectKey, repoSlug, bra
 		"id": ensureRef(branch),
 	}
 
-	req, err := c.http.NewRequest(ctx, "PUT", fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/settings/default-branch",
+	req, err := c.http.NewRequest(ctx, "PUT", fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/default-branch",
 		url.PathEscape(projectKey),
 		url.PathEscape(repoSlug),
 	), body)

--- a/pkg/bbdc/repos_test.go
+++ b/pkg/bbdc/repos_test.go
@@ -1,0 +1,73 @@
+package bbdc_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/avivsinai/bitbucket-cli/pkg/bbdc"
+)
+
+func TestCreateRepositorySetsDefaultBranch(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/rest/api/1.0/projects/~USER/repos":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode create body: %v", err)
+			}
+			if got := body["name"]; got != "example" {
+				t.Errorf("create name = %v, want example", got)
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"slug": "example",
+				"name": "example",
+				"project": map[string]any{
+					"key": "~USER",
+				},
+			})
+
+		case r.Method == http.MethodPut && r.URL.Path == "/rest/api/1.0/projects/~USER/repos/example/default-branch":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode default branch body: %v", err)
+			}
+			if got := body["id"]; got != "refs/heads/main" {
+				t.Errorf("default branch id = %v, want refs/heads/main", got)
+			}
+			w.WriteHeader(http.StatusNoContent)
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := bbdc.New(bbdc.Options{BaseURL: server.URL})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	repo, err := client.CreateRepository(context.Background(), "~USER", bbdc.CreateRepositoryInput{
+		Name:          "example",
+		Description:   "Example repository",
+		DefaultBranch: "main",
+	})
+	if err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+	if repo.DefaultBranch != "main" {
+		t.Errorf("default branch = %q, want main", repo.DefaultBranch)
+	}
+}

--- a/pkg/cmd/branch/branch_test.go
+++ b/pkg/cmd/branch/branch_test.go
@@ -364,7 +364,7 @@ func TestBranchDeleteRejectsCloud(t *testing.T) {
 
 func TestBranchSetDefaultDC(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPut || !strings.Contains(r.URL.Path, "/settings/default-branch") {
+		if r.Method != http.MethodPut || r.URL.Path != "/rest/api/1.0/projects/PROJ/repos/my-repo/default-branch" {
 			http.NotFound(w, r)
 			return
 		}


### PR DESCRIPTION
## Summary

- use the supported Bitbucket Data Center `/default-branch` endpoint
- add regression coverage for repository creation and branch defaulting
- add the missing `Unreleased / Fixed` release note

This is the maintainer-owned replacement for #284. It preserves the original code and tests exactly while avoiding any forged contributor DCO sign-off.

## Provenance

- source/test patch-id matches #284: `9474a671172c0ad5595942ca58ebfb1edb0e9067`
- original contributors are retained through both `Co-authored-by` trailers
- the replacement commit is authored and signed off by the maintainer

## Testing

- regression tests fail against current `master` with the false 404
- focused regression tests pass after the endpoint fix
- targeted race tests pass
- `make test` — 1,623 pass events, 0 failures, 0 skips
- `go vet ./...`
- `make build`
- `git diff --check`

No live Bitbucket Data Center instance was used; runtime confidence comes from the official REST contract plus exact HTTP regression tests.