### PR TITLE
feat(pipeline): support pipeline selectors

### DIFF
--- a/.agents/skills/bkt/rules/pipeline.md
+++ b/.agents/skills/bkt/rules/pipeline.md
@@ -119,9 +119,12 @@ bkt pipeline logs <id> [flags]
 
 Trigger a new pipeline run on Bitbucket Cloud for the current repository.
 
-The pipeline runs against the specified Git ref (branch, tag, or commit). You can
-pass custom pipeline variables using the --var flag, which accepts KEY=VALUE pairs
-and can be repeated. This command is available for Bitbucket Cloud contexts only.
+The pipeline runs against the specified branch. Set --selector-type to choose a
+pipeline definition for that branch target. For selector types other than default,
+also set --selector-pattern. Selector values are passed directly to Bitbucket. You
+can pass custom pipeline variables using the --var flag, which accepts KEY=VALUE
+pairs and can be repeated. This command is available for Bitbucket Cloud contexts
+only.
 
 Use --wait to poll the triggered pipeline until it completes, with exponential
 backoff and jitter. Exit codes in --wait mode: 0 = pipeline succeeded,
@@ -139,8 +142,10 @@ bkt pipeline run [flags]
 |---|---|---|
 | `--interval` |  | Initial polling interval when using --wait |
 | `--max-interval` |  | Maximum polling interval (backoff cap) |
-| `--ref` |  | Git ref to run the pipeline on |
+| `--ref` |  | Branch to run the pipeline on |
 | `--repo` |  | Repository slug override |
+| `--selector-pattern` |  | Pipeline definition name or pattern; omit for default |
+| `--selector-type` |  | Pipeline selector type (for example custom or pull-requests) |
 | `--timeout` |  | Maximum time to wait for the pipeline (0 for no timeout) |
 | `--var` |  | Pipeline variable in KEY=VALUE form (repeatable) |
 | `--wait` |  | Wait for the triggered pipeline to complete |
@@ -160,11 +165,14 @@ bkt pipeline run [flags]
 ### Examples
 
 ```bash
-# Run the pipeline on the default branch
+# Run the pipeline on the main branch
   bkt pipeline run
 
   # Run the pipeline on a specific branch
   bkt pipeline run --ref feature/my-branch
+
+  # Run a named custom pipeline
+  bkt pipeline run --ref master --selector-type custom --selector-pattern deploy-to-production
 
   # Run with custom pipeline variables
   bkt pipeline run --ref main --var ENV=staging --var DEBUG=true

--- a/.claude/skills/bkt/rules/pipeline.md
+++ b/.claude/skills/bkt/rules/pipeline.md
@@ -119,9 +119,12 @@ bkt pipeline logs <id> [flags]
 
 Trigger a new pipeline run on Bitbucket Cloud for the current repository.
 
-The pipeline runs against the specified Git ref (branch, tag, or commit). You can
-pass custom pipeline variables using the --var flag, which accepts KEY=VALUE pairs
-and can be repeated. This command is available for Bitbucket Cloud contexts only.
+The pipeline runs against the specified branch. Set --selector-type to choose a
+pipeline definition for that branch target. For selector types other than default,
+also set --selector-pattern. Selector values are passed directly to Bitbucket. You
+can pass custom pipeline variables using the --var flag, which accepts KEY=VALUE
+pairs and can be repeated. This command is available for Bitbucket Cloud contexts
+only.
 
 Use --wait to poll the triggered pipeline until it completes, with exponential
 backoff and jitter. Exit codes in --wait mode: 0 = pipeline succeeded,
@@ -139,8 +142,10 @@ bkt pipeline run [flags]
 |---|---|---|
 | `--interval` |  | Initial polling interval when using --wait |
 | `--max-interval` |  | Maximum polling interval (backoff cap) |
-| `--ref` |  | Git ref to run the pipeline on |
+| `--ref` |  | Branch to run the pipeline on |
 | `--repo` |  | Repository slug override |
+| `--selector-pattern` |  | Pipeline definition name or pattern; omit for default |
+| `--selector-type` |  | Pipeline selector type (for example custom or pull-requests) |
 | `--timeout` |  | Maximum time to wait for the pipeline (0 for no timeout) |
 | `--var` |  | Pipeline variable in KEY=VALUE form (repeatable) |
 | `--wait` |  | Wait for the triggered pipeline to complete |
@@ -160,11 +165,14 @@ bkt pipeline run [flags]
 ### Examples
 
 ```bash
-# Run the pipeline on the default branch
+# Run the pipeline on the main branch
   bkt pipeline run
 
   # Run the pipeline on a specific branch
   bkt pipeline run --ref feature/my-branch
+
+  # Run a named custom pipeline
+  bkt pipeline run --ref master --selector-type custom --selector-pattern deploy-to-production
 
   # Run with custom pipeline variables
   bkt pipeline run --ref main --var ENV=staging --var DEBUG=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented here. The format follows
 
 ## [Unreleased]
 ### Added
+- `bkt pipeline run` can select a pipeline definition with `--selector-type`
+  and `--selector-pattern`, including named custom pipelines on a branch.
 - Data Center `bkt repo list` and `bkt repo view` include the repository
   `archived` flag in structured output (always present, including `false`).
   Human `repo view` prints `Archived: true|false`; archived `repo list` rows

--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ bkt branch create release/1.9 --from main    # Data Center branch utils
 bkt perms repo list --project DATA --repo platform-api
 bkt webhook create --name "CI" --url https://ci.example.com/hook --event repo:refs_changed
 bkt pipeline run --workspace myteam --repo api --ref main --var ENV=staging
+bkt pipeline run --ref master --selector-type custom --selector-pattern deploy-to-production
 bkt extension install https://github.com/example/bkt-hello.git
 bkt extension exec hello -- --flag=1
 bkt status pipeline {pipeline-uuid}

--- a/pkg/bbcloud/client.go
+++ b/pkg/bbcloud/client.go
@@ -418,7 +418,14 @@ func (c *Client) CreateRepository(ctx context.Context, workspace string, input C
 // TriggerPipelineInput configures a pipeline run.
 type TriggerPipelineInput struct {
 	Ref       string
+	Selector  *PipelineSelector
 	Variables map[string]string
+}
+
+// PipelineSelector identifies a pipeline definition in bitbucket-pipelines.yml.
+type PipelineSelector struct {
+	Type    string
+	Pattern string
 }
 
 // TriggerPipeline triggers a new pipeline for the repo.
@@ -429,13 +436,25 @@ func (c *Client) TriggerPipeline(ctx context.Context, workspace, repoSlug string
 	if in.Ref == "" {
 		return nil, fmt.Errorf("ref is required")
 	}
+	if err := validatePipelineSelector(in.Selector); err != nil {
+		return nil, err
+	}
+
+	target := map[string]any{
+		"ref_type": "branch",
+		"type":     "pipeline_ref_target",
+		"ref_name": in.Ref,
+	}
+	if in.Selector != nil {
+		selector := map[string]any{"type": in.Selector.Type}
+		if in.Selector.Pattern != "" {
+			selector["pattern"] = in.Selector.Pattern
+		}
+		target["selector"] = selector
+	}
 
 	body := map[string]any{
-		"target": map[string]any{
-			"ref_type": "branch",
-			"type":     "pipeline_ref_target",
-			"ref_name": in.Ref,
-		},
+		"target": target,
 	}
 	if len(in.Variables) > 0 {
 		vars := make([]map[string]any, 0, len(in.Variables))
@@ -464,6 +483,25 @@ func (c *Client) TriggerPipeline(ctx context.Context, workspace, repoSlug string
 		return nil, err
 	}
 	return &pipeline, nil
+}
+
+func validatePipelineSelector(selector *PipelineSelector) error {
+	if selector == nil {
+		return nil
+	}
+	if strings.TrimSpace(selector.Type) == "" {
+		return fmt.Errorf("pipeline selector type is required")
+	}
+	if selector.Type == "default" {
+		if selector.Pattern != "" {
+			return fmt.Errorf("pipeline selector pattern must be omitted for type default")
+		}
+		return nil
+	}
+	if strings.TrimSpace(selector.Pattern) == "" {
+		return fmt.Errorf("pipeline selector pattern is required for type %q", selector.Type)
+	}
+	return nil
 }
 
 // GetPipeline fetches pipeline details.

--- a/pkg/bbcloud/client_test.go
+++ b/pkg/bbcloud/client_test.go
@@ -927,6 +927,9 @@ func TestTriggerPipeline(t *testing.T) {
 		if target["ref_name"] != "main" {
 			t.Errorf("expected ref_name=main, got %v", target["ref_name"])
 		}
+		if _, ok := target["selector"]; ok {
+			t.Errorf("expected selector to be omitted, got %v", target["selector"])
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(Pipeline{UUID: "{abc-123}"})
@@ -944,7 +947,94 @@ func TestTriggerPipeline(t *testing.T) {
 	}
 }
 
-func TestTriggerPipelineWithVariables(t *testing.T) {
+func TestTriggerPipelineWithSelector(t *testing.T) {
+	tests := []struct {
+		name        string
+		selector    PipelineSelector
+		wantPattern string
+		hasPattern  bool
+	}{
+		{
+			name:        "custom pipeline",
+			selector:    PipelineSelector{Type: "custom", Pattern: "deploy-to-production"},
+			wantPattern: "deploy-to-production",
+			hasPattern:  true,
+		},
+		{
+			name:        "branch pattern",
+			selector:    PipelineSelector{Type: "branches", Pattern: "feature/*"},
+			wantPattern: "feature/*",
+			hasPattern:  true,
+		},
+		{
+			name:        "pull request pattern",
+			selector:    PipelineSelector{Type: "pull-requests", Pattern: "**"},
+			wantPattern: "**",
+			hasPattern:  true,
+		},
+		{
+			name:        "custom name preserves spaces",
+			selector:    PipelineSelector{Type: "custom", Pattern: " Deploy to production "},
+			wantPattern: " Deploy to production ",
+			hasPattern:  true,
+		},
+		{
+			name:       "default pipeline",
+			selector:   PipelineSelector{Type: "default"},
+			hasPattern: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var body struct {
+				Target struct {
+					Type     string            `json:"type"`
+					RefType  string            `json:"ref_type"`
+					RefName  string            `json:"ref_name"`
+					Selector map[string]string `json:"selector"`
+				} `json:"target"`
+			}
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Errorf("method = %s, want POST", r.Method)
+				}
+				if r.URL.Path != "/repositories/ws/repo/pipelines/" {
+					t.Errorf("path = %q, want pipeline endpoint", r.URL.Path)
+				}
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Errorf("decode request: %v", err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(Pipeline{UUID: "{abc}"})
+			})
+
+			client := newTestClient(t, handler)
+			_, err := client.TriggerPipeline(context.Background(), "ws", "repo", TriggerPipelineInput{
+				Ref:      "master",
+				Selector: &tt.selector,
+			})
+			if err != nil {
+				t.Fatalf("TriggerPipeline: %v", err)
+			}
+			if body.Target.Type != "pipeline_ref_target" || body.Target.RefType != "branch" || body.Target.RefName != "master" {
+				t.Errorf("unexpected target: %+v", body.Target)
+			}
+			if got := body.Target.Selector["type"]; got != tt.selector.Type {
+				t.Errorf("selector type = %q, want %q", got, tt.selector.Type)
+			}
+			gotPattern, hasPattern := body.Target.Selector["pattern"]
+			if hasPattern != tt.hasPattern {
+				t.Errorf("selector pattern presence = %v, want %v", hasPattern, tt.hasPattern)
+			}
+			if gotPattern != tt.wantPattern {
+				t.Errorf("selector pattern = %q, want %q", gotPattern, tt.wantPattern)
+			}
+		})
+	}
+}
+
+func TestTriggerPipelineWithSelectorAndVariables(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body map[string]any
 		_ = json.NewDecoder(r.Body).Decode(&body)
@@ -952,6 +1042,11 @@ func TestTriggerPipelineWithVariables(t *testing.T) {
 		vars, ok := body["variables"].([]any)
 		if !ok || len(vars) == 0 {
 			t.Fatal("expected variables in body")
+		}
+		target := body["target"].(map[string]any)
+		selector := target["selector"].(map[string]any)
+		if selector["type"] != "custom" || selector["pattern"] != "deploy" {
+			t.Errorf("unexpected selector: %v", selector)
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -961,6 +1056,7 @@ func TestTriggerPipelineWithVariables(t *testing.T) {
 	client := newTestClient(t, handler)
 	_, err := client.TriggerPipeline(context.Background(), "ws", "repo", TriggerPipelineInput{
 		Ref:       "main",
+		Selector:  &PipelineSelector{Type: "custom", Pattern: "deploy"},
 		Variables: map[string]string{"ENV": "prod"},
 	})
 	if err != nil {
@@ -977,6 +1073,39 @@ func TestTriggerPipelineValidation(t *testing.T) {
 	_, err = client.TriggerPipeline(context.Background(), "ws", "repo", TriggerPipelineInput{})
 	if err == nil {
 		t.Fatal("expected error for empty ref")
+	}
+}
+
+func TestTriggerPipelineSelectorValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		selector PipelineSelector
+		wantErr  string
+	}{
+		{"empty type", PipelineSelector{Pattern: "deploy"}, "pipeline selector type is required"},
+		{"blank type", PipelineSelector{Type: "  ", Pattern: "deploy"}, "pipeline selector type is required"},
+		{"missing pattern", PipelineSelector{Type: "custom"}, `pipeline selector pattern is required for type "custom"`},
+		{"blank pattern", PipelineSelector{Type: "custom", Pattern: "  "}, `pipeline selector pattern is required for type "custom"`},
+		{"default with pattern", PipelineSelector{Type: "default", Pattern: "main"}, "pipeline selector pattern must be omitted for type default"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				called = true
+			}))
+			_, err := client.TriggerPipeline(context.Background(), "ws", "repo", TriggerPipelineInput{
+				Ref:      "main",
+				Selector: &tt.selector,
+			})
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("TriggerPipeline error = %v, want %q", err, tt.wantErr)
+			}
+			if called {
+				t.Fatal("request was sent for invalid selector")
+			}
+		})
 	}
 }
 

--- a/pkg/cmd/pipeline/pipeline.go
+++ b/pkg/cmd/pipeline/pipeline.go
@@ -52,8 +52,10 @@ type waitOptions struct {
 type runOptions struct {
 	baseOptions
 	waitOptions
-	Ref       string
-	Variables []string
+	Ref             string
+	SelectorType    string
+	SelectorPattern string
+	Variables       []string
 }
 
 type listOptions struct {
@@ -80,18 +82,24 @@ func newRunCmd(f *cmdutil.Factory) *cobra.Command {
 		Short: "Trigger a new pipeline run (Cloud only)",
 		Long: `Trigger a new pipeline run on Bitbucket Cloud for the current repository.
 
-The pipeline runs against the specified Git ref (branch, tag, or commit). You can
-pass custom pipeline variables using the --var flag, which accepts KEY=VALUE pairs
-and can be repeated. This command is available for Bitbucket Cloud contexts only.
+The pipeline runs against the specified branch. Set --selector-type to choose a
+pipeline definition for that branch target. For selector types other than default,
+also set --selector-pattern. Selector values are passed directly to Bitbucket. You
+can pass custom pipeline variables using the --var flag, which accepts KEY=VALUE
+pairs and can be repeated. This command is available for Bitbucket Cloud contexts
+only.
 
 Use --wait to poll the triggered pipeline until it completes, with exponential
 backoff and jitter. Exit codes in --wait mode: 0 = pipeline succeeded,
 1 = pipeline completed unsuccessfully, 8 = timed out while still running.`,
-		Example: `  # Run the pipeline on the default branch
+		Example: `  # Run the pipeline on the main branch
   bkt pipeline run
 
   # Run the pipeline on a specific branch
   bkt pipeline run --ref feature/my-branch
+
+  # Run a named custom pipeline
+  bkt pipeline run --ref master --selector-type custom --selector-pattern deploy-to-production
 
   # Run with custom pipeline variables
   bkt pipeline run --ref main --var ENV=staging --var DEBUG=true
@@ -101,7 +109,11 @@ backoff and jitter. Exit codes in --wait mode: 0 = pipeline succeeded,
 
   # Trigger and wait for the result
   bkt pipeline run --ref main --wait`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateRunSelectorFlags(cmd, opts); err != nil {
+				return err
+			}
 			if err := validateWaitFlags(cmd, &opts.waitOptions); err != nil {
 				return err
 			}
@@ -111,11 +123,40 @@ backoff and jitter. Exit codes in --wait mode: 0 = pipeline succeeded,
 
 	cmd.Flags().StringVar(&opts.Workspace, "workspace", "", "Bitbucket Cloud workspace override")
 	cmd.Flags().StringVar(&opts.Repo, "repo", "", "Repository slug override")
-	cmd.Flags().StringVar(&opts.Ref, "ref", "main", "Git ref to run the pipeline on")
+	cmd.Flags().StringVar(&opts.Ref, "ref", "main", "Branch to run the pipeline on")
+	cmd.Flags().StringVar(&opts.SelectorType, "selector-type", "", "Pipeline selector type (for example custom or pull-requests)")
+	cmd.Flags().StringVar(&opts.SelectorPattern, "selector-pattern", "", "Pipeline definition name or pattern; omit for default")
 	cmd.Flags().StringSliceVar(&opts.Variables, "var", nil, "Pipeline variable in KEY=VALUE form (repeatable)")
 	addWaitFlags(cmd, &opts.waitOptions, "Wait for the triggered pipeline to complete")
 
 	return cmd
+}
+
+func validateRunSelectorFlags(cmd *cobra.Command, opts *runOptions) error {
+	typeSet := cmd.Flags().Changed("selector-type")
+	patternSet := cmd.Flags().Changed("selector-pattern")
+	if !typeSet && !patternSet {
+		return nil
+	}
+	if !typeSet {
+		return fmt.Errorf("--selector-pattern requires --selector-type")
+	}
+	if strings.TrimSpace(opts.SelectorType) == "" {
+		return fmt.Errorf("--selector-type cannot be empty")
+	}
+	if opts.SelectorType == "default" {
+		if patternSet {
+			return fmt.Errorf("--selector-pattern cannot be used with --selector-type default")
+		}
+		return nil
+	}
+	if !patternSet {
+		return fmt.Errorf("--selector-pattern is required with --selector-type %s", opts.SelectorType)
+	}
+	if strings.TrimSpace(opts.SelectorPattern) == "" {
+		return fmt.Errorf("--selector-pattern cannot be empty")
+	}
+	return nil
 }
 
 func newListCmd(f *cmdutil.Factory) *cobra.Command {
@@ -255,8 +296,17 @@ func runPipelineRun(cmd *cobra.Command, f *cmdutil.Factory, opts *runOptions) er
 	ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
 	defer cancel()
 
+	var selector *bbcloud.PipelineSelector
+	if opts.SelectorType != "" {
+		selector = &bbcloud.PipelineSelector{
+			Type:    opts.SelectorType,
+			Pattern: opts.SelectorPattern,
+		}
+	}
+
 	pipeline, err := client.TriggerPipeline(ctx, workspace, repo, bbcloud.TriggerPipelineInput{
 		Ref:       opts.Ref,
+		Selector:  selector,
 		Variables: vars,
 	})
 	if err != nil {

--- a/pkg/cmd/pipeline/pipeline_test.go
+++ b/pkg/cmd/pipeline/pipeline_test.go
@@ -225,6 +225,48 @@ func TestValidateWaitFlags(t *testing.T) {
 	}
 }
 
+func TestValidateRunSelectorFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"no selector", nil, ""},
+		{"custom selector", []string{"--selector-type", "custom", "--selector-pattern", "deploy-to-production"}, ""},
+		{"pull request selector", []string{"--selector-type", "pull-requests", "--selector-pattern", "**"}, ""},
+		{"default selector", []string{"--selector-type", "default"}, ""},
+		{"pattern without type", []string{"--selector-pattern", "deploy-to-production"}, "--selector-pattern requires --selector-type"},
+		{"empty type", []string{"--selector-type="}, "--selector-type cannot be empty"},
+		{"type without pattern", []string{"--selector-type", "custom"}, "--selector-pattern is required with --selector-type custom"},
+		{"empty pattern", []string{"--selector-type", "custom", "--selector-pattern="}, "--selector-pattern cannot be empty"},
+		{"blank pattern", []string{"--selector-type", "custom", "--selector-pattern", "  "}, "--selector-pattern cannot be empty"},
+		{"default with pattern", []string{"--selector-type", "default", "--selector-pattern", "main"}, "--selector-pattern cannot be used with --selector-type default"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "run"}
+			opts := &runOptions{}
+			cmd.Flags().StringVar(&opts.SelectorType, "selector-type", "", "")
+			cmd.Flags().StringVar(&opts.SelectorPattern, "selector-pattern", "", "")
+			if err := cmd.ParseFlags(tt.args); err != nil {
+				t.Fatalf("ParseFlags: %v", err)
+			}
+
+			err := validateRunSelectorFlags(cmd, opts)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateRunSelectorFlags: %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("validateRunSelectorFlags = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 // Regression test for the steps-fetch context wiring: cancelling the command
 // context while the steps request is in flight must abort it immediately
 // (a detached context would hang until the 10s fetch deadline instead).
@@ -423,6 +465,75 @@ func TestPipelineRunWaitStructuredOutputPurity(t *testing.T) {
 	}
 	if strings.Contains(out.String(), "Triggered") {
 		t.Errorf("trigger progress text leaked into structured stdout: %q", out.String())
+	}
+}
+
+func TestPipelineRunSendsSelector(t *testing.T) {
+	var body struct {
+		Target struct {
+			Type     string            `json:"type"`
+			RefType  string            `json:"ref_type"`
+			RefName  string            `json:"ref_name"`
+			Selector map[string]string `json:"selector"`
+		} `json:"target"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/repositories/ws/repo/pipelines/" {
+			t.Errorf("path = %q, want pipeline endpoint", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(pipelineJSONBody("PENDING", "")))
+	}))
+	defer srv.Close()
+
+	f, _, _ := pipelineTestFactory(srv.URL)
+	cmd := newRunCmd(f)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{
+		"--ref", "master",
+		"--selector-type", "custom",
+		"--selector-pattern", "deploy-to-production",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if body.Target.Type != "pipeline_ref_target" || body.Target.RefType != "branch" || body.Target.RefName != "master" {
+		t.Errorf("unexpected target: %+v", body.Target)
+	}
+	if got := body.Target.Selector["type"]; got != "custom" {
+		t.Errorf("selector type = %q, want custom", got)
+	}
+	if got := body.Target.Selector["pattern"]; got != "deploy-to-production" {
+		t.Errorf("selector pattern = %q, want deploy-to-production", got)
+	}
+}
+
+func TestPipelineRunRejectsArguments(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer srv.Close()
+
+	f, _, _ := pipelineTestFactory(srv.URL)
+	cmd := newRunCmd(f)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"deploy-to-production"})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected positional argument to be rejected")
+	}
+	if called {
+		t.Fatal("request was sent for invalid positional argument")
 	}
 }
 

--- a/skills/bkt/rules/pipeline.md
+++ b/skills/bkt/rules/pipeline.md
@@ -119,9 +119,12 @@ bkt pipeline logs <id> [flags]
 
 Trigger a new pipeline run on Bitbucket Cloud for the current repository.
 
-The pipeline runs against the specified Git ref (branch, tag, or commit). You can
-pass custom pipeline variables using the --var flag, which accepts KEY=VALUE pairs
-and can be repeated. This command is available for Bitbucket Cloud contexts only.
+The pipeline runs against the specified branch. Set --selector-type to choose a
+pipeline definition for that branch target. For selector types other than default,
+also set --selector-pattern. Selector values are passed directly to Bitbucket. You
+can pass custom pipeline variables using the --var flag, which accepts KEY=VALUE
+pairs and can be repeated. This command is available for Bitbucket Cloud contexts
+only.
 
 Use --wait to poll the triggered pipeline until it completes, with exponential
 backoff and jitter. Exit codes in --wait mode: 0 = pipeline succeeded,
@@ -139,8 +142,10 @@ bkt pipeline run [flags]
 |---|---|---|
 | `--interval` |  | Initial polling interval when using --wait |
 | `--max-interval` |  | Maximum polling interval (backoff cap) |
-| `--ref` |  | Git ref to run the pipeline on |
+| `--ref` |  | Branch to run the pipeline on |
 | `--repo` |  | Repository slug override |
+| `--selector-pattern` |  | Pipeline definition name or pattern; omit for default |
+| `--selector-type` |  | Pipeline selector type (for example custom or pull-requests) |
 | `--timeout` |  | Maximum time to wait for the pipeline (0 for no timeout) |
 | `--var` |  | Pipeline variable in KEY=VALUE form (repeatable) |
 | `--wait` |  | Wait for the triggered pipeline to complete |
@@ -160,11 +165,14 @@ bkt pipeline run [flags]
 ### Examples
 
 ```bash
-# Run the pipeline on the default branch
+# Run the pipeline on the main branch
   bkt pipeline run
 
   # Run the pipeline on a specific branch
   bkt pipeline run --ref feature/my-branch
+
+  # Run a named custom pipeline
+  bkt pipeline run --ref master --selector-type custom --selector-pattern deploy-to-production
 
   # Run with custom pipeline variables
   bkt pipeline run --ref main --var ENV=staging --var DEBUG=true


### PR DESCRIPTION
Closes #308

## Summary

- Add `--selector-type` and `--selector-pattern` to `bkt pipeline run`.
- Send the values as `target.selector.type` and `target.selector.pattern`.
- Keep the existing request unchanged when no selector is set.
- Pass selector types and patterns directly to Bitbucket without an allowlist.
- Validate incomplete selector input before sending a request.
- Update tests, help, README, changelog, and generated skill docs.

## Testing

- [x] `make fmt` — formatting verified by GitHub Actions
- [x] `make test` — passed on Linux and Windows in GitHub Actions
- [x] `make build` — passed on Linux and Windows in GitHub Actions
- [x] Other:
  - `git diff --check`
  - `make check-skills`
  - Static review of the Go changes and request payload

This machine does not have a Go toolchain, so the Go 1.25 checks ran in the
fork's GitHub Actions on the same commit:

- [CI](https://github.com/givemetraffic/bitbucket-cli/actions/runs/33702186020): generated docs, gofmt, vet, lint, tests, Linux build, and Windows build/tests
- [Nix](https://github.com/givemetraffic/bitbucket-cli/actions/runs/33702186080): Ubuntu and macOS builds
- [Gitleaks](https://github.com/givemetraffic/bitbucket-cli/actions/runs/33702186057): secret scan

All checks passed. The upstream workflow still needs maintainer approval because
this is the contributor's first pull request to the repository.

## Screenshots / recordings

New CLI usage:

```bash
bkt pipeline run \
  --ref master \
  --selector-type custom \
  --selector-pattern deploy-to-production
```

## Checklist

- [x] Adds or updates documentation
- [x] Updates `CHANGELOG.md`
- [x] Signed commits (`git commit -s`)

## Notes for reviewers

This change only adds selector fields to the existing `pipeline_ref_target`
with `ref_type: branch`. It does not change how the target itself is built.
