### PR TITLE
feat: add bkt project reviewer-groups list command

### DIFF
--- a/.agents/skills/bkt/rules/project.md
+++ b/.agents/skills/bkt/rules/project.md
@@ -28,6 +28,7 @@ bkt project <command> [flags]
 | Subcommand | Description | Key Flags |
 |---|---|---|
 | [list](#bkt-project-list) | List Bitbucket Data Center projects *(DC)* | `--host`, `--limit` |
+| [reviewer-groups](#bkt-project-reviewer-groups) | Work with project reviewer groups *(DC)* | — |
 
 ## bkt project list
 
@@ -78,5 +79,80 @@ bkt project list [flags]
 
   # List projects in JSON format
   bkt project list --json
+```
+
+## bkt project reviewer-groups
+
+List the reviewer groups defined in a project's settings.
+
+Reviewer groups are named sets of users that can be added as default reviewers
+on repositories within the project. Data Center only.
+
+**Alias:** `reviewer-group`
+
+```
+bkt project reviewer-groups <command> [flags]
+```
+
+### Examples
+
+```bash
+# List reviewer groups for the active context project
+  bkt project reviewer-groups list
+
+  # List reviewer groups for a specific project
+  bkt project reviewer-groups list --project PLATFORM
+```
+
+| Subcommand | Description |
+|---|---|
+| list | List project reviewer groups (DC only) |
+
+## bkt project reviewer-groups list
+
+List the reviewer groups defined in a Bitbucket Data Center project's
+settings, including each group's members. The project is resolved from the
+active context unless overridden with --project.
+
+This command is only available for Data Center hosts. Attempting to run it
+against a Cloud context will return an error.
+
+**Alias:** `ls`
+
+### Usage
+
+```
+bkt project reviewer-groups list [flags]
+```
+
+### Flags
+
+| Flag | Short | Description |
+|---|---|---|
+| `--limit` |  | Maximum reviewer groups to display (0 for all) |
+| `--project` |  | Bitbucket project key override |
+
+### Inherited Flags
+
+| Flag | Short | Description |
+|---|---|---|
+| `--context` | `-c` | Active Bitbucket context name |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
+| `--json` |  | Output in JSON format when supported |
+| `--template` |  | Render output using Go templates |
+| `--yaml` |  | Output in YAML format when supported |
+
+### Examples
+
+```bash
+# List reviewer groups for the active context project
+  bkt project reviewer-groups list
+
+  # List reviewer groups for a specific project
+  bkt project reviewer-groups list --project PLATFORM
+
+  # List reviewer groups in JSON format
+  bkt project reviewer-groups list --project PLATFORM --json
 ```
 

--- a/.agents/skills/bkt/rules/project.md
+++ b/.agents/skills/bkt/rules/project.md
@@ -112,7 +112,8 @@ bkt project reviewer-groups <command> [flags]
 
 List the reviewer groups defined in a Bitbucket Data Center project's
 settings, including each group's members. The project is resolved from the
-active context unless overridden with --project.
+active context unless overridden with --project. Use --limit to control the
+number of results returned.
 
 This command is only available for Data Center hosts. Attempting to run it
 against a Cloud context will return an error.
@@ -146,8 +147,11 @@ bkt project reviewer-groups list [flags]
 ### Examples
 
 ```bash
-# List reviewer groups for the active context project
+# List reviewer groups for the active context project (default limit of 30)
   bkt project reviewer-groups list
+
+  # List all reviewer groups without a limit
+  bkt project reviewer-groups ls --limit 0
 
   # List reviewer groups for a specific project
   bkt project reviewer-groups list --project PLATFORM

--- a/.claude/skills/bkt/rules/project.md
+++ b/.claude/skills/bkt/rules/project.md
@@ -28,6 +28,7 @@ bkt project <command> [flags]
 | Subcommand | Description | Key Flags |
 |---|---|---|
 | [list](#bkt-project-list) | List Bitbucket Data Center projects *(DC)* | `--host`, `--limit` |
+| [reviewer-groups](#bkt-project-reviewer-groups) | Work with project reviewer groups *(DC)* | — |
 
 ## bkt project list
 
@@ -78,5 +79,80 @@ bkt project list [flags]
 
   # List projects in JSON format
   bkt project list --json
+```
+
+## bkt project reviewer-groups
+
+List the reviewer groups defined in a project's settings.
+
+Reviewer groups are named sets of users that can be added as default reviewers
+on repositories within the project. Data Center only.
+
+**Alias:** `reviewer-group`
+
+```
+bkt project reviewer-groups <command> [flags]
+```
+
+### Examples
+
+```bash
+# List reviewer groups for the active context project
+  bkt project reviewer-groups list
+
+  # List reviewer groups for a specific project
+  bkt project reviewer-groups list --project PLATFORM
+```
+
+| Subcommand | Description |
+|---|---|
+| list | List project reviewer groups (DC only) |
+
+## bkt project reviewer-groups list
+
+List the reviewer groups defined in a Bitbucket Data Center project's
+settings, including each group's members. The project is resolved from the
+active context unless overridden with --project.
+
+This command is only available for Data Center hosts. Attempting to run it
+against a Cloud context will return an error.
+
+**Alias:** `ls`
+
+### Usage
+
+```
+bkt project reviewer-groups list [flags]
+```
+
+### Flags
+
+| Flag | Short | Description |
+|---|---|---|
+| `--limit` |  | Maximum reviewer groups to display (0 for all) |
+| `--project` |  | Bitbucket project key override |
+
+### Inherited Flags
+
+| Flag | Short | Description |
+|---|---|---|
+| `--context` | `-c` | Active Bitbucket context name |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
+| `--json` |  | Output in JSON format when supported |
+| `--template` |  | Render output using Go templates |
+| `--yaml` |  | Output in YAML format when supported |
+
+### Examples
+
+```bash
+# List reviewer groups for the active context project
+  bkt project reviewer-groups list
+
+  # List reviewer groups for a specific project
+  bkt project reviewer-groups list --project PLATFORM
+
+  # List reviewer groups in JSON format
+  bkt project reviewer-groups list --project PLATFORM --json
 ```
 

--- a/.claude/skills/bkt/rules/project.md
+++ b/.claude/skills/bkt/rules/project.md
@@ -112,7 +112,8 @@ bkt project reviewer-groups <command> [flags]
 
 List the reviewer groups defined in a Bitbucket Data Center project's
 settings, including each group's members. The project is resolved from the
-active context unless overridden with --project.
+active context unless overridden with --project. Use --limit to control the
+number of results returned.
 
 This command is only available for Data Center hosts. Attempting to run it
 against a Cloud context will return an error.
@@ -146,8 +147,11 @@ bkt project reviewer-groups list [flags]
 ### Examples
 
 ```bash
-# List reviewer groups for the active context project
+# List reviewer groups for the active context project (default limit of 30)
   bkt project reviewer-groups list
+
+  # List all reviewer groups without a limit
+  bkt project reviewer-groups ls --limit 0
 
   # List reviewer groups for a specific project
   bkt project reviewer-groups list --project PLATFORM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented here. The format follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Added
+- `bkt project reviewer-groups list` lists the reviewer groups defined in a
+  Bitbucket Data Center project's settings, including each group's members.
+  The project is resolved from the active context or `--project`. (#290)
 
 ## [0.30.1] - 2026-08-05
 ### Added

--- a/pkg/bbdc/reviewers.go
+++ b/pkg/bbdc/reviewers.go
@@ -77,6 +77,9 @@ func (c *Client) ListProjectReviewerGroups(ctx context.Context, projectKey strin
 			break
 		}
 
+		if resp.NextPageStart <= start {
+			return nil, fmt.Errorf("invalid pagination response: nextPageStart %d did not advance from %d", resp.NextPageStart, start)
+		}
 		start = resp.NextPageStart
 	}
 

--- a/pkg/bbdc/reviewers.go
+++ b/pkg/bbdc/reviewers.go
@@ -13,6 +13,76 @@ type ReviewerGroup struct {
 	ID   int    `json:"id"`
 }
 
+// ReviewerGroupScope identifies the entity a reviewer group is defined on.
+type ReviewerGroupScope struct {
+	Type       string `json:"type"`
+	ResourceID int    `json:"resourceId"`
+}
+
+// ProjectReviewerGroup represents a reviewer group defined in a project's settings.
+type ProjectReviewerGroup struct {
+	ID          int                `json:"id"`
+	Name        string             `json:"name"`
+	Description string             `json:"description"`
+	Scope       ReviewerGroupScope `json:"scope"`
+	Users       []User             `json:"users"`
+}
+
+// ListProjectReviewerGroups returns the reviewer groups defined in a project's
+// settings. A limit of 0 returns all groups.
+func (c *Client) ListProjectReviewerGroups(ctx context.Context, projectKey string, limit int) ([]ProjectReviewerGroup, error) {
+	if projectKey == "" {
+		return nil, fmt.Errorf("project key is required")
+	}
+
+	const defaultPageSize = 25
+
+	var (
+		start = 0
+		found []ProjectReviewerGroup
+	)
+
+	for {
+		pageSize := defaultPageSize
+		if limit > 0 {
+			remaining := limit - len(found)
+			if remaining <= 0 {
+				break
+			}
+			if remaining < pageSize {
+				pageSize = remaining
+			}
+		}
+
+		path := fmt.Sprintf("/rest/api/1.0/projects/%s/settings/reviewer-groups?limit=%d&start=%d",
+			url.PathEscape(projectKey), pageSize, start)
+		req, err := c.http.NewRequest(ctx, "GET", path, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var resp paged[ProjectReviewerGroup]
+		if err := c.http.Do(req, &resp); err != nil {
+			return nil, err
+		}
+
+		found = append(found, resp.Values...)
+
+		if limit > 0 && len(found) >= limit {
+			found = found[:limit]
+			break
+		}
+
+		if resp.IsLastPage || len(resp.Values) == 0 {
+			break
+		}
+
+		start = resp.NextPageStart
+	}
+
+	return found, nil
+}
+
 // ListReviewerGroups returns reviewer groups associated with a repository's default reviewers.
 func (c *Client) ListReviewerGroups(ctx context.Context, projectKey, repoSlug string) ([]ReviewerGroup, error) {
 	if projectKey == "" || repoSlug == "" {

--- a/pkg/bbdc/reviewers_test.go
+++ b/pkg/bbdc/reviewers_test.go
@@ -114,6 +114,105 @@ func TestGetDefaultReviewersDataCenter8BranchAndTagRefs(t *testing.T) {
 	}
 }
 
+func TestListProjectReviewerGroups(t *testing.T) {
+	var requests []string
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		requests = append(requests, r.Method+" "+r.URL.Path+"?"+r.URL.RawQuery)
+
+		if r.URL.Path != "/rest/api/1.0/projects/PROJ/settings/reviewer-groups" {
+			http.NotFound(w, r)
+			return
+		}
+
+		switch r.URL.Query().Get("start") {
+		case "0":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"isLastPage":    false,
+				"nextPageStart": 1,
+				"values": []map[string]any{
+					{
+						"id":          7,
+						"name":        "backend-team",
+						"description": "Backend reviewers",
+						"scope":       map[string]any{"type": "PROJECT", "resourceId": 3},
+						"users": []map[string]any{
+							{"name": "alice", "slug": "alice", "id": 10, "displayName": "Alice"},
+						},
+					},
+				},
+			})
+		case "1":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"isLastPage": true,
+				"values": []map[string]any{
+					{"id": 8, "name": "frontend-team", "users": []map[string]any{}},
+				},
+			})
+		default:
+			t.Fatalf("unexpected start %q", r.URL.Query().Get("start"))
+		}
+	}))
+
+	groups, err := client.ListProjectReviewerGroups(context.Background(), "PROJ", 0)
+	if err != nil {
+		t.Fatalf("ListProjectReviewerGroups: %v", err)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("expected 2 requests, got %v", requests)
+	}
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(groups))
+	}
+	if groups[0].Name != "backend-team" || groups[0].ID != 7 {
+		t.Fatalf("unexpected first group: %#v", groups[0])
+	}
+	if groups[0].Scope.Type != "PROJECT" || groups[0].Scope.ResourceID != 3 {
+		t.Fatalf("unexpected scope: %#v", groups[0].Scope)
+	}
+	if len(groups[0].Users) != 1 || groups[0].Users[0].Name != "alice" {
+		t.Fatalf("unexpected users: %#v", groups[0].Users)
+	}
+	if groups[1].Name != "frontend-team" {
+		t.Fatalf("unexpected second group: %#v", groups[1])
+	}
+}
+
+func TestListProjectReviewerGroupsLimit(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if got := r.URL.Query().Get("limit"); got != "1" {
+			t.Fatalf("limit = %q, want 1", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"isLastPage": false,
+			"values": []map[string]any{
+				{"id": 1, "name": "one"},
+			},
+		})
+	}))
+
+	groups, err := client.ListProjectReviewerGroups(context.Background(), "PROJ", 1)
+	if err != nil {
+		t.Fatalf("ListProjectReviewerGroups: %v", err)
+	}
+	if len(groups) != 1 || groups[0].Name != "one" {
+		t.Fatalf("unexpected groups: %#v", groups)
+	}
+}
+
+func TestListProjectReviewerGroupsValidation(t *testing.T) {
+	client, err := bbdc.New(bbdc.Options{
+		BaseURL: "http://localhost", Username: "u", Token: "t",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.ListProjectReviewerGroups(context.Background(), "", 0); err == nil {
+		t.Error("expected error for empty project key")
+	}
+}
+
 func TestGetDefaultReviewersValidation(t *testing.T) {
 	client, err := bbdc.New(bbdc.Options{
 		BaseURL: "http://localhost", Username: "u", Token: "t",

--- a/pkg/bbdc/reviewers_test.go
+++ b/pkg/bbdc/reviewers_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/avivsinai/bitbucket-cli/pkg/bbdc"
@@ -150,7 +151,8 @@ func TestListProjectReviewerGroups(t *testing.T) {
 				},
 			})
 		default:
-			t.Fatalf("unexpected start %q", r.URL.Query().Get("start"))
+			t.Errorf("unexpected start %q", r.URL.Query().Get("start"))
+			http.Error(w, "unexpected start", http.StatusBadRequest)
 		}
 	}))
 
@@ -182,12 +184,14 @@ func TestListProjectReviewerGroupsLimit(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if got := r.URL.Query().Get("limit"); got != "1" {
-			t.Fatalf("limit = %q, want 1", got)
+			t.Errorf("limit = %q, want 1", got)
 		}
+		// Over-return to prove the client truncates to the requested limit.
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"isLastPage": false,
+			"isLastPage": true,
 			"values": []map[string]any{
 				{"id": 1, "name": "one"},
+				{"id": 2, "name": "two"},
 			},
 		})
 	}))
@@ -198,6 +202,27 @@ func TestListProjectReviewerGroupsLimit(t *testing.T) {
 	}
 	if len(groups) != 1 || groups[0].Name != "one" {
 		t.Fatalf("unexpected groups: %#v", groups)
+	}
+}
+
+func TestListProjectReviewerGroupsStalledPagination(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"isLastPage":    false,
+			"nextPageStart": 0,
+			"values": []map[string]any{
+				{"id": 1, "name": "one"},
+			},
+		})
+	}))
+
+	_, err := client.ListProjectReviewerGroups(context.Background(), "PROJ", 0)
+	if err == nil {
+		t.Fatal("expected error for non-advancing pagination")
+	}
+	if !strings.Contains(err.Error(), "did not advance") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/pkg/cmd/project/project.go
+++ b/pkg/cmd/project/project.go
@@ -31,6 +31,7 @@ other commands.`,
 	}
 
 	cmd.AddCommand(newListCmd(f))
+	cmd.AddCommand(newReviewerGroupsCmd(f))
 
 	return cmd
 }

--- a/pkg/cmd/project/project_test.go
+++ b/pkg/cmd/project/project_test.go
@@ -236,6 +236,25 @@ func TestProjectReviewerGroupsListProjectOverride(t *testing.T) {
 	}
 }
 
+func TestProjectReviewerGroupsListLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("limit"); got != "5" {
+			t.Errorf("limit = %q, want 5", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"isLastPage": true,
+			"values":     []any{},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	f, _, stderr := newTestFactory(dcConfig(srv.URL))
+	if err := runProjectCmd(t, f, "reviewer-groups", "list", "--limit", "5"); err != nil {
+		t.Fatalf("unexpected error: %v (stderr=%s)", err, stderr.String())
+	}
+}
+
 func TestProjectReviewerGroupsListEmpty(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/cmd/project/project_test.go
+++ b/pkg/cmd/project/project_test.go
@@ -171,3 +171,111 @@ func TestProjectListRejectsCloud(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
+
+func reviewerGroupsHandler(t *testing.T, wantProject string) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wantPath := "/rest/api/1.0/projects/" + wantProject + "/settings/reviewer-groups"
+		if r.URL.Path != wantPath {
+			t.Errorf("path = %q, want %q", r.URL.Path, wantPath)
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"isLastPage": true,
+			"values": []map[string]any{
+				{
+					"id":          7,
+					"name":        "backend-team",
+					"description": "  Backend reviewers  ",
+					"scope":       map[string]any{"type": "PROJECT", "resourceId": 3},
+					"users": []map[string]any{
+						{"name": "alice", "slug": "alice", "id": 10, "displayName": "Alice"},
+						{"name": "bob", "slug": "bob", "id": 20, "displayName": "Bob"},
+					},
+				},
+				{"id": 8, "name": "frontend-team"},
+			},
+		})
+	})
+}
+
+func TestProjectReviewerGroupsList(t *testing.T) {
+	srv := httptest.NewServer(reviewerGroupsHandler(t, "PROJ"))
+	t.Cleanup(srv.Close)
+
+	f, stdout, stderr := newTestFactory(dcConfig(srv.URL))
+	if err := runProjectCmd(t, f, "reviewer-groups", "list"); err != nil {
+		t.Fatalf("unexpected error: %v (stderr=%s)", err, stderr.String())
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "backend-team\t(id: 7, members: 2)") {
+		t.Errorf("expected backend-team row, got: %s", out)
+	}
+	// Description should be trimmed.
+	if !strings.Contains(out, "desc: Backend reviewers") {
+		t.Errorf("expected trimmed description, got: %s", out)
+	}
+	if !strings.Contains(out, "member: Alice (alice)") {
+		t.Errorf("expected Alice member line, got: %s", out)
+	}
+	if !strings.Contains(out, "frontend-team\t(id: 8, members: 0)") {
+		t.Errorf("expected frontend-team row, got: %s", out)
+	}
+}
+
+func TestProjectReviewerGroupsListProjectOverride(t *testing.T) {
+	srv := httptest.NewServer(reviewerGroupsHandler(t, "OTHER"))
+	t.Cleanup(srv.Close)
+
+	f, _, stderr := newTestFactory(dcConfig(srv.URL))
+	if err := runProjectCmd(t, f, "reviewer-groups", "list", "--project", "OTHER"); err != nil {
+		t.Fatalf("unexpected error: %v (stderr=%s)", err, stderr.String())
+	}
+}
+
+func TestProjectReviewerGroupsListEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"isLastPage": true,
+			"values":     []any{},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	f, stdout, _ := newTestFactory(dcConfig(srv.URL))
+	if err := runProjectCmd(t, f, "reviewer-groups", "list"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "No reviewer groups defined for project PROJ.") {
+		t.Errorf("expected empty message, got: %s", stdout.String())
+	}
+}
+
+func TestProjectReviewerGroupsListRequiresProject(t *testing.T) {
+	cfg := dcConfig("http://localhost")
+	cfg.Contexts["test"].ProjectKey = ""
+
+	f, _, _ := newTestFactory(cfg)
+	err := runProjectCmd(t, f, "reviewer-groups", "list")
+	if err == nil {
+		t.Fatal("expected error without project")
+	}
+	if !strings.Contains(err.Error(), "--project") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestProjectReviewerGroupsListRejectsCloud(t *testing.T) {
+	f, _, _ := newTestFactory(cloudConfig("http://localhost"))
+	err := runProjectCmd(t, f, "reviewer-groups", "list")
+	if err == nil {
+		t.Fatal("expected error on Cloud host")
+	}
+	if !strings.Contains(err.Error(), "Data Center") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/pkg/cmd/project/reviewergroups.go
+++ b/pkg/cmd/project/reviewergroups.go
@@ -38,19 +38,25 @@ type reviewerGroupsListOptions struct {
 }
 
 func newReviewerGroupsListCmd(f *cmdutil.Factory) *cobra.Command {
-	opts := &reviewerGroupsListOptions{}
+	opts := &reviewerGroupsListOptions{
+		Limit: 30,
+	}
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List project reviewer groups (DC only)",
 		Long: `List the reviewer groups defined in a Bitbucket Data Center project's
 settings, including each group's members. The project is resolved from the
-active context unless overridden with --project.
+active context unless overridden with --project. Use --limit to control the
+number of results returned.
 
 This command is only available for Data Center hosts. Attempting to run it
 against a Cloud context will return an error.`,
-		Example: `  # List reviewer groups for the active context project
+		Example: `  # List reviewer groups for the active context project (default limit of 30)
   bkt project reviewer-groups list
+
+  # List all reviewer groups without a limit
+  bkt project reviewer-groups ls --limit 0
 
   # List reviewer groups for a specific project
   bkt project reviewer-groups list --project PLATFORM

--- a/pkg/cmd/project/reviewergroups.go
+++ b/pkg/cmd/project/reviewergroups.go
@@ -1,0 +1,170 @@
+package project
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/avivsinai/bitbucket-cli/pkg/cmdutil"
+)
+
+func newReviewerGroupsCmd(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "reviewer-groups",
+		Aliases: []string{"reviewer-group"},
+		Short:   "Work with project reviewer groups (DC only)",
+		Long: `List the reviewer groups defined in a project's settings.
+
+Reviewer groups are named sets of users that can be added as default reviewers
+on repositories within the project. Data Center only.`,
+		Example: `  # List reviewer groups for the active context project
+  bkt project reviewer-groups list
+
+  # List reviewer groups for a specific project
+  bkt project reviewer-groups list --project PLATFORM`,
+	}
+
+	cmd.AddCommand(newReviewerGroupsListCmd(f))
+
+	return cmd
+}
+
+type reviewerGroupsListOptions struct {
+	Project string
+	Limit   int
+}
+
+func newReviewerGroupsListCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &reviewerGroupsListOptions{}
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List project reviewer groups (DC only)",
+		Long: `List the reviewer groups defined in a Bitbucket Data Center project's
+settings, including each group's members. The project is resolved from the
+active context unless overridden with --project.
+
+This command is only available for Data Center hosts. Attempting to run it
+against a Cloud context will return an error.`,
+		Example: `  # List reviewer groups for the active context project
+  bkt project reviewer-groups list
+
+  # List reviewer groups for a specific project
+  bkt project reviewer-groups list --project PLATFORM
+
+  # List reviewer groups in JSON format
+  bkt project reviewer-groups list --project PLATFORM --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runReviewerGroupsList(cmd, f, opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Project, "project", "", "Bitbucket project key override")
+	cmd.Flags().IntVar(&opts.Limit, "limit", opts.Limit, "Maximum reviewer groups to display (0 for all)")
+
+	return cmd
+}
+
+func runReviewerGroupsList(cmd *cobra.Command, f *cmdutil.Factory, opts *reviewerGroupsListOptions) error {
+	ios, err := f.Streams()
+	if err != nil {
+		return err
+	}
+
+	override := cmdutil.FlagValue(cmd, "context")
+	_, ctxCfg, host, err := cmdutil.ResolveContext(f, cmd, override)
+	if err != nil {
+		return err
+	}
+
+	if host.Kind != "dc" {
+		return fmt.Errorf("project reviewer groups are only supported for Bitbucket Data Center hosts")
+	}
+
+	projectKey := cmdutil.FirstNonEmpty(opts.Project, ctxCfg.ProjectKey)
+	if projectKey == "" {
+		return fmt.Errorf("context must supply a project; use --project if needed")
+	}
+
+	client, err := cmdutil.NewDCClient(host)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
+	defer cancel()
+
+	groups, err := client.ListProjectReviewerGroups(ctx, projectKey, opts.Limit)
+	if err != nil {
+		return err
+	}
+
+	type memberSummary struct {
+		DisplayName string `json:"display_name"`
+		Username    string `json:"username"`
+		ID          int    `json:"id"`
+	}
+
+	type groupSummary struct {
+		ID          int             `json:"id"`
+		Name        string          `json:"name"`
+		Description string          `json:"description,omitempty"`
+		Members     []memberSummary `json:"members"`
+	}
+
+	var summaries []groupSummary
+	for _, g := range groups {
+		var members []memberSummary
+		for _, u := range g.Users {
+			members = append(members, memberSummary{
+				DisplayName: u.FullName,
+				Username:    u.Name,
+				ID:          u.ID,
+			})
+		}
+		summaries = append(summaries, groupSummary{
+			ID:          g.ID,
+			Name:        g.Name,
+			Description: strings.TrimSpace(g.Description),
+			Members:     members,
+		})
+	}
+
+	payload := struct {
+		Project        string         `json:"project"`
+		ReviewerGroups []groupSummary `json:"reviewer_groups"`
+	}{
+		Project:        projectKey,
+		ReviewerGroups: summaries,
+	}
+
+	return cmdutil.WriteOutput(cmd, ios.Out, payload, func() error {
+		if len(summaries) == 0 {
+			_, err := fmt.Fprintf(ios.Out, "No reviewer groups defined for project %s.\n", projectKey)
+			return err
+		}
+
+		if _, err := fmt.Fprintf(ios.Out, "Reviewer groups for project %s:\n", projectKey); err != nil {
+			return err
+		}
+		for _, g := range summaries {
+			if _, err := fmt.Fprintf(ios.Out, "%s\t(id: %d, members: %d)\n", g.Name, g.ID, len(g.Members)); err != nil {
+				return err
+			}
+			if g.Description != "" {
+				if _, err := fmt.Fprintf(ios.Out, "    desc: %s\n", g.Description); err != nil {
+					return err
+				}
+			}
+			for _, m := range g.Members {
+				if _, err := fmt.Fprintf(ios.Out, "    member: %s (%s)\n", m.DisplayName, m.Username); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+}

--- a/skills/bkt/rules/project.md
+++ b/skills/bkt/rules/project.md
@@ -28,6 +28,7 @@ bkt project <command> [flags]
 | Subcommand | Description | Key Flags |
 |---|---|---|
 | [list](#bkt-project-list) | List Bitbucket Data Center projects *(DC)* | `--host`, `--limit` |
+| [reviewer-groups](#bkt-project-reviewer-groups) | Work with project reviewer groups *(DC)* | — |
 
 ## bkt project list
 
@@ -78,5 +79,80 @@ bkt project list [flags]
 
   # List projects in JSON format
   bkt project list --json
+```
+
+## bkt project reviewer-groups
+
+List the reviewer groups defined in a project's settings.
+
+Reviewer groups are named sets of users that can be added as default reviewers
+on repositories within the project. Data Center only.
+
+**Alias:** `reviewer-group`
+
+```
+bkt project reviewer-groups <command> [flags]
+```
+
+### Examples
+
+```bash
+# List reviewer groups for the active context project
+  bkt project reviewer-groups list
+
+  # List reviewer groups for a specific project
+  bkt project reviewer-groups list --project PLATFORM
+```
+
+| Subcommand | Description |
+|---|---|
+| list | List project reviewer groups (DC only) |
+
+## bkt project reviewer-groups list
+
+List the reviewer groups defined in a Bitbucket Data Center project's
+settings, including each group's members. The project is resolved from the
+active context unless overridden with --project.
+
+This command is only available for Data Center hosts. Attempting to run it
+against a Cloud context will return an error.
+
+**Alias:** `ls`
+
+### Usage
+
+```
+bkt project reviewer-groups list [flags]
+```
+
+### Flags
+
+| Flag | Short | Description |
+|---|---|---|
+| `--limit` |  | Maximum reviewer groups to display (0 for all) |
+| `--project` |  | Bitbucket project key override |
+
+### Inherited Flags
+
+| Flag | Short | Description |
+|---|---|---|
+| `--context` | `-c` | Active Bitbucket context name |
+| `--format` |  | Output format: json or yaml (alias for --json/--yaml) |
+| `--jq` |  | Apply a jq expression to JSON output (requires --json or --format json) |
+| `--json` |  | Output in JSON format when supported |
+| `--template` |  | Render output using Go templates |
+| `--yaml` |  | Output in YAML format when supported |
+
+### Examples
+
+```bash
+# List reviewer groups for the active context project
+  bkt project reviewer-groups list
+
+  # List reviewer groups for a specific project
+  bkt project reviewer-groups list --project PLATFORM
+
+  # List reviewer groups in JSON format
+  bkt project reviewer-groups list --project PLATFORM --json
 ```
 

--- a/skills/bkt/rules/project.md
+++ b/skills/bkt/rules/project.md
@@ -112,7 +112,8 @@ bkt project reviewer-groups <command> [flags]
 
 List the reviewer groups defined in a Bitbucket Data Center project's
 settings, including each group's members. The project is resolved from the
-active context unless overridden with --project.
+active context unless overridden with --project. Use --limit to control the
+number of results returned.
 
 This command is only available for Data Center hosts. Attempting to run it
 against a Cloud context will return an error.
@@ -146,8 +147,11 @@ bkt project reviewer-groups list [flags]
 ### Examples
 
 ```bash
-# List reviewer groups for the active context project
+# List reviewer groups for the active context project (default limit of 30)
   bkt project reviewer-groups list
+
+  # List all reviewer groups without a limit
+  bkt project reviewer-groups ls --limit 0
 
   # List reviewer groups for a specific project
   bkt project reviewer-groups list --project PLATFORM


### PR DESCRIPTION
## Summary

Adds first-class CLI support for the Bitbucket Data Center project settings reviewer-groups endpoint (`/rest/api/1.0/projects/{project}/settings/reviewer-groups`), closing #290:

- `bbdc.ListProjectReviewerGroups` with pagination, a non-advancing `nextPageStart` guard (matching the `tasks.go` precedent), and `limit` support
- `bkt project reviewer-groups list` (aliases: `reviewer-group`, `ls`) with `--project`/`--limit` flags, context-based project resolution, JSON/text output, and a DC-only guard
- Regenerated `skills/bkt/rules/project.md` docs and mirrors via `make generate-skill`

Closes #290

## Testing

- [x] `make fmt`
- [x] `make test`
- [x] `make build`
- [x] Other (please specify): `go vet ./...`, `./scripts/check-generated-skill.sh`, smoke-tested `bin/bkt project reviewer-groups list --help`

## Screenshots / recordings

Text output shape:

```
Reviewer groups for project PROJ:
backend-team	(id: 7, members: 2)
    desc: Backend reviewers
    member: Alice (alice)
    member: Bob (bob)
frontend-team	(id: 8, members: 0)
```

## Checklist

- [x] Adds or updates documentation
- [x] Updates `CHANGELOG.md`
- [ ] Signed commits (`git commit -s`)

## Notes for reviewers

- Pagination copies the `ListProjects` loop but adds the `nextPageStart <= start` advance guard already used in `pkg/bbdc/tasks.go` to prevent infinite loops/duplicates on misbehaving servers.
- `--limit` defaults to 30, matching `bkt project list` and other sibling list commands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYuxsW7LCtLik2fsSHHazM)_