### PR TITLE
fix: complete Data Center repo archived output (#306)

### DIFF
--- a/.agents/skills/bkt/rules/repo.md
+++ b/.agents/skills/bkt/rules/repo.md
@@ -306,6 +306,7 @@ bkt repo list [flags]
 ## bkt repo view
 
 Display details for a repository, including its name, web URL, and clone URLs.
+On Data Center, output also includes whether the repository is archived.
 
 On Data Center, the project key and repository slug are resolved from the active
 context or overridden with --project and --repo. On Cloud, the workspace and

--- a/.claude/skills/bkt/rules/repo.md
+++ b/.claude/skills/bkt/rules/repo.md
@@ -306,6 +306,7 @@ bkt repo list [flags]
 ## bkt repo view
 
 Display details for a repository, including its name, web URL, and clone URLs.
+On Data Center, output also includes whether the repository is archived.
 
 On Data Center, the project key and repository slug are resolved from the active
 context or overridden with --project and --repo. On Cloud, the workspace and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented here. The format follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Changed
+- The list repos operation now returns the 'archived' flag for Bitbucket Server.
 
 ## [0.31.1] - 2026-08-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ All notable changes to this project will be documented here. The format follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
-### Changed
-- The list repos operation now returns the 'archived' flag for Bitbucket Server.
+### Added
+- Data Center `bkt repo list` and `bkt repo view` include the repository
+  `archived` flag in structured output (always present, including `false`).
+  Human `repo view` prints `Archived: true|false`; archived `repo list` rows
+  get an `(archived)` suffix. Bitbucket Cloud is unchanged.
 
 ## [0.31.1] - 2026-08-21
 ### Added

--- a/pkg/bbdc/client.go
+++ b/pkg/bbdc/client.go
@@ -88,6 +88,7 @@ type Repository struct {
 	Slug          string   `json:"slug"`
 	Name          string   `json:"name"`
 	ID            int      `json:"id"`
+	Archived      bool     `json:"archived"`
 	Project       *Project `json:"project"`
 	DefaultBranch string   `json:"defaultBranch,omitempty"`
 	Links         struct {

--- a/pkg/cmd/repo/repo.go
+++ b/pkg/cmd/repo/repo.go
@@ -130,23 +130,25 @@ func runList(cmd *cobra.Command, f *cmdutil.Factory, opts *listOptions) error {
 		}
 
 		type repoSummary struct {
-			Project string   `json:"project"`
-			Slug    string   `json:"slug"`
-			Name    string   `json:"name"`
-			ID      int      `json:"id"`
-			WebURL  string   `json:"web_url,omitempty"`
-			Clone   []string `json:"clone_urls,omitempty"`
+			Project  string   `json:"project"`
+			Slug     string   `json:"slug"`
+			Name     string   `json:"name"`
+			ID       int      `json:"id"`
+			Archived bool     `json:"archived"`
+			WebURL   string   `json:"web_url,omitempty"`
+			Clone    []string `json:"clone_urls,omitempty"`
 		}
 
 		var summaries []repoSummary
 		for _, repo := range repos {
 			summaries = append(summaries, repoSummary{
-				Project: repo.Project.Key,
-				Slug:    repo.Slug,
-				Name:    repo.Name,
-				ID:      repo.ID,
-				WebURL:  firstLinkDC(repo, "web"),
-				Clone:   cloneLinksDC(repo),
+				Project:  repo.Project.Key,
+				Slug:     repo.Slug,
+				Name:     repo.Name,
+				ID:       repo.ID,
+				Archived: repo.Archived,
+				WebURL:   firstLinkDC(repo, "web"),
+				Clone:    cloneLinksDC(repo),
 			})
 		}
 
@@ -363,21 +365,23 @@ func runView(cmd *cobra.Command, f *cmdutil.Factory, opts *viewOptions) error {
 		}
 
 		type repoDetails struct {
-			Project string   `json:"project"`
-			Slug    string   `json:"slug"`
-			Name    string   `json:"name"`
-			ID      int      `json:"id"`
-			WebURL  string   `json:"web_url,omitempty"`
-			Clone   []string `json:"clone_urls,omitempty"`
+			Project  string   `json:"project"`
+			Slug     string   `json:"slug"`
+			Name     string   `json:"name"`
+			ID       int      `json:"id"`
+			Archived bool     `json:"archived"`
+			WebURL   string   `json:"web_url,omitempty"`
+			Clone    []string `json:"clone_urls,omitempty"`
 		}
 
 		details := repoDetails{
-			Project: repo.Project.Key,
-			Slug:    repo.Slug,
-			Name:    repo.Name,
-			ID:      repo.ID,
-			WebURL:  firstLinkDC(*repo, "web"),
-			Clone:   cloneLinksDC(*repo),
+			Project:  repo.Project.Key,
+			Slug:     repo.Slug,
+			Name:     repo.Name,
+			ID:       repo.ID,
+			Archived: repo.Archived,
+			WebURL:   firstLinkDC(*repo, "web"),
+			Clone:    cloneLinksDC(*repo),
 		}
 
 		return cmdutil.WriteOutput(cmd, ios.Out, details, func() error {
@@ -385,6 +389,9 @@ func runView(cmd *cobra.Command, f *cmdutil.Factory, opts *viewOptions) error {
 				return err
 			}
 			if _, err := fmt.Fprintf(ios.Out, "Name: %s\n", details.Name); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintf(ios.Out, "Archived: %t\n", details.Archived); err != nil {
 				return err
 			}
 			if details.WebURL != "" {

--- a/pkg/cmd/repo/repo.go
+++ b/pkg/cmd/repo/repo.go
@@ -167,7 +167,11 @@ func runList(cmd *cobra.Command, f *cmdutil.Factory, opts *listOptions) error {
 			}
 
 			for _, r := range summaries {
-				if _, err := fmt.Fprintf(ios.Out, "%s/%s\t%s\n", r.Project, r.Slug, r.Name); err != nil {
+				name := r.Name
+				if r.Archived {
+					name += " (archived)"
+				}
+				if _, err := fmt.Fprintf(ios.Out, "%s/%s\t%s\n", r.Project, r.Slug, name); err != nil {
 					return err
 				}
 				if r.WebURL != "" {
@@ -284,6 +288,7 @@ func newViewCmd(f *cmdutil.Factory) *cobra.Command {
 		Use:   "view [repository]",
 		Short: "Display details for a repository",
 		Long: `Display details for a repository, including its name, web URL, and clone URLs.
+On Data Center, output also includes whether the repository is archived.
 
 On Data Center, the project key and repository slug are resolved from the active
 context or overridden with --project and --repo. On Cloud, the workspace and

--- a/pkg/cmd/repo/repo_test.go
+++ b/pkg/cmd/repo/repo_test.go
@@ -375,3 +375,165 @@ func TestRepoCreateRejectsHostNoOpFlags(t *testing.T) {
 		})
 	}
 }
+
+func TestRepoListDataCenterMarksArchivedRows(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/rest/api/1.0/projects/PROJ/repos" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"isLastPage": true,
+			"values": []map[string]any{
+				{
+					"slug":     "active",
+					"name":     "Active Repo",
+					"id":       1,
+					"archived": false,
+					"project":  map[string]any{"key": "PROJ"},
+				},
+				{
+					"slug":     "legacy",
+					"name":     "Legacy Repo",
+					"id":       2,
+					"archived": true,
+					"project":  map[string]any{"key": "PROJ"},
+				},
+			},
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	cfg := dcRepoConfig(server.URL)
+	stdout := &strings.Builder{}
+	cmd := newListCmd(repoTestFactory(cfg, stdout))
+	cmd.SetContext(context.Background())
+	cmd.PersistentFlags().Bool("json", false, "")
+	cmd.SetArgs([]string{"--limit", "25"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("repo list: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "PROJ/active\tActive Repo\n") {
+		t.Fatalf("expected active repo row, got %q", out)
+	}
+	if strings.Contains(out, "PROJ/active\tActive Repo (archived)") {
+		t.Fatalf("did not expect archived marker on active repo, got %q", out)
+	}
+	if !strings.Contains(out, "PROJ/legacy\tLegacy Repo (archived)") {
+		t.Fatalf("expected archived suffix, got %q", out)
+	}
+
+	stdout.Reset()
+	cmd = newListCmd(repoTestFactory(cfg, stdout))
+	cmd.SetContext(context.Background())
+	cmd.PersistentFlags().Bool("json", false, "")
+	cmd.SetArgs([]string{"--limit", "25", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("repo list --json: %v", err)
+	}
+	var payload struct {
+		Repos []struct {
+			Slug     string `json:"slug"`
+			Archived bool   `json:"archived"`
+		} `json:"repositories"`
+	}
+	if err := json.Unmarshal([]byte(stdout.String()), &payload); err != nil {
+		t.Fatalf("decode list JSON: %v\n%s", err, stdout.String())
+	}
+	if len(payload.Repos) != 2 {
+		t.Fatalf("expected 2 repos, got %d", len(payload.Repos))
+	}
+	if payload.Repos[0].Slug != "active" || payload.Repos[0].Archived {
+		t.Fatalf("unexpected first repo: %+v", payload.Repos[0])
+	}
+	if payload.Repos[1].Slug != "legacy" || !payload.Repos[1].Archived {
+		t.Fatalf("unexpected second repo: %+v", payload.Repos[1])
+	}
+	if !strings.Contains(stdout.String(), `"archived": false`) {
+		t.Fatalf("expected archived=false in JSON, got %s", stdout.String())
+	}
+}
+
+func TestRepoViewDataCenterArchivedOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/rest/api/1.0/projects/PROJ/repos/sample" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"slug":     "sample",
+			"name":     "Sample Repo",
+			"id":       42,
+			"archived": true,
+			"project":  map[string]any{"key": "PROJ"},
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	cfg := dcRepoConfig(server.URL)
+	stdout := &strings.Builder{}
+	cmd := newViewCmd(repoTestFactory(cfg, stdout))
+	cmd.SetContext(context.Background())
+	cmd.PersistentFlags().Bool("json", false, "")
+	cmd.SetArgs([]string{"sample"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("repo view: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "PROJ/sample (42)") {
+		t.Fatalf("expected heading, got %q", out)
+	}
+	if !strings.Contains(out, "Archived: true") {
+		t.Fatalf("expected Archived line, got %q", out)
+	}
+
+	stdout.Reset()
+	cmd = newViewCmd(repoTestFactory(cfg, stdout))
+	cmd.SetContext(context.Background())
+	cmd.PersistentFlags().Bool("json", false, "")
+	cmd.SetArgs([]string{"sample", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("repo view --json: %v", err)
+	}
+	var payload struct {
+		Slug     string `json:"slug"`
+		Archived bool   `json:"archived"`
+	}
+	if err := json.Unmarshal([]byte(stdout.String()), &payload); err != nil {
+		t.Fatalf("decode view JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.Slug != "sample" || !payload.Archived {
+		t.Fatalf("unexpected view payload: %+v", payload)
+	}
+	if !strings.Contains(stdout.String(), `"archived": true`) {
+		t.Fatalf("expected archived=true in JSON, got %s", stdout.String())
+	}
+}
+
+func dcRepoConfig(baseURL string) *config.Config {
+	return &config.Config{
+		ActiveContext: "default",
+		Contexts: map[string]*config.Context{
+			"default": {Host: "main", ProjectKey: "PROJ"},
+		},
+		Hosts: map[string]*config.Host{
+			"main": {Kind: "dc", BaseURL: baseURL, Token: "test-token"},
+		},
+	}
+}
+
+func repoTestFactory(cfg *config.Config, stdout *strings.Builder) *cmdutil.Factory {
+	return &cmdutil.Factory{
+		AppVersion:     "test",
+		ExecutableName: "bkt",
+		IOStreams:      &iostreams.IOStreams{Out: stdout, ErrOut: &strings.Builder{}},
+		Config: func() (*config.Config, error) {
+			return cfg, nil
+		},
+	}
+}

--- a/pkg/cmd/smoke/cli_smoke_test.go
+++ b/pkg/cmd/smoke/cli_smoke_test.go
@@ -36,6 +36,14 @@ func TestRepoListDataCenterTextOutput(t *testing.T) {
 				{Name: "ssh", Href: "ssh://git@bitbucket.example.com/BKT/sample.git"},
 				{Name: "http", Href: "https://bitbucket.example.com/scm/bkt/sample.git"},
 			},
+		}, {
+			Slug:     "legacy",
+			Name:     "Legacy Repo",
+			ID:       43,
+			Archived: true,
+			Project: projectRef{
+				Key: "BKT",
+			},
 		}},
 	})
 
@@ -50,8 +58,14 @@ func TestRepoListDataCenterTextOutput(t *testing.T) {
 	}
 
 	got := stdout
-	if !strings.Contains(got, "BKT/sample\tSample Repo") {
+	if !strings.Contains(got, "BKT/sample\tSample Repo\n") {
 		t.Fatalf("expected repo summary in output, got:\n%s", got)
+	}
+	if strings.Contains(got, "BKT/sample\tSample Repo (archived)") {
+		t.Fatalf("did not expect archived marker on active repo, got:\n%s", got)
+	}
+	if !strings.Contains(got, "BKT/legacy\tLegacy Repo (archived)") {
+		t.Fatalf("expected archived suffix on list row, got:\n%s", got)
 	}
 	if !strings.Contains(got, "web:   "+mock.URL()+"/projects/BKT/repos/sample") {
 		t.Fatalf("expected web link in output, got:\n%s", got)
@@ -126,6 +140,115 @@ func TestRepoListDataCenterJSONOutput(t *testing.T) {
 	}
 	if calls := mock.RepoListCalls(); calls != 1 {
 		t.Fatalf("expected single repo list request, got %d", calls)
+	}
+}
+
+func TestRepoViewDataCenterTextOutput(t *testing.T) {
+	mock := newBitbucketMock(t, "admin", "admin123")
+	defer mock.Close()
+
+	mock.StubRepoGet("BKT", "sample", repoPayload{
+		Slug:     "sample",
+		Name:     "Sample Repo",
+		ID:       42,
+		Archived: true,
+		Project: projectRef{
+			Key: "BKT",
+		},
+		WebLinks: []string{mock.URL() + "/projects/BKT/repos/sample"},
+		CloneLinks: []cloneLink{
+			{Name: "ssh", Href: "ssh://git@bitbucket.example.com/BKT/sample.git"},
+			{Name: "http", Href: "https://bitbucket.example.com/scm/bkt/sample.git"},
+		},
+	})
+
+	cfg := configForMock(mock.URL(), "admin", "admin123", "smoke", "bkt", "")
+
+	stdout, stderr, err := runCLI(t, cfg, "repo", "view", "sample")
+	if err != nil {
+		t.Fatalf("repo view returned error: %v (stderr=%s)", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected no stderr output, got %q", stderr)
+	}
+
+	if !strings.Contains(stdout, "BKT/sample (42)") {
+		t.Fatalf("expected repo heading in output, got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "Name: Sample Repo") {
+		t.Fatalf("expected repo name in output, got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "Archived: true") {
+		t.Fatalf("expected archived line in output, got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "Web:  "+mock.URL()+"/projects/BKT/repos/sample") {
+		t.Fatalf("expected web link in output, got:\n%s", stdout)
+	}
+	if calls := mock.RepoGetCalls(); calls != 1 {
+		t.Fatalf("expected single repo get request, got %d", calls)
+	}
+}
+
+func TestRepoViewDataCenterJSONOutput(t *testing.T) {
+	mock := newBitbucketMock(t, "svc", "token")
+	defer mock.Close()
+
+	mock.StubRepoGet("BKT", "sample", repoPayload{
+		Slug: "sample",
+		Name: "Sample Repo",
+		ID:   7,
+		Project: projectRef{
+			Key: "BKT",
+		},
+		CloneLinks: []cloneLink{
+			{Name: "ssh", Href: "ssh://git@bitbucket.example.com/BKT/sample.git"},
+		},
+	})
+
+	cfg := configForMock(mock.URL(), "svc", "token", "json", "bkt", "")
+
+	stdout, stderr, err := runCLI(t, cfg, "repo", "view", "sample", "--json")
+	if err != nil {
+		t.Fatalf("repo view --json error: %v (stderr=%s)", err, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected no stderr output, got %q", stderr)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(stdout), &raw); err != nil {
+		t.Fatalf("failed to decode JSON output: %v\nstdout=%s", err, stdout)
+	}
+	archivedRaw, ok := raw["archived"]
+	if !ok {
+		t.Fatalf("expected archived field in JSON output, got %s", stdout)
+	}
+	if string(archivedRaw) != "false" {
+		t.Fatalf("expected archived=false in JSON (no omitempty), got %s", archivedRaw)
+	}
+
+	var payload struct {
+		Project  string   `json:"project"`
+		Slug     string   `json:"slug"`
+		Name     string   `json:"name"`
+		ID       int      `json:"id"`
+		Archived bool     `json:"archived"`
+		Clone    []string `json:"clone_urls"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("failed to decode JSON output: %v\nstdout=%s", err, stdout)
+	}
+	if payload.Slug != "sample" || payload.Project != "BKT" || payload.Name != "Sample Repo" {
+		t.Fatalf("unexpected repo payload: %+v", payload)
+	}
+	if payload.Archived {
+		t.Fatalf("expected repository not to be archived: %+v", payload)
+	}
+	if len(payload.Clone) != 1 || payload.Clone[0] != "ssh://git@bitbucket.example.com/BKT/sample.git (ssh)" {
+		t.Fatalf("unexpected clone URLs: %v", payload.Clone)
+	}
+	if calls := mock.RepoGetCalls(); calls != 1 {
+		t.Fatalf("expected single repo get request, got %d", calls)
 	}
 }
 
@@ -232,8 +355,10 @@ type bitbucketMock struct {
 	server       *httptest.Server
 	expectedAuth string
 	repoStub     repoStub
+	repoGetStub  repoGetStub
 	projectStub  projectStub
 	repoCalls    atomic.Int32
+	repoGetCalls atomic.Int32
 	projectCalls atomic.Int32
 }
 
@@ -242,6 +367,13 @@ type repoStub struct {
 	projectKey    string
 	expectedLimit int
 	response      repoListResponse
+}
+
+type repoGetStub struct {
+	enabled    bool
+	projectKey string
+	slug       string
+	response   repoPayload
 }
 
 type projectStub struct {
@@ -277,6 +409,15 @@ func (m *bitbucketMock) StubRepoList(projectKey string, limit int, resp repoList
 	}
 }
 
+func (m *bitbucketMock) StubRepoGet(projectKey, slug string, resp repoPayload) {
+	m.repoGetStub = repoGetStub{
+		enabled:    true,
+		projectKey: projectKey,
+		slug:       slug,
+		response:   resp,
+	}
+}
+
 func (m *bitbucketMock) StubProjectList(limit int, resp projectListResponse) {
 	m.projectStub = projectStub{
 		enabled:       true,
@@ -289,12 +430,18 @@ func (m *bitbucketMock) RepoListCalls() int {
 	return int(m.repoCalls.Load())
 }
 
+func (m *bitbucketMock) RepoGetCalls() int {
+	return int(m.repoGetCalls.Load())
+}
+
 func (m *bitbucketMock) ProjectListCalls() int {
 	return int(m.projectCalls.Load())
 }
 
 func (m *bitbucketMock) dispatch(w http.ResponseWriter, r *http.Request) {
 	switch {
+	case strings.HasPrefix(r.URL.Path, "/rest/api/1.0/projects/") && strings.Contains(r.URL.Path, "/repos/"):
+		m.handleRepoGet(w, r)
 	case strings.HasPrefix(r.URL.Path, "/rest/api/1.0/projects/") && strings.HasSuffix(r.URL.Path, "/repos"):
 		m.handleRepoList(w, r)
 	case r.URL.Path == "/rest/api/1.0/projects":
@@ -344,6 +491,44 @@ func (m *bitbucketMock) handleRepoList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	m.writeJSON(w, m.repoStub.response.page(m.repoStub.expectedLimit))
+}
+
+func (m *bitbucketMock) handleRepoGet(w http.ResponseWriter, r *http.Request) {
+	if !m.repoGetStub.enabled {
+		http.NotFound(w, r)
+		return
+	}
+	m.repoGetCalls.Add(1)
+
+	if err := m.assertAuth(r); err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	if r.Method != http.MethodGet {
+		http.Error(w, "unsupported method", http.StatusMethodNotAllowed)
+		return
+	}
+
+	segments := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+	var projectKey, slug string
+	for i := 0; i < len(segments); i++ {
+		if segments[i] == "projects" && i+1 < len(segments) {
+			projectKey = segments[i+1]
+		}
+		if segments[i] == "repos" && i+1 < len(segments) {
+			slug = segments[i+1]
+		}
+	}
+	if projectKey == "" || slug == "" {
+		http.Error(w, "unexpected path", http.StatusBadRequest)
+		return
+	}
+	if projectKey != m.repoGetStub.projectKey || slug != m.repoGetStub.slug {
+		http.Error(w, fmt.Sprintf("expected %s/%s, got %s/%s", m.repoGetStub.projectKey, m.repoGetStub.slug, projectKey, slug), http.StatusBadRequest)
+		return
+	}
+
+	m.writeJSON(w, repoAPIObject(m.repoGetStub.response))
 }
 
 func (m *bitbucketMock) handleProjectList(w http.ResponseWriter, r *http.Request) {
@@ -408,21 +593,24 @@ type repoListResponse struct {
 	Values []repoPayload
 }
 
+func repoAPIObject(repo repoPayload) map[string]any {
+	return map[string]any{
+		"slug":     repo.Slug,
+		"name":     repo.Name,
+		"id":       repo.ID,
+		"archived": repo.Archived,
+		"project":  map[string]any{"key": repo.Project.Key},
+		"links": map[string]any{
+			"web":   toWebLinks(repo.WebLinks),
+			"clone": repo.CloneLinks,
+		},
+	}
+}
+
 func (r repoListResponse) page(limit int) map[string]any {
 	var values []map[string]any
 	for _, repo := range r.Values {
-		links := map[string]any{
-			"web":   toWebLinks(repo.WebLinks),
-			"clone": repo.CloneLinks,
-		}
-		values = append(values, map[string]any{
-			"slug":     repo.Slug,
-			"name":     repo.Name,
-			"id":       repo.ID,
-			"archived": repo.Archived,
-			"project":  map[string]any{"key": repo.Project.Key},
-			"links":    links,
-		})
+		values = append(values, repoAPIObject(repo))
 	}
 
 	return map[string]any{

--- a/pkg/cmd/smoke/cli_smoke_test.go
+++ b/pkg/cmd/smoke/cli_smoke_test.go
@@ -70,9 +70,10 @@ func TestRepoListDataCenterJSONOutput(t *testing.T) {
 
 	mock.StubRepoList("BKT", 7, repoListResponse{
 		Values: []repoPayload{{
-			Slug: "sample",
-			Name: "Sample Repo",
-			ID:   7,
+			Slug:     "sample",
+			Name:     "Sample Repo",
+			ID:       7,
+			Archived: true,
 			Project: projectRef{
 				Key: "BKT",
 			},
@@ -96,11 +97,12 @@ func TestRepoListDataCenterJSONOutput(t *testing.T) {
 	var payload struct {
 		Project string `json:"project"`
 		Repos   []struct {
-			Project string   `json:"project"`
-			Slug    string   `json:"slug"`
-			Name    string   `json:"name"`
-			ID      int      `json:"id"`
-			Clone   []string `json:"clone_urls"`
+			Project  string   `json:"project"`
+			Slug     string   `json:"slug"`
+			Name     string   `json:"name"`
+			ID       int      `json:"id"`
+			Archived bool     `json:"archived"`
+			Clone    []string `json:"clone_urls"`
 		} `json:"repositories"`
 	}
 	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
@@ -115,6 +117,9 @@ func TestRepoListDataCenterJSONOutput(t *testing.T) {
 	repo := payload.Repos[0]
 	if repo.Slug != "sample" || repo.Project != "BKT" || repo.Name != "Sample Repo" {
 		t.Fatalf("unexpected repo payload: %+v", repo)
+	}
+	if !repo.Archived {
+		t.Fatalf("expected repository to be archived: %+v", repo)
 	}
 	if len(repo.Clone) != 1 || repo.Clone[0] != "ssh://git@bitbucket.example.com/BKT/sample.git (ssh)" {
 		t.Fatalf("unexpected clone URLs: %v", repo.Clone)
@@ -393,6 +398,7 @@ type repoPayload struct {
 	Slug       string      `json:"slug"`
 	Name       string      `json:"name"`
 	ID         int         `json:"id"`
+	Archived   bool        `json:"archived"`
 	Project    projectRef  `json:"project"`
 	WebLinks   []string    `json:"web_links"`
 	CloneLinks []cloneLink `json:"clone_links"`
@@ -410,11 +416,12 @@ func (r repoListResponse) page(limit int) map[string]any {
 			"clone": repo.CloneLinks,
 		}
 		values = append(values, map[string]any{
-			"slug":    repo.Slug,
-			"name":    repo.Name,
-			"id":      repo.ID,
-			"project": map[string]any{"key": repo.Project.Key},
-			"links":   links,
+			"slug":     repo.Slug,
+			"name":     repo.Name,
+			"id":       repo.ID,
+			"archived": repo.Archived,
+			"project":  map[string]any{"key": repo.Project.Key},
+			"links":    links,
 		})
 	}
 

--- a/skills/bkt/rules/repo.md
+++ b/skills/bkt/rules/repo.md
@@ -306,6 +306,7 @@ bkt repo list [flags]
 ## bkt repo view
 
 Display details for a repository, including its name, web URL, and clone URLs.
+On Data Center, output also includes whether the repository is archived.
 
 On Data Center, the project key and repository slug are resolved from the active
 context or overridden with --project and --repo. On Cloud, the workspace and


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to make [avivsinai/bitbucket-cli#306](https://github.com/avivsinai/bitbucket-cli/pull/306) landable. Keeps Cory Lucas's original `feat: add archived flag to repo response` commit and adds the review gaps only.

Data Center `bkt repo list` and `bkt repo view` already expose `archived` in JSON (no `omitempty`). This PR:

- Adds DC `repo view` smoke coverage for JSON `archived` (including `false`) and the human `Archived: %t` line
- Adds an `(archived)` TTY suffix on archived DC list rows (no `--archived` filter)
- Adds `pkg/cmd/repo` package tests so `codecov/patch` covers the changed list/view lines (smoke tests do not count toward that package)
- Moves the changelog line to **Added**
- Mentions the DC archived field in `repo view` help (commands that describe output fields)

Cloud list/view structs are unchanged. No README, tap, goreportcard, or Homebrew work.

## Testing

- [x] `make fmt`
- [x] `make test`
- [x] `make build`
- [x] Other: Cloud VM named checks (all exit 0)

```
go test ./pkg/bbdc/... ./pkg/cmd/repo/... ./pkg/cmd/smoke/...
go test ./...
make test
```

Named-check logs:
- <a href="/opt/cursor/artifacts/named_checks_archived_flag.log">named_checks_archived_flag.log</a>
- <a href="/opt/cursor/artifacts/named_checks_archived_flag_after_codecov_fix.log">named_checks_archived_flag_after_codecov_fix.log</a>

## Screenshots / recordings

N/A — CLI output covered by smoke and package tests. Named-check logs are attached as PR artifacts.

## Checklist

- [x] Adds or updates documentation (`repo view` help + generated skill rules)
- [x] Updates `CHANGELOG.md`
- [ ] Signed commits (`git commit -s`)

## Notes for reviewers

- Original authorship is preserved on `859dffa` (`Cory Lucas <cory.lucas@aexp.com>`).
- Do not merge #306 itself; this branch is the landing vehicle against `master`.
- `archived` stays DC-only and is always serialized so `false` is filterable.
- Waiting on GitHub CI after the `codecov/patch` follow-up; this draft will be marked ready when CI is green.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75a04529-ee4d-4e4d-976e-1d2781b434d3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75a04529-ee4d-4e4d-976e-1d2781b434d3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

