### PR TITLE
docs: drop sunsetting Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![CI](https://github.com/avivsinai/bitbucket-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/avivsinai/bitbucket-cli/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/avivsinai/bitbucket-cli/graph/badge.svg)](https://codecov.io/gh/avivsinai/bitbucket-cli)
 [![Release](https://img.shields.io/github/v/release/avivsinai/bitbucket-cli?cache=none)](https://github.com/avivsinai/bitbucket-cli/releases)
-[![Go Report Card](https://goreportcard.com/badge/github.com/avivsinai/bitbucket-cli?cache=none)](https://goreportcard.com/report/github.com/avivsinai/bitbucket-cli)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/avivsinai/bitbucket-cli/badge)](https://scorecard.dev/viewer/?uri=github.com/avivsinai/bitbucket-cli)
 [![Go Reference](https://pkg.go.dev/badge/github.com/avivsinai/bitbucket-cli.svg)](https://pkg.go.dev/github.com/avivsinai/bitbucket-cli)
 [![License](https://img.shields.io/github/license/avivsinai/bitbucket-cli?cache=none)](LICENSE)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes https://github.com/avivsinai/bitbucket-cli/issues/304.

Public [goreportcard.com](https://goreportcard.com) is sunsetting. Shawn and Herman recommend [golangci-lint](https://golangci-lint.run/) as the successor; self-hosting [gojp/goreportcard](https://github.com/gojp/goreportcard) is the other option. We are not self-hosting.

This PR removes the README Go Report Card badge that pointed at:

- `https://goreportcard.com/badge/github.com/avivsinai/bitbucket-cli`
- `https://goreportcard.com/report/github.com/avivsinai/bitbucket-cli`

A repo-wide search found no other `goreportcard.com` links (README, docs, CI, formulas, skills). CI Lint (`golangci/golangci-lint-action` v9), `make lint`, and `.golangci.yaml` are unchanged. No replacement report-card badge was added.

## Testing

- [x] `golangci-lint run` on Cloud VM — exit 0, 0 issues (golangci-lint 2.13.2)
- [x] `go test ./...` on Cloud VM — exit 0
- [x] CI green on this PR (11 checks, no failures)

Full named-check log is in the first PR comment and below.

## Screenshots / recordings

N/A — docs-only badge removal.

## Checklist

- [x] Adds or updates documentation
- [ ] Updates `CHANGELOG.md` (docs-only README badge; no user-facing CLI change)
- [x] Signed commits (`git commit -s`)

## Notes for reviewers

Human merge only after the named Cloud VM checks and CI are green. Both are green. Do not merge from this agent.

## Cloud VM named checks

Commit `463d936752cc79611ea167ac87d59c8d36a4bbbc` (`cursor/drop-goreportcard-badge-8889`), 2026-08-31T16:11:08Z, go1.25.0, golangci-lint 2.13.2.

```
=== Cloud VM named checks ===
date: 2026-08-31T16:11:08Z
branch: cursor/drop-goreportcard-badge-8889
commit: 463d936752cc79611ea167ac87d59c8d36a4bbbc
go: go version go1.25.0 linux/amd64
golangci-lint: golangci-lint has version 2.13.2 built with go1.27.0 from 27774aaf on 2026-08-27T23:01:12Z

===== golangci-lint run =====
+ golangci-lint run
0 issues.
golangci-lint run exit code: 0

===== go test ./... =====
+ go test ./...
?   	github.com/avivsinai/bitbucket-cli/cmd/bkt	[no test files]
?   	github.com/avivsinai/bitbucket-cli/cmd/docgen	[no test files]
?   	github.com/avivsinai/bitbucket-cli/internal/bktcmd	[no test files]
ok  	github.com/avivsinai/bitbucket-cli/internal/build	0.001s
ok  	github.com/avivsinai/bitbucket-cli/internal/config	0.003s
ok  	github.com/avivsinai/bitbucket-cli/internal/docgen	0.015s
?   	github.com/avivsinai/bitbucket-cli/internal/filelock	[no test files]
ok  	github.com/avivsinai/bitbucket-cli/internal/mcpserver	0.138s
ok  	github.com/avivsinai/bitbucket-cli/internal/remote	0.053s
ok  	github.com/avivsinai/bitbucket-cli/internal/secret	0.017s
ok  	github.com/avivsinai/bitbucket-cli/pkg/bbcloud	0.180s
ok  	github.com/avivsinai/bitbucket-cli/pkg/bbdc	0.026s
?   	github.com/avivsinai/bitbucket-cli/pkg/browser	[no test files]
?   	github.com/avivsinai/bitbucket-cli/pkg/cmd/admin	[no test files]
ok  	github.com/avivsinai/bitbucket-cli/pkg/cmd/api	0.038s
ok  	github.com/avivsinai/bitbucket-cli/pkg/cmd/auth	0.058s
ok  	github.com/avivsinai/bitbucket-cli/pkg/cmd/branch	0.060s
ok  	github.com/avivsinai/bitbucket-cli/pkg/cmd/commit	0.017s
ok  	github.com/avivsinai/bitbucket-cli/pkg/cmd/context	0.009s
ok  	github.com/avivsinai/bitbucket-cli/pkg/cmd/extension	0.018s
?   	github.com/avivsinai/bitbucket-cli/pkg/cmd/factory	[no test files]
ok  	github.com/avivsinai/bitbucket-cli/pkg/cmd/issue	0.109s
ok  	github.com/avivsinai/bitbucket-cli/pkg/cmd/mcp	0.016s
?   	github.com/avivsinai/bitbucket-cli/pkg/cmd/perms	[no test files]
ok  	github.com/avivsinai/bitbucket-cli/pkg/cmd/pipeline	2.315s
ok  	github.com/avivsinai/bitbucket-cli/pkg/cmd/pr	4.561s
ok  	github.com/avivsinai/bitbucket-cli/pkg/cmd/project	0.018s
ok  	github.com/avivsinai/bitbucket-cli/pkg/cmd/repo	0.021s
?   	github.com/avivsinai/bitbucket-cli/pkg/cmd/root	[no test files]
ok  	github.com/avivsinai/bitbucket-cli/pkg/cmd/smoke	0.012s
?   	github.com/avivsinai/bitbucket-cli/pkg/cmd/status	[no test files]
ok  	github.com/avivsinai/bitbucket-cli/pkg/cmd/variable	0.011s
ok  	github.com/avivsinai/bitbucket-cli/pkg/cmd/webhook	0.031s
ok  	github.com/avivsinai/bitbucket-cli/pkg/cmdutil	0.146s
ok  	github.com/avivsinai/bitbucket-cli/pkg/format	0.002s
ok  	github.com/avivsinai/bitbucket-cli/pkg/httpx	0.283s
ok  	github.com/avivsinai/bitbucket-cli/pkg/iostreams	0.001s
ok  	github.com/avivsinai/bitbucket-cli/pkg/oauth	0.049s
?   	github.com/avivsinai/bitbucket-cli/pkg/pager	[no test files]
?   	github.com/avivsinai/bitbucket-cli/pkg/progress	[no test files]
ok  	github.com/avivsinai/bitbucket-cli/pkg/prompter	0.002s
?   	github.com/avivsinai/bitbucket-cli/pkg/types	[no test files]
go test ./... exit code: 0

===== summary =====
golangci-lint run: 0
go test ./...: 0
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9281c3f3-d77f-40db-8ebb-29b35c8f8889?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9281c3f3-d77f-40db-8ebb-29b35c8f8889&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

