### PR TITLE
feat: add archived flag to repo response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented here. The format follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Changed
+- The list repos operation now returns the 'archived' flag for Bitbucket Server.
 
 ## [0.31.1] - 2026-08-21
 ### Added

--- a/pkg/bbdc/client.go
+++ b/pkg/bbdc/client.go
@@ -88,6 +88,7 @@ type Repository struct {
 	Slug          string   `json:"slug"`
 	Name          string   `json:"name"`
 	ID            int      `json:"id"`
+	Archived      bool     `json:"archived"`
 	Project       *Project `json:"project"`
 	DefaultBranch string   `json:"defaultBranch,omitempty"`
 	Links         struct {

--- a/pkg/cmd/repo/repo.go
+++ b/pkg/cmd/repo/repo.go
@@ -130,23 +130,25 @@ func runList(cmd *cobra.Command, f *cmdutil.Factory, opts *listOptions) error {
 		}
 
 		type repoSummary struct {
-			Project string   `json:"project"`
-			Slug    string   `json:"slug"`
-			Name    string   `json:"name"`
-			ID      int      `json:"id"`
-			WebURL  string   `json:"web_url,omitempty"`
-			Clone   []string `json:"clone_urls,omitempty"`
+			Project  string   `json:"project"`
+			Slug     string   `json:"slug"`
+			Name     string   `json:"name"`
+			ID       int      `json:"id"`
+			Archived bool     `json:"archived"`
+			WebURL   string   `json:"web_url,omitempty"`
+			Clone    []string `json:"clone_urls,omitempty"`
 		}
 
 		var summaries []repoSummary
 		for _, repo := range repos {
 			summaries = append(summaries, repoSummary{
-				Project: repo.Project.Key,
-				Slug:    repo.Slug,
-				Name:    repo.Name,
-				ID:      repo.ID,
-				WebURL:  firstLinkDC(repo, "web"),
-				Clone:   cloneLinksDC(repo),
+				Project:  repo.Project.Key,
+				Slug:     repo.Slug,
+				Name:     repo.Name,
+				ID:       repo.ID,
+				Archived: repo.Archived,
+				WebURL:   firstLinkDC(repo, "web"),
+				Clone:    cloneLinksDC(repo),
 			})
 		}
 
@@ -363,21 +365,23 @@ func runView(cmd *cobra.Command, f *cmdutil.Factory, opts *viewOptions) error {
 		}
 
 		type repoDetails struct {
-			Project string   `json:"project"`
-			Slug    string   `json:"slug"`
-			Name    string   `json:"name"`
-			ID      int      `json:"id"`
-			WebURL  string   `json:"web_url,omitempty"`
-			Clone   []string `json:"clone_urls,omitempty"`
+			Project  string   `json:"project"`
+			Slug     string   `json:"slug"`
+			Name     string   `json:"name"`
+			ID       int      `json:"id"`
+			Archived bool     `json:"archived"`
+			WebURL   string   `json:"web_url,omitempty"`
+			Clone    []string `json:"clone_urls,omitempty"`
 		}
 
 		details := repoDetails{
-			Project: repo.Project.Key,
-			Slug:    repo.Slug,
-			Name:    repo.Name,
-			ID:      repo.ID,
-			WebURL:  firstLinkDC(*repo, "web"),
-			Clone:   cloneLinksDC(*repo),
+			Project:  repo.Project.Key,
+			Slug:     repo.Slug,
+			Name:     repo.Name,
+			ID:       repo.ID,
+			Archived: repo.Archived,
+			WebURL:   firstLinkDC(*repo, "web"),
+			Clone:    cloneLinksDC(*repo),
 		}
 
 		return cmdutil.WriteOutput(cmd, ios.Out, details, func() error {
@@ -385,6 +389,9 @@ func runView(cmd *cobra.Command, f *cmdutil.Factory, opts *viewOptions) error {
 				return err
 			}
 			if _, err := fmt.Fprintf(ios.Out, "Name: %s\n", details.Name); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintf(ios.Out, "Archived: %t\n", details.Archived); err != nil {
 				return err
 			}
 			if details.WebURL != "" {

--- a/pkg/cmd/smoke/cli_smoke_test.go
+++ b/pkg/cmd/smoke/cli_smoke_test.go
@@ -70,9 +70,10 @@ func TestRepoListDataCenterJSONOutput(t *testing.T) {
 
 	mock.StubRepoList("BKT", 7, repoListResponse{
 		Values: []repoPayload{{
-			Slug: "sample",
-			Name: "Sample Repo",
-			ID:   7,
+			Slug:     "sample",
+			Name:     "Sample Repo",
+			ID:       7,
+			Archived: true,
 			Project: projectRef{
 				Key: "BKT",
 			},
@@ -96,11 +97,12 @@ func TestRepoListDataCenterJSONOutput(t *testing.T) {
 	var payload struct {
 		Project string `json:"project"`
 		Repos   []struct {
-			Project string   `json:"project"`
-			Slug    string   `json:"slug"`
-			Name    string   `json:"name"`
-			ID      int      `json:"id"`
-			Clone   []string `json:"clone_urls"`
+			Project  string   `json:"project"`
+			Slug     string   `json:"slug"`
+			Name     string   `json:"name"`
+			ID       int      `json:"id"`
+			Archived bool     `json:"archived"`
+			Clone    []string `json:"clone_urls"`
 		} `json:"repositories"`
 	}
 	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
@@ -115,6 +117,9 @@ func TestRepoListDataCenterJSONOutput(t *testing.T) {
 	repo := payload.Repos[0]
 	if repo.Slug != "sample" || repo.Project != "BKT" || repo.Name != "Sample Repo" {
 		t.Fatalf("unexpected repo payload: %+v", repo)
+	}
+	if !repo.Archived {
+		t.Fatalf("expected repository to be archived: %+v", repo)
 	}
 	if len(repo.Clone) != 1 || repo.Clone[0] != "ssh://git@bitbucket.example.com/BKT/sample.git (ssh)" {
 		t.Fatalf("unexpected clone URLs: %v", repo.Clone)
@@ -393,6 +398,7 @@ type repoPayload struct {
 	Slug       string      `json:"slug"`
 	Name       string      `json:"name"`
 	ID         int         `json:"id"`
+	Archived   bool        `json:"archived"`
 	Project    projectRef  `json:"project"`
 	WebLinks   []string    `json:"web_links"`
 	CloneLinks []cloneLink `json:"clone_links"`
@@ -410,11 +416,12 @@ func (r repoListResponse) page(limit int) map[string]any {
 			"clone": repo.CloneLinks,
 		}
 		values = append(values, map[string]any{
-			"slug":    repo.Slug,
-			"name":    repo.Name,
-			"id":      repo.ID,
-			"project": map[string]any{"key": repo.Project.Key},
-			"links":   links,
+			"slug":     repo.Slug,
+			"name":     repo.Name,
+			"id":       repo.ID,
+			"archived": repo.Archived,
+			"project":  map[string]any{"key": repo.Project.Key},
+			"links":    links,
 		})
 	}
 


### PR DESCRIPTION
## Summary

The Bitbucket Server API returns an `archived` flag per repo in the list repos call ([documentation](https://developer.atlassian.com/server/bitbucket/rest/v1004/api-group-project/#api-api-latest-projects-projectkey-repos-get)).  This adds that field to the response to allow filtering based on it.

## Testing

- [x] `make fmt`
- [x] `make test`
- [x] `make build`
- [x] Other (please specify): smoke test against a Bitbucket Server installation

## Screenshots / recordings

N/A

## Checklist

- [ ] Adds or updates documentation
- [x] Updates `CHANGELOG.md`
- [x] Signed commits (`git commit -s`)

## Notes for reviewers

Not implemented for Cloud since it does not support archiving a repo ([docs](https://support.atlassian.com/bitbucket-cloud/kb/how-to-archive-repositories/)).