### PR TITLE
chore(release): v0.31.1

### DIFF
--- a/.agents/skills/bkt/SKILL.md
+++ b/.agents/skills/bkt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bkt
-version: 0.31.0
+version: 0.31.1
 description: Bitbucket CLI for Data Center and Cloud. Use when users need to manage repositories, pull requests, branches, issues, webhooks, or pipelines in Bitbucket. Triggers include "bitbucket", "bkt", "pull request", "PR", "repo list", "branch create", "Bitbucket Data Center", "Bitbucket Cloud", "keyring timeout".
 metadata:
   short-description: Bitbucket CLI for repos, PRs, branches

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/.claude/skills/bkt/SKILL.md
+++ b/.claude/skills/bkt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bkt
-version: 0.31.0
+version: 0.31.1
 description: Bitbucket CLI for Data Center and Cloud. Use when users need to manage repositories, pull requests, branches, issues, webhooks, or pipelines in Bitbucket. Triggers include "bitbucket", "bkt", "pull request", "PR", "repo list", "branch create", "Bitbucket Data Center", "Bitbucket Cloud", "keyring timeout".
 metadata:
   short-description: Bitbucket CLI for repos, PRs, branches

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented here. The format follows
 
 ## [Unreleased]
 
+## [0.31.1] - 2026-08-21
 ### Added
 - Headless Bitbucket Cloud authentication now supports repository, project,
   and workspace access tokens through `BKT_AUTH_METHOD=bearer` without
@@ -22,6 +23,7 @@ All notable changes to this project will be documented here. The format follows
   secret across multiple WinCred items. Token refresh write-back uses the
   same store. The default Windows path stays WinCred; oversized writes
   never fall back to the encrypted file backend. (#298)
+
 
 ## [0.31.0] - 2026-08-12
 ### Added
@@ -683,7 +685,8 @@ All notable changes to this project will be documented here. The format follows
 ## [0.1.0] - 2025-10-26
 - Initial public release of `bkt`.
 
-[Unreleased]: https://github.com/avivsinai/bitbucket-cli/compare/v0.31.0...HEAD
+[Unreleased]: https://github.com/avivsinai/bitbucket-cli/compare/v0.31.1...HEAD
+[0.31.1]: https://github.com/avivsinai/bitbucket-cli/compare/v0.31.0...v0.31.1
 [0.31.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.30.1...v0.31.0
 [0.30.1]: https://github.com/avivsinai/bitbucket-cli/compare/v0.30.0...v0.30.1
 [0.30.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.29.0...v0.30.0

--- a/skills/bkt/SKILL.md
+++ b/skills/bkt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bkt
-version: 0.31.0
+version: 0.31.1
 description: Bitbucket CLI for Data Center and Cloud. Use when users need to manage repositories, pull requests, branches, issues, webhooks, or pipelines in Bitbucket. Triggers include "bitbucket", "bkt", "pull request", "PR", "repo list", "branch create", "Bitbucket Data Center", "Bitbucket Cloud", "keyring timeout".
 metadata:
   short-description: Bitbucket CLI for repos, PRs, branches


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Release

- moves `CHANGELOG.md` into `v0.31.1`
- aligns skill/plugin metadata to `0.31.1`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.31.1`, publishes the release, and publishes skills in the same workflow run

Ships the current Unreleased items already on master: Cloud bearer resource tokens (#294), README demo first screen (#299), and the WinCred chunk fix (#298/#300).

## Named check

```
$ ./scripts/check-release-version.sh 0.31.1
release metadata matches 0.31.1
```

Also ran `go test ./internal/secret ./pkg/oauth ./pkg/cmd/auth ./pkg/cmdutil` (all ok). Full `make test` / `make build` ran in `./scripts/release.sh 0.31.1 --no-auto-merge --date 2026-08-21`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6a0328e-328f-4b53-a862-28e2461b9ddc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6a0328e-328f-4b53-a862-28e2461b9ddc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

