### PR TITLE
feat(auth): support Cloud resource access tokens

### DIFF
--- a/.agents/skills/bkt/rules/headless.md
+++ b/.agents/skills/bkt/rules/headless.md
@@ -12,12 +12,18 @@ export BKT_PROJECT=MYPROJ   # optional default project
 export BKT_REPO=my-service  # optional default repo
 bkt pr list
 
-# Bitbucket Cloud — basic auth; username is required
+# Bitbucket Cloud user API token — basic auth; username is required
 export BKT_HOST=https://bitbucket.org
 export BKT_TOKEN=my-api-token
 export BKT_USERNAME=me@example.com
 export BKT_WORKSPACE=my-workspace
 export BKT_REPO=my-repo
+bkt pr list
+
+# Bitbucket Cloud repository/project/workspace access token — bearer auth
+export BKT_TOKEN=my-resource-access-token
+export BKT_AUTH_METHOD=bearer
+unset BKT_USERNAME
 bkt pr list
 ```
 
@@ -29,7 +35,9 @@ bkt pr list
 | DC, `BKT_USERNAME` set, no `BKT_AUTH_METHOD` | `basic` |
 | DC, `BKT_AUTH_METHOD=bearer` | `bearer` |
 | DC, `BKT_AUTH_METHOD=basic` + no `BKT_USERNAME` | **error** — set `BKT_USERNAME` |
-| Cloud | always `basic`; `BKT_USERNAME` is required |
+| Cloud, no `BKT_AUTH_METHOD` | `basic` (default); `BKT_USERNAME` is required |
+| Cloud, `BKT_AUTH_METHOD=basic` | `BKT_USERNAME` is required |
+| Cloud, `BKT_AUTH_METHOD=bearer` | bearer; `BKT_USERNAME` is not required |
 
 ## Environment variables
 
@@ -37,8 +45,8 @@ bkt pr list
 |---|---|
 | `BKT_TOKEN` | Authentication token. Bypasses keyring. |
 | `BKT_HOST` | Bitbucket server URL. Required with `BKT_TOKEN` for config-free use. |
-| `BKT_USERNAME` | Username for basic auth. Required for Cloud; optional for DC. |
-| `BKT_AUTH_METHOD` | Auth method: `basic` or `bearer`. DC defaults to `bearer` when no username is set. |
+| `BKT_USERNAME` | Username for basic auth. Required for Cloud basic auth; optional for DC and Cloud bearer auth. |
+| `BKT_AUTH_METHOD` | Auth method: `basic` or `bearer`. DC defaults to `bearer` when no username is set; Cloud defaults to `basic`. Use `bearer` for Cloud repository, project, or workspace access tokens. |
 | `BKT_PROJECT` | Default Data Center project key. |
 | `BKT_WORKSPACE` | Default Bitbucket Cloud workspace. |
 | `BKT_REPO` | Default repository slug. |
@@ -51,6 +59,10 @@ bkt pr list
 ## Saved-host behaviour
 
 When `BKT_HOST` matches a host already in `~/.config/bkt/config.yml`, the saved entry is used as the base (preserving fields like `username` and `auth_method`). `BKT_TOKEN` always overrides the stored token. `BKT_USERNAME` and `BKT_AUTH_METHOD`, when set, override the saved values.
+
+Cloud resource access tokens are not associated with a user. Commands that
+require authenticated-user identity, such as cross-repository
+`bkt pr list --mine`, still require user API-token or OAuth credentials.
 
 ## Bitbucket Pipelines example
 

--- a/.claude/skills/bkt/rules/headless.md
+++ b/.claude/skills/bkt/rules/headless.md
@@ -12,12 +12,18 @@ export BKT_PROJECT=MYPROJ   # optional default project
 export BKT_REPO=my-service  # optional default repo
 bkt pr list
 
-# Bitbucket Cloud — basic auth; username is required
+# Bitbucket Cloud user API token — basic auth; username is required
 export BKT_HOST=https://bitbucket.org
 export BKT_TOKEN=my-api-token
 export BKT_USERNAME=me@example.com
 export BKT_WORKSPACE=my-workspace
 export BKT_REPO=my-repo
+bkt pr list
+
+# Bitbucket Cloud repository/project/workspace access token — bearer auth
+export BKT_TOKEN=my-resource-access-token
+export BKT_AUTH_METHOD=bearer
+unset BKT_USERNAME
 bkt pr list
 ```
 
@@ -29,7 +35,9 @@ bkt pr list
 | DC, `BKT_USERNAME` set, no `BKT_AUTH_METHOD` | `basic` |
 | DC, `BKT_AUTH_METHOD=bearer` | `bearer` |
 | DC, `BKT_AUTH_METHOD=basic` + no `BKT_USERNAME` | **error** — set `BKT_USERNAME` |
-| Cloud | always `basic`; `BKT_USERNAME` is required |
+| Cloud, no `BKT_AUTH_METHOD` | `basic` (default); `BKT_USERNAME` is required |
+| Cloud, `BKT_AUTH_METHOD=basic` | `BKT_USERNAME` is required |
+| Cloud, `BKT_AUTH_METHOD=bearer` | bearer; `BKT_USERNAME` is not required |
 
 ## Environment variables
 
@@ -37,8 +45,8 @@ bkt pr list
 |---|---|
 | `BKT_TOKEN` | Authentication token. Bypasses keyring. |
 | `BKT_HOST` | Bitbucket server URL. Required with `BKT_TOKEN` for config-free use. |
-| `BKT_USERNAME` | Username for basic auth. Required for Cloud; optional for DC. |
-| `BKT_AUTH_METHOD` | Auth method: `basic` or `bearer`. DC defaults to `bearer` when no username is set. |
+| `BKT_USERNAME` | Username for basic auth. Required for Cloud basic auth; optional for DC and Cloud bearer auth. |
+| `BKT_AUTH_METHOD` | Auth method: `basic` or `bearer`. DC defaults to `bearer` when no username is set; Cloud defaults to `basic`. Use `bearer` for Cloud repository, project, or workspace access tokens. |
 | `BKT_PROJECT` | Default Data Center project key. |
 | `BKT_WORKSPACE` | Default Bitbucket Cloud workspace. |
 | `BKT_REPO` | Default repository slug. |
@@ -51,6 +59,10 @@ bkt pr list
 ## Saved-host behaviour
 
 When `BKT_HOST` matches a host already in `~/.config/bkt/config.yml`, the saved entry is used as the base (preserving fields like `username` and `auth_method`). `BKT_TOKEN` always overrides the stored token. `BKT_USERNAME` and `BKT_AUTH_METHOD`, when set, override the saved values.
+
+Cloud resource access tokens are not associated with a user. Commands that
+require authenticated-user identity, such as cross-repository
+`bkt pr list --mine`, still require user API-token or OAuth credentials.
 
 ## Bitbucket Pipelines example
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+- Headless Bitbucket Cloud authentication now supports repository, project,
+  and workspace access tokens through `BKT_AUTH_METHOD=bearer` without
+  requiring `BKT_USERNAME`.
+
 ## [0.31.0] - 2026-08-12
 ### Added
 - `bkt project reviewer-groups list` lists the reviewer groups defined in a

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ All `bkt` behaviour can be configured via environment variables, which is especi
 |---|---|
 | `BKT_TOKEN` | Authentication token. Bypasses keyring storage entirely. |
 | `BKT_HOST` | Bitbucket server base URL (e.g. `https://bitbucket.example.com`). Required alongside `BKT_TOKEN` for config-free use. `bitbucket.org` is auto-detected as Cloud. |
-| `BKT_USERNAME` | Username for basic authentication in headless mode. |
-| `BKT_AUTH_METHOD` | Authentication method: `basic` or `bearer`. DC defaults to `bearer` when `BKT_USERNAME` is absent; Cloud always uses `basic`. |
+| `BKT_USERNAME` | Username for basic authentication in headless mode. Required for Cloud basic auth; not required for bearer auth. |
+| `BKT_AUTH_METHOD` | Authentication method: `basic` or `bearer`. DC defaults to `bearer` when `BKT_USERNAME` is absent; Cloud defaults to `basic`. Use `bearer` for Cloud repository, project, or workspace access tokens. |
 | `BKT_PROJECT` | Default Data Center project key (headless mode). |
 | `BKT_WORKSPACE` | Default Bitbucket Cloud workspace (headless mode). |
 | `BKT_REPO` | Default repository slug (headless mode). |
@@ -115,6 +115,7 @@ bkt pr create --title "Automated PR" --source feature/my-branch
 **Minimal headless example (Bitbucket Cloud):**
 
 ```bash
+# User API token — basic auth
 export BKT_HOST=https://bitbucket.org
 export BKT_TOKEN=my-api-token
 export BKT_USERNAME=me@example.com
@@ -122,7 +123,18 @@ export BKT_WORKSPACE=my-workspace
 export BKT_REPO=my-repo
 
 bkt pr list
+
+# Repository, project, or workspace access token — bearer auth
+export BKT_TOKEN=my-resource-access-token
+export BKT_AUTH_METHOD=bearer
+unset BKT_USERNAME
+
+bkt pr list
 ```
+
+Resource access tokens are not associated with a user. Commands that require
+authenticated-user identity, such as cross-repository `bkt pr list --mine`,
+still require user API-token or OAuth credentials.
 
 ### From Source
 

--- a/pkg/cmdutil/client.go
+++ b/pkg/cmdutil/client.go
@@ -77,6 +77,9 @@ func newCloudClient(host *config.Host, enableOAuthRefresh bool) (*bbcloud.Client
 		},
 	}
 
+	if host.AuthMethod != "oauth" {
+		opts.AuthMethod = host.AuthMethod
+	}
 	if host.AuthMethod == "oauth" && (!enableOAuthRefresh || secret.TokenFromEnv() == "") {
 		opts.AuthMethod = "bearer"
 	}

--- a/pkg/cmdutil/client_test.go
+++ b/pkg/cmdutil/client_test.go
@@ -34,6 +34,27 @@ func TestNewCloudClientBasicAuth(t *testing.T) {
 	}
 }
 
+func TestNewCloudClientBearerAuth(t *testing.T) {
+	host := &config.Host{
+		Kind:       "cloud",
+		BaseURL:    "https://api.bitbucket.org/2.0",
+		AuthMethod: "bearer",
+		Token:      "repository-access-token",
+	}
+
+	client, err := NewCloudClient(host)
+	if err != nil {
+		t.Fatalf("NewCloudClient error: %v", err)
+	}
+	req, err := client.HTTP().NewRequest(context.Background(), http.MethodGet, "/repositories/team/repo", nil)
+	if err != nil {
+		t.Fatalf("NewRequest error: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer repository-access-token" {
+		t.Errorf("Authorization = %q, want bearer repository access token", got)
+	}
+}
+
 func TestNewCloudClientOAuthWiresRefresher(t *testing.T) {
 	host := &config.Host{
 		Kind:       "cloud",
@@ -72,6 +93,14 @@ func TestNewCloudClientOAuthSkipsRefresherWithBKTToken(t *testing.T) {
 	}
 	if client == nil {
 		t.Fatal("expected client, got nil")
+	}
+	req, err := client.HTTP().NewRequest(context.Background(), http.MethodGet, "/user", nil)
+	if err != nil {
+		t.Fatalf("NewRequest error: %v", err)
+	}
+	username, token, ok := req.BasicAuth()
+	if !ok || username != "erank_ai21" || token != "env-override" {
+		t.Errorf("BasicAuth = (%q, %q, %t), want OAuth host env override as basic auth", username, token, ok)
 	}
 }
 

--- a/pkg/cmdutil/context.go
+++ b/pkg/cmdutil/context.go
@@ -251,7 +251,7 @@ func mergeEnvHost(executable, key string, base config.Host) (*config.Host, error
 	if u := strings.TrimSpace(os.Getenv(secret.EnvUsername)); u != "" {
 		h.Username = u
 	}
-	if m := strings.TrimSpace(os.Getenv(secret.EnvAuthMethod)); m != "" {
+	if m := strings.ToLower(strings.TrimSpace(os.Getenv(secret.EnvAuthMethod))); m != "" {
 		h.AuthMethod = m
 	}
 	return &h, nil
@@ -268,14 +268,16 @@ func loadHostToken(executable, hostKey string, host *config.Host) error {
 		host.Token = envToken
 		// Apply BKT_USERNAME and BKT_AUTH_METHOD so that OAuth-saved hosts
 		// (where Username is a Bitbucket ID, not an email) work correctly
-		// when overridden with a Cloud API token.
+		// when overridden with a Cloud API token or resource access token.
+		requiresCloudUsername := host.AuthMethod == "oauth" && host.Kind == "cloud"
+		if m := strings.ToLower(strings.TrimSpace(os.Getenv(secret.EnvAuthMethod))); m != "" {
+			host.AuthMethod = m
+			requiresCloudUsername = requiresCloudUsername && m != "bearer"
+		}
 		if u := strings.TrimSpace(os.Getenv(secret.EnvUsername)); u != "" {
 			host.Username = u
-		} else if host.AuthMethod == "oauth" && host.Kind == "cloud" {
+		} else if requiresCloudUsername {
 			return fmt.Errorf("BKT_USERNAME is required when overriding an OAuth-authenticated Cloud host with BKT_TOKEN; set BKT_USERNAME to your Atlassian account email")
-		}
-		if m := strings.TrimSpace(os.Getenv(secret.EnvAuthMethod)); m != "" {
-			host.AuthMethod = m
 		}
 		return nil
 	}
@@ -388,15 +390,20 @@ func hostFromEnv(rawURL string) (string, *config.Host, error) {
 	}
 
 	username := strings.TrimSpace(os.Getenv(secret.EnvUsername))
-	authMethod := strings.TrimSpace(os.Getenv(secret.EnvAuthMethod))
+	authMethod := strings.ToLower(strings.TrimSpace(os.Getenv(secret.EnvAuthMethod)))
 
 	if isCloud {
-		// Cloud only supports basic auth; a username (Atlassian account email)
-		// is always required.
-		if username == "" {
+		// User API tokens use basic auth with an Atlassian account email, while
+		// repository, project, and workspace access tokens use bearer auth.
+		if authMethod == "" {
+			authMethod = "basic"
+		}
+		if authMethod != "basic" && authMethod != "bearer" {
+			return "", nil, fmt.Errorf("unsupported BKT_AUTH_METHOD %q; use basic or bearer", authMethod)
+		}
+		if authMethod == "basic" && username == "" {
 			return "", nil, fmt.Errorf("BKT_USERNAME is required for Bitbucket Cloud; set it to your Atlassian account email")
 		}
-		authMethod = "basic"
 	} else {
 		// DC: default to bearer when no username is available so that PAT-only
 		// headless flows work without requiring BKT_AUTH_METHOD=bearer.

--- a/pkg/cmdutil/context_test.go
+++ b/pkg/cmdutil/context_test.go
@@ -383,6 +383,27 @@ func TestHostFromEnv(t *testing.T) {
 			token:   "cloud-token",
 			wantErr: "BKT_USERNAME",
 		},
+		{
+			name:       "Cloud bearer without username is supported",
+			rawURL:     "https://bitbucket.org",
+			token:      "repository-access-token",
+			authMethod: "bearer",
+			wantHost:   &hostAssert{key: "api.bitbucket.org", kind: "cloud", authMethod: "bearer"},
+		},
+		{
+			name:       "Cloud bearer auth method is normalized",
+			rawURL:     "https://bitbucket.org",
+			token:      "repository-access-token",
+			authMethod: " BEARER ",
+			wantHost:   &hostAssert{key: "api.bitbucket.org", kind: "cloud", authMethod: "bearer"},
+		},
+		{
+			name:       "Cloud rejects unsupported auth method",
+			rawURL:     "https://bitbucket.org",
+			token:      "cloud-token",
+			authMethod: "digest",
+			wantErr:    "unsupported BKT_AUTH_METHOD",
+		},
 	}
 
 	for _, tt := range tests {
@@ -909,6 +930,50 @@ func TestLoadHostTokenOAuthRequiresBKTUsername(t *testing.T) {
 	err := loadHostToken("bkt", "api.bitbucket.org", host)
 	if err == nil {
 		t.Fatal("expected error for OAuth host without BKT_USERNAME")
+	}
+	if !strings.Contains(err.Error(), "BKT_USERNAME") {
+		t.Errorf("error = %v, want BKT_USERNAME mention", err)
+	}
+}
+
+func TestLoadHostTokenOAuthOverrideAcceptsCloudBearerWithoutUsername(t *testing.T) {
+	t.Setenv(secret.EnvToken, "repository-access-token")
+	t.Setenv(secret.EnvUsername, "")
+	t.Setenv(secret.EnvAuthMethod, " BEARER ")
+
+	host := &config.Host{
+		Kind:       "cloud",
+		BaseURL:    "https://api.bitbucket.org/2.0",
+		Username:   "old-oauth-user",
+		AuthMethod: "oauth",
+	}
+
+	if err := loadHostToken("bkt", "api.bitbucket.org", host); err != nil {
+		t.Fatalf("loadHostToken error: %v", err)
+	}
+	if host.Token != "repository-access-token" {
+		t.Errorf("Token = %q, want repository-access-token", host.Token)
+	}
+	if host.AuthMethod != "bearer" {
+		t.Errorf("AuthMethod = %q, want bearer", host.AuthMethod)
+	}
+}
+
+func TestLoadHostTokenOAuthBasicOverrideStillRequiresBKTUsername(t *testing.T) {
+	t.Setenv(secret.EnvToken, "api-token")
+	t.Setenv(secret.EnvUsername, "")
+	t.Setenv(secret.EnvAuthMethod, "basic")
+
+	host := &config.Host{
+		Kind:       "cloud",
+		BaseURL:    "https://api.bitbucket.org/2.0",
+		Username:   "old-oauth-user",
+		AuthMethod: "oauth",
+	}
+
+	err := loadHostToken("bkt", "api.bitbucket.org", host)
+	if err == nil {
+		t.Fatal("expected error for basic override without BKT_USERNAME")
 	}
 	if !strings.Contains(err.Error(), "BKT_USERNAME") {
 		t.Errorf("error = %v, want BKT_USERNAME mention", err)

--- a/skills/bkt/rules/headless.md
+++ b/skills/bkt/rules/headless.md
@@ -12,12 +12,18 @@ export BKT_PROJECT=MYPROJ   # optional default project
 export BKT_REPO=my-service  # optional default repo
 bkt pr list
 
-# Bitbucket Cloud — basic auth; username is required
+# Bitbucket Cloud user API token — basic auth; username is required
 export BKT_HOST=https://bitbucket.org
 export BKT_TOKEN=my-api-token
 export BKT_USERNAME=me@example.com
 export BKT_WORKSPACE=my-workspace
 export BKT_REPO=my-repo
+bkt pr list
+
+# Bitbucket Cloud repository/project/workspace access token — bearer auth
+export BKT_TOKEN=my-resource-access-token
+export BKT_AUTH_METHOD=bearer
+unset BKT_USERNAME
 bkt pr list
 ```
 
@@ -29,7 +35,9 @@ bkt pr list
 | DC, `BKT_USERNAME` set, no `BKT_AUTH_METHOD` | `basic` |
 | DC, `BKT_AUTH_METHOD=bearer` | `bearer` |
 | DC, `BKT_AUTH_METHOD=basic` + no `BKT_USERNAME` | **error** — set `BKT_USERNAME` |
-| Cloud | always `basic`; `BKT_USERNAME` is required |
+| Cloud, no `BKT_AUTH_METHOD` | `basic` (default); `BKT_USERNAME` is required |
+| Cloud, `BKT_AUTH_METHOD=basic` | `BKT_USERNAME` is required |
+| Cloud, `BKT_AUTH_METHOD=bearer` | bearer; `BKT_USERNAME` is not required |
 
 ## Environment variables
 
@@ -37,8 +45,8 @@ bkt pr list
 |---|---|
 | `BKT_TOKEN` | Authentication token. Bypasses keyring. |
 | `BKT_HOST` | Bitbucket server URL. Required with `BKT_TOKEN` for config-free use. |
-| `BKT_USERNAME` | Username for basic auth. Required for Cloud; optional for DC. |
-| `BKT_AUTH_METHOD` | Auth method: `basic` or `bearer`. DC defaults to `bearer` when no username is set. |
+| `BKT_USERNAME` | Username for basic auth. Required for Cloud basic auth; optional for DC and Cloud bearer auth. |
+| `BKT_AUTH_METHOD` | Auth method: `basic` or `bearer`. DC defaults to `bearer` when no username is set; Cloud defaults to `basic`. Use `bearer` for Cloud repository, project, or workspace access tokens. |
 | `BKT_PROJECT` | Default Data Center project key. |
 | `BKT_WORKSPACE` | Default Bitbucket Cloud workspace. |
 | `BKT_REPO` | Default repository slug. |
@@ -51,6 +59,10 @@ bkt pr list
 ## Saved-host behaviour
 
 When `BKT_HOST` matches a host already in `~/.config/bkt/config.yml`, the saved entry is used as the base (preserving fields like `username` and `auth_method`). `BKT_TOKEN` always overrides the stored token. `BKT_USERNAME` and `BKT_AUTH_METHOD`, when set, override the saved values.
+
+Cloud resource access tokens are not associated with a user. Commands that
+require authenticated-user identity, such as cross-repository
+`bkt pr list --mine`, still require user API-token or OAuth credentials.
 
 ## Bitbucket Pipelines example
 


### PR DESCRIPTION
## Summary

- Allow headless Bitbucket Cloud authentication with
  `BKT_AUTH_METHOD=bearer`.
- Do not require `BKT_USERNAME` when Bearer authentication is selected.
- Forward the configured authentication method to the Cloud HTTP client.
- Preserve Cloud Basic authentication defaults and existing OAuth behavior.
- Document resource-token configuration and identity-related limitations.
- Update the canonical headless skill documentation and its generated mirrors.

Bitbucket Cloud repository, project, and workspace access tokens must be sent
as Bearer tokens. They are not associated with an Atlassian user, so requiring
a username prevents these tokens from being used by automated `bkt` processes.

Atlassian documentation:
https://support.atlassian.com/bitbucket-cloud/docs/using-access-tokens/

Closes #293

## Testing

- [x] `make fmt`
- [x] `make test`
- [x] `make build`
- [x] Other: `make check-skills`, `go vet ./...`, and
  `make check-generated-skill`
- [x] Read-only live validation using a Bitbucket repository access token:
  `pr list`, `pr view`, `pr checks`, and `pr comments`

## Screenshots / recordings

Not applicable; this changes headless authentication behavior without visual
CLI output changes.

## Checklist

- [x] Adds or updates documentation
- [x] Updates `CHANGELOG.md`
- [x] Signed commits (`git commit -s`)

## Notes for reviewers

Cloud Basic authentication remains the default, and the existing OAuth refresh
path is unchanged. Resource access tokens do not represent a normal user, so
commands requiring authenticated-user identity, such as cross-repository
`bkt pr list --mine`, remain unavailable with these credentials.
