### PR TITLE
fix: chunk WinCred secrets that exceed the 2560-byte blob limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ All notable changes to this project will be documented here. The format follows
   `bkt --help` session (`docs/demo.gif` and `docs/demo.svg`). No
   credentials are used.
 
+### Fixed
+- Windows Cloud `--web` login now stores OAuth credentials that exceed
+  Windows Credential Manager's 2560-byte blob limit by splitting the
+  secret across multiple WinCred items. Token refresh write-back uses the
+  same store. The default Windows path stays WinCred; oversized writes
+  never fall back to the encrypted file backend. (#298)
+
 ## [0.31.0] - 2026-08-12
 ### Added
 - `bkt project reviewer-groups list` lists the reviewer groups defined in a

--- a/internal/secret/chunk.go
+++ b/internal/secret/chunk.go
@@ -1,0 +1,198 @@
+package secret
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/99designs/keyring"
+)
+
+// winCredMaxBlobSize is CRED_MAX_CREDENTIAL_BLOB_SIZE (5 * 512).
+// A single CredWriteW payload larger than this fails with RPC_X_BAD_STUB_DATA
+// ("The stub received bad data.").
+const winCredMaxBlobSize = 2560
+
+const (
+	chunkedHeaderPrefix = "bkt.chunked.v1:"
+	chunkKeySep         = "#c"
+	maxSecretChunks     = 256
+)
+
+// errSecretChunkTooLarge is returned when a single keyring write would exceed
+// the backend blob limit. Callers must not fall back to the file backend.
+var errSecretChunkTooLarge = errors.New("secret chunk exceeds backend blob size limit")
+
+func chunkSizeForBackends(backends []keyring.BackendType) int {
+	for _, backend := range backends {
+		if backend == keyring.WinCredBackend {
+			return winCredMaxBlobSize
+		}
+	}
+	return 0
+}
+
+func chunkKey(key string, i int) string {
+	return key + chunkKeySep + strconv.Itoa(i)
+}
+
+func encodeChunkHeader(n int) []byte {
+	return []byte(chunkedHeaderPrefix + strconv.Itoa(n))
+}
+
+// parseChunkHeader returns the chunk count when data is a chunked-secret
+// header. A count of 0 means data is a regular (unchunked) value.
+func parseChunkHeader(data []byte) (int, error) {
+	s := string(data)
+	if !strings.HasPrefix(s, chunkedHeaderPrefix) {
+		return 0, nil
+	}
+	n, err := strconv.Atoi(s[len(chunkedHeaderPrefix):])
+	if err != nil || n < 1 || n > maxSecretChunks {
+		return 0, fmt.Errorf("invalid chunked secret header")
+	}
+	return n, nil
+}
+
+func splitChunks(data []byte, size int) [][]byte {
+	if len(data) == 0 {
+		return [][]byte{data}
+	}
+	if size <= 0 {
+		return [][]byte{data}
+	}
+	n := (len(data) + size - 1) / size
+	out := make([][]byte, 0, n)
+	for len(data) > 0 {
+		if size > len(data) {
+			size = len(data)
+		}
+		out = append(out, data[:size])
+		data = data[size:]
+	}
+	return out
+}
+
+func (s *Store) writeItem(key string, data []byte) error {
+	if s.maxChunkSize > 0 && len(data) > s.maxChunkSize {
+		return fmt.Errorf("%w: %d bytes (limit %d)", errSecretChunkTooLarge, len(data), s.maxChunkSize)
+	}
+	return s.kr.Set(keyring.Item{
+		Key:   key,
+		Data:  data,
+		Label: fmt.Sprintf("bkt %s", key),
+	})
+}
+
+func (s *Store) setValue(key, value string) error {
+	data := []byte(value)
+	limit := s.maxChunkSize
+	if limit <= 0 || len(data) <= limit {
+		if err := s.writeItem(key, data); err != nil {
+			return err
+		}
+		if s.maxChunkSize > 0 {
+			return s.removeChunksFrom(key, 0)
+		}
+		return nil
+	}
+
+	chunks := splitChunks(data, limit)
+	if len(chunks) > maxSecretChunks {
+		return fmt.Errorf("%w: value needs %d chunks (limit %d)", errSecretChunkTooLarge, len(chunks), maxSecretChunks)
+	}
+
+	for i, chunk := range chunks {
+		if err := s.writeItem(chunkKey(key, i), chunk); err != nil {
+			return err
+		}
+	}
+	if err := s.writeItem(key, encodeChunkHeader(len(chunks))); err != nil {
+		return err
+	}
+	return s.removeChunksFrom(key, len(chunks))
+}
+
+func (s *Store) getValue(key string) (string, error) {
+	item, err := s.kr.Get(key)
+	if err != nil {
+		return "", err
+	}
+
+	n, err := parseChunkHeader(item.Data)
+	if err != nil {
+		return "", err
+	}
+	if n == 0 {
+		return string(item.Data), nil
+	}
+
+	var buf []byte
+	for i := 0; i < n; i++ {
+		part, getErr := s.kr.Get(chunkKey(key, i))
+		if getErr != nil {
+			return "", fmt.Errorf("read secret chunk %d: %w", i, getErr)
+		}
+		buf = append(buf, part.Data...)
+	}
+	return string(buf), nil
+}
+
+func (s *Store) deleteValue(key string) error {
+	n := 0
+	if item, err := s.kr.Get(key); err == nil {
+		count, parseErr := parseChunkHeader(item.Data)
+		if parseErr == nil {
+			n = count
+		}
+	}
+
+	if n > 0 {
+		if err := s.removeKnownChunks(key, n); err != nil {
+			return err
+		}
+	} else if s.maxChunkSize > 0 {
+		if err := s.removeChunksFrom(key, 0); err != nil {
+			return err
+		}
+	}
+
+	err := s.kr.Remove(key)
+	if err == nil || errors.Is(err, keyring.ErrKeyNotFound) || errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+func (s *Store) removeKnownChunks(key string, n int) error {
+	var first error
+	for i := 0; i < n; i++ {
+		if err := ignoreMissing(s.kr.Remove(chunkKey(key, i))); err != nil && first == nil {
+			first = err
+		}
+	}
+	return first
+}
+
+func (s *Store) removeChunksFrom(key string, start int) error {
+	for i := start; i < maxSecretChunks; i++ {
+		err := s.kr.Remove(chunkKey(key, i))
+		if err == nil {
+			continue
+		}
+		if errors.Is(err, keyring.ErrKeyNotFound) || errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func ignoreMissing(err error) error {
+	if err == nil || errors.Is(err, keyring.ErrKeyNotFound) || errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}

--- a/internal/secret/chunk_test.go
+++ b/internal/secret/chunk_test.go
@@ -1,0 +1,316 @@
+package secret
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/99designs/keyring"
+)
+
+type recordedWrite struct {
+	key  string
+	size int
+}
+
+// memoryKeyring is an in-memory keyring that rejects blobs larger than limit,
+// standing in for WinCred's CRED_MAX_CREDENTIAL_BLOB_SIZE check.
+type memoryKeyring struct {
+	items map[string][]byte
+	limit int
+	sets  []recordedWrite
+}
+
+func newMemoryKeyring(limit int) *memoryKeyring {
+	return &memoryKeyring{items: make(map[string][]byte), limit: limit}
+}
+
+func (m *memoryKeyring) Get(key string) (keyring.Item, error) {
+	data, ok := m.items[key]
+	if !ok {
+		return keyring.Item{}, keyring.ErrKeyNotFound
+	}
+	return keyring.Item{Key: key, Data: append([]byte(nil), data...)}, nil
+}
+
+func (m *memoryKeyring) GetMetadata(string) (keyring.Metadata, error) {
+	return keyring.Metadata{}, keyring.ErrMetadataNotSupported
+}
+
+func (m *memoryKeyring) Set(item keyring.Item) error {
+	m.sets = append(m.sets, recordedWrite{key: item.Key, size: len(item.Data)})
+	if m.limit > 0 && len(item.Data) > m.limit {
+		return errors.New("The stub received bad data")
+	}
+	m.items[item.Key] = append([]byte(nil), item.Data...)
+	return nil
+}
+
+func (m *memoryKeyring) Remove(key string) error {
+	if _, ok := m.items[key]; !ok {
+		return keyring.ErrKeyNotFound
+	}
+	delete(m.items, key)
+	return nil
+}
+
+func (m *memoryKeyring) Keys() ([]string, error) {
+	keys := make([]string, 0, len(m.items))
+	for k := range m.items {
+		keys = append(keys, k)
+	}
+	return keys, nil
+}
+
+func winCredStore(kr *memoryKeyring) *Store {
+	return &Store{kr: kr, maxChunkSize: winCredMaxBlobSize}
+}
+
+func TestSplitChunks(t *testing.T) {
+	t.Parallel()
+
+	got := splitChunks(bytes.Repeat([]byte("a"), 5558), winCredMaxBlobSize)
+	if len(got) != 3 {
+		t.Fatalf("chunks = %d, want 3", len(got))
+	}
+	if len(got[0]) != winCredMaxBlobSize || len(got[1]) != winCredMaxBlobSize {
+		t.Fatalf("full chunks = %d, %d, want %d", len(got[0]), len(got[1]), winCredMaxBlobSize)
+	}
+	if len(got[2]) != 5558-2*winCredMaxBlobSize {
+		t.Fatalf("tail chunk = %d, want %d", len(got[2]), 5558-2*winCredMaxBlobSize)
+	}
+	for i, chunk := range got {
+		if len(chunk) > winCredMaxBlobSize {
+			t.Fatalf("chunk %d is %d bytes, exceeds %d", i, len(chunk), winCredMaxBlobSize)
+		}
+	}
+}
+
+func TestStoreRoundTripOversizedBlob(t *testing.T) {
+	kr := newMemoryKeyring(winCredMaxBlobSize)
+	store := winCredStore(kr)
+	key := TokenKey("bitbucket.org")
+	want := strings.Repeat("A", 5558)
+
+	if err := store.Set(key, want); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	for _, w := range kr.sets {
+		if w.size > winCredMaxBlobSize {
+			t.Fatalf("wrote %q at %d bytes; CredWriteW limit is %d", w.key, w.size, winCredMaxBlobSize)
+		}
+	}
+	if len(kr.items) < 2 {
+		t.Fatalf("expected chunked write, got %d items", len(kr.items))
+	}
+
+	got, err := store.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != want {
+		t.Fatalf("Get reconstructed %d bytes, want %d", len(got), len(want))
+	}
+}
+
+func TestStoreExactLimitIsSingleItem(t *testing.T) {
+	kr := newMemoryKeyring(winCredMaxBlobSize)
+	store := winCredStore(kr)
+	key := TokenKey("bitbucket.org")
+	want := strings.Repeat("B", winCredMaxBlobSize)
+
+	if err := store.Set(key, want); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if _, ok := kr.items[key]; !ok {
+		t.Fatal("expected primary key")
+	}
+	if _, ok := kr.items[chunkKey(key, 0)]; ok {
+		t.Fatal("value at the blob limit must not be chunked")
+	}
+
+	got, err := store.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != want {
+		t.Fatalf("Get = %d bytes, want %d", len(got), len(want))
+	}
+}
+
+func TestStoreSmallValueUnchunked(t *testing.T) {
+	kr := newMemoryKeyring(winCredMaxBlobSize)
+	store := winCredStore(kr)
+	key := TokenKey("bitbucket.org")
+	const want = "scoped-api-token"
+
+	if err := store.Set(key, want); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if len(kr.items) != 1 {
+		t.Fatalf("small value should write one item, got %d", len(kr.items))
+	}
+
+	got, err := store.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != want {
+		t.Fatalf("Get = %q, want %q", got, want)
+	}
+}
+
+func TestStoreDeleteRemovesAllChunks(t *testing.T) {
+	kr := newMemoryKeyring(winCredMaxBlobSize)
+	store := winCredStore(kr)
+	key := TokenKey("bitbucket.org")
+
+	if err := store.Set(key, strings.Repeat("C", 5558)); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := store.Delete(key); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if len(kr.items) != 0 {
+		t.Fatalf("Delete left %d items: %v", len(kr.items), keysOf(kr))
+	}
+	if _, err := store.Get(key); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Get after Delete: %v, want os.ErrNotExist", err)
+	}
+}
+
+func keysOf(kr *memoryKeyring) []string {
+	keys, _ := kr.Keys()
+	return keys
+}
+
+func TestStoreDeleteMissingIsOK(t *testing.T) {
+	kr := newMemoryKeyring(winCredMaxBlobSize)
+	store := winCredStore(kr)
+	if err := store.Delete(TokenKey("bitbucket.org")); err != nil {
+		t.Fatalf("Delete missing: %v", err)
+	}
+}
+
+func TestStoreOverwriteLargeWithSmallClearsChunks(t *testing.T) {
+	kr := newMemoryKeyring(winCredMaxBlobSize)
+	store := winCredStore(kr)
+	key := TokenKey("bitbucket.org")
+
+	if err := store.Set(key, strings.Repeat("D", 4000)); err != nil {
+		t.Fatalf("Set large: %v", err)
+	}
+	if err := store.Set(key, "small-token"); err != nil {
+		t.Fatalf("Set small: %v", err)
+	}
+	if len(kr.items) != 1 {
+		t.Fatalf("overwrite should leave one item, got %d: %v", len(kr.items), keysOf(kr))
+	}
+	got, err := store.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != "small-token" {
+		t.Fatalf("Get = %q, want small-token", got)
+	}
+}
+
+func TestStoreLegacyUnchunkedGet(t *testing.T) {
+	kr := newMemoryKeyring(winCredMaxBlobSize)
+	store := winCredStore(kr)
+	key := TokenKey("bitbucket.org")
+	if err := kr.Set(keyring.Item{Key: key, Data: []byte("legacy-api-token")}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != "legacy-api-token" {
+		t.Fatalf("Get = %q, want legacy-api-token", got)
+	}
+}
+
+func TestWriteItemNeverCallsSetWithOversizedBlob(t *testing.T) {
+	kr := newMemoryKeyring(winCredMaxBlobSize)
+	store := winCredStore(kr)
+
+	err := store.writeItem("host/bitbucket.org/token", bytes.Repeat([]byte("x"), winCredMaxBlobSize+1))
+	if !errors.Is(err, errSecretChunkTooLarge) {
+		t.Fatalf("error = %v, want %v", err, errSecretChunkTooLarge)
+	}
+	if len(kr.sets) != 0 {
+		t.Fatalf("Set was called %d times; oversized blob must not reach CredWriteW", len(kr.sets))
+	}
+}
+
+func TestSetDoesNotFallBackToFileOnChunkError(t *testing.T) {
+	kr := newMemoryKeyring(winCredMaxBlobSize)
+	store := winCredStore(kr)
+
+	// Force the size-aware error path with no second backend to retry.
+	err := store.writeItem("k", bytes.Repeat([]byte("y"), 3000))
+	if !errors.Is(err, errSecretChunkTooLarge) {
+		t.Fatalf("error = %v, want %v", err, errSecretChunkTooLarge)
+	}
+	if usesFileBackend([]keyring.BackendType{keyring.WinCredBackend}) {
+		t.Fatal("WinCred-only path must not include the file backend")
+	}
+	if _, ok := kr.items["k"]; ok {
+		t.Fatal("failed write must not leave a file-backend fallback item")
+	}
+}
+
+func TestStoreRefreshWriteBackReplacesChunks(t *testing.T) {
+	kr := newMemoryKeyring(winCredMaxBlobSize)
+	store := winCredStore(kr)
+	key := TokenKey("api.bitbucket.org")
+
+	first := strings.Repeat("F", 5558)
+	if err := store.Set(key, first); err != nil {
+		t.Fatalf("Set first: %v", err)
+	}
+	second := strings.Repeat("G", 3000)
+	if err := store.Set(key, second); err != nil {
+		t.Fatalf("Set refresh: %v", err)
+	}
+	for _, w := range kr.sets {
+		if w.size > winCredMaxBlobSize {
+			t.Fatalf("refresh write %q was %d bytes", w.key, w.size)
+		}
+	}
+	got, err := store.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != second {
+		t.Fatalf("Get = %d bytes, want %d", len(got), len(second))
+	}
+	if _, ok := kr.items[chunkKey(key, 2)]; ok {
+		t.Fatal("refresh to a smaller blob left an extra chunk")
+	}
+}
+
+func TestUnlimitedStoreKeepsSingleBlob(t *testing.T) {
+	kr := newMemoryKeyring(0)
+	store := &Store{kr: kr, maxChunkSize: 0}
+	key := TokenKey("bitbucket.org")
+	want := strings.Repeat("E", 5558)
+
+	if err := store.Set(key, want); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if len(kr.items) != 1 {
+		t.Fatalf("unlimited store should write one item, got %d", len(kr.items))
+	}
+	got, err := store.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != want {
+		t.Fatalf("Get = %d bytes, want %d", len(got), len(want))
+	}
+}

--- a/internal/secret/store.go
+++ b/internal/secret/store.go
@@ -128,7 +128,8 @@ func timeoutHint() string {
 
 // Store wraps access to the configured keyring backend.
 type Store struct {
-	kr keyring.Keyring
+	kr           keyring.Keyring
+	maxChunkSize int // 0 means the backend has no blob-size limit
 }
 
 type openOptions struct {
@@ -185,7 +186,10 @@ func Open(opts ...Option) (*Store, error) {
 		return nil, fmt.Errorf("open keyring: %w", err)
 	}
 
-	return &Store{kr: kr}, nil
+	return &Store{
+		kr:           kr,
+		maxChunkSize: chunkSizeForBackends(cfg.AllowedBackends),
+	}, nil
 }
 
 // buildConfig assembles the keyring.Config the same way Open does, without
@@ -278,11 +282,7 @@ func (s *Store) Set(key, value string) error {
 
 	return s.withTimeout(func() error {
 		return withDarwinKeychainLock(func() error {
-			return s.kr.Set(keyring.Item{
-				Key:   key,
-				Data:  []byte(value),
-				Label: fmt.Sprintf("bkt %s", key),
-			})
+			return s.setValue(key, value)
 		})
 	})
 }
@@ -293,11 +293,11 @@ func (s *Store) Get(key string) (string, error) {
 		return "", errors.New("secret store not initialized")
 	}
 
-	var item keyring.Item
+	var value string
 	err := s.withTimeout(func() error {
 		return withDarwinKeychainLock(func() error {
 			var getErr error
-			item, getErr = s.kr.Get(key)
+			value, getErr = s.getValue(key)
 			return getErr
 		})
 	})
@@ -308,7 +308,7 @@ func (s *Store) Get(key string) (string, error) {
 		return "", err
 	}
 
-	return string(item.Data), nil
+	return value, nil
 }
 
 // Delete removes a stored secret. Missing items are treated as success.
@@ -319,7 +319,7 @@ func (s *Store) Delete(key string) error {
 
 	err := s.withTimeout(func() error {
 		return withDarwinKeychainLock(func() error {
-			return s.kr.Remove(key)
+			return s.deleteValue(key)
 		})
 	})
 	if err == nil || errors.Is(err, keyring.ErrKeyNotFound) || errors.Is(err, os.ErrNotExist) {
@@ -374,15 +374,21 @@ func resolveAllowedBackends(opts openOptions) []keyring.BackendType {
 }
 
 func defaultBackends() []keyring.BackendType {
-	switch runtime.GOOS {
+	return defaultBackendsFor(runtime.GOOS, IsHeadless())
+}
+
+func defaultBackendsFor(goos string, headless bool) []keyring.BackendType {
+	switch goos {
 	case "darwin":
 		return []keyring.BackendType{keyring.KeychainBackend}
 	case "windows":
+		// WinCred only. File is never a silent fallback — oversized OAuth
+		// blobs are stored as multiple WinCred items (see chunk.go).
 		return []keyring.BackendType{keyring.WinCredBackend}
 	default:
 		// In headless environments (SSH without X11, containers, etc.),
 		// skip GUI-based backends that would hang waiting for unlock prompts.
-		if IsHeadless() {
+		if headless {
 			return []keyring.BackendType{
 				keyring.KeyCtlBackend,
 				keyring.PassBackend,

--- a/internal/secret/store_test.go
+++ b/internal/secret/store_test.go
@@ -125,6 +125,112 @@ func TestConfigureFileBackend_HeadlessNoPassphrase(t *testing.T) {
 	}
 }
 
+func TestDefaultBackends_WindowsIsWinCredOnly(t *testing.T) {
+	t.Parallel()
+
+	got := defaultBackendsFor("windows", false)
+	if len(got) != 1 || got[0] != keyring.WinCredBackend {
+		t.Fatalf("windows default backends = %v, want [wincred]", got)
+	}
+	if usesFileBackend(got) {
+		t.Fatal("windows default path must not include the file backend")
+	}
+	if chunkSizeForBackends(got) != winCredMaxBlobSize {
+		t.Fatalf("windows default must enable WinCred chunking, got %d", chunkSizeForBackends(got))
+	}
+
+	headless := defaultBackendsFor("windows", true)
+	if len(headless) != 1 || headless[0] != keyring.WinCredBackend {
+		t.Fatalf("windows headless backends = %v, want [wincred]", headless)
+	}
+}
+
+func TestResolveAllowedBackends_DefaultExcludesFile(t *testing.T) {
+	t.Setenv(envBackend, "")
+	t.Setenv(envAllowInsecure, "")
+
+	got := resolveAllowedBackends(openOptions{})
+	if usesFileBackend(got) {
+		t.Fatal("default path must not enable the file backend without opt-in")
+	}
+	if chunkSizeForBackends(got) != chunkSizeForBackends(defaultBackends()) {
+		t.Fatal("default chunk limit should match platform native backends")
+	}
+}
+
+func TestResolveAllowedBackends_AllowFileDoesNotReplaceNative(t *testing.T) {
+	t.Setenv(envBackend, "")
+	t.Setenv(envAllowInsecure, "")
+
+	got := resolveAllowedBackends(openOptions{allowFile: true})
+	native := defaultBackends()
+	if len(got) != len(native)+1 {
+		t.Fatalf("allowFile should append file, got %v (native %v)", got, native)
+	}
+	for i, backend := range native {
+		if got[i] != backend {
+			t.Fatalf("allowFile reordered native backends: got %v, native %v", got, native)
+		}
+	}
+	if got[len(got)-1] != keyring.FileBackend {
+		t.Fatalf("file should be last, got %v", got)
+	}
+	if runtime.GOOS == "windows" && got[0] != keyring.WinCredBackend {
+		t.Fatal("windows must keep WinCred first; file is not a silent size-error fallback")
+	}
+}
+
+func TestChunkSizeForBackends(t *testing.T) {
+	t.Parallel()
+
+	if got := chunkSizeForBackends([]keyring.BackendType{keyring.WinCredBackend}); got != winCredMaxBlobSize {
+		t.Fatalf("wincred = %d, want %d", got, winCredMaxBlobSize)
+	}
+	if got := chunkSizeForBackends([]keyring.BackendType{keyring.WinCredBackend, keyring.FileBackend}); got != winCredMaxBlobSize {
+		t.Fatalf("wincred+file = %d, want %d (file must not disable chunking)", got, winCredMaxBlobSize)
+	}
+	if got := chunkSizeForBackends([]keyring.BackendType{keyring.FileBackend}); got != 0 {
+		t.Fatalf("file-only = %d, want 0", got)
+	}
+	if got := chunkSizeForBackends(defaultBackendsFor("linux", false)); got != 0 {
+		t.Fatalf("linux default = %d, want 0", got)
+	}
+	if got := chunkSizeForBackends(defaultBackendsFor("darwin", false)); got != 0 {
+		t.Fatalf("darwin default = %d, want 0", got)
+	}
+}
+
+func TestBuildConfig_DefaultDoesNotRequireInsecureEnv(t *testing.T) {
+	t.Setenv(envBackend, "")
+	t.Setenv(envAllowInsecure, "")
+	t.Setenv(envPassphrase, "")
+	t.Setenv(envFileDir, "")
+
+	cfg, err := buildConfig()
+	if err != nil {
+		t.Fatalf("buildConfig: %v", err)
+	}
+	if usesFileBackend(cfg.AllowedBackends) {
+		t.Fatal("default buildConfig must not enable the file backend")
+	}
+}
+
+func TestOpen_FileBackendDoesNotEnableWinCredChunking(t *testing.T) {
+	t.Setenv(envBackend, "file")
+	t.Setenv(envAllowInsecure, "1")
+	t.Setenv(envPassphrase, "test-pass")
+	dir := t.TempDir()
+	t.Setenv(envFileDir, dir)
+
+	store, err := Open(WithAllowFileFallback(true), WithPassphrase("test-pass"), WithFileDir(dir))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if store.maxChunkSize != 0 {
+		t.Fatalf("file-only Open set maxChunkSize=%d, want 0", store.maxChunkSize)
+	}
+}
+
 func TestConfigureFileBackend_HeadlessWithPassphrase(t *testing.T) {
 	// Simulate headless with passphrase provided.
 	t.Setenv("SSH_TTY", "/dev/pts/0")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Windows Credential Manager rejects generic credential blobs larger than 2560 bytes (`CRED_MAX_CREDENTIAL_BLOB_SIZE`). Cloud `--web` OAuth login marshals access + refresh + expiry as one JSON value (~5.5KB in #298), so `CredWriteW` failed with `The stub received bad data.`

`internal/secret.Store` now splits large values across multiple WinCred items when WinCred is an allowed backend. Callers still `Set`/`Get`/`Delete` one logical value — including OAuth refresh write-back in `pkg/cmdutil/client.go`. Each written piece is checked against the 2560-byte limit before it can reach `CredWriteW`.

The default Windows path remains WinCred only. There is no silent fallback to the encrypted file backend on size errors. `--web-token` is unchanged. `--allow-insecure-store` still only *permits* file; it does not become the default.

Closes #298.

## Testing

- [x] `make fmt`
- [x] `make test`
- [x] `make build`
- [x] Named check on the Cloud VM:

```
$ go test ./internal/secret ./pkg/oauth ./pkg/cmd/auth ./pkg/cmdutil
ok  	github.com/avivsinai/bitbucket-cli/internal/secret	0.024s
ok  	github.com/avivsinai/bitbucket-cli/pkg/oauth	0.072s
ok  	github.com/avivsinai/bitbucket-cli/pkg/cmd/auth	0.037s
ok  	github.com/avivsinai/bitbucket-cli/pkg/cmdutil	0.152s
```

Test plan:

- Blob larger than 2560 bytes round-trips through the store
- Each written piece is ≤2560 (oversized writes never call the keyring `Set`)
- `Get` reconstructs; `Delete` removes all chunks
- Overwrite (refresh write-back) replaces chunks and drops leftovers
- Windows default backends are WinCred only — no `KEYRING_BACKEND=file` / `BKT_ALLOW_INSECURE_STORE`
- File is not a silent downgrade on WinCred size errors
- Existing tests stay green (`make test` / `make build` passed on the Cloud VM)

## Checklist

- [x] Adds or updates documentation (CHANGELOG only; no user-facing flag change)
- [x] Updates `CHANGELOG.md`
- [x] Signed commits (`git commit -s`)

## Notes for reviewers

Chunking lives in `internal/secret` so login and refresh share one implementation. Tests use an in-memory keyring that rejects blobs >2560; they do not require a real WinCred.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-107f97c9-fd4b-4d18-b562-9d207b651a63?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-107f97c9-fd4b-4d18-b562-9d207b651a63&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

