### PR TITLE
fix(skill): exclude Git metadata from local discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project will be documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+- Carried forward from the unpublished `v0.32.0` tag: `bkt skill` now supports
+  installing, listing, previewing, updating, and publishing Agent Skills hosted
+  in Bitbucket Cloud or Data Center, plus Cloud workspace skill search.
+- `bkt pipeline run` can select branch and custom pipeline definitions with
+  `--selector-type` and `--selector-pattern`.
+
+### Fixed
+- Local skill discovery ignores Git metadata, so concurrent Git maintenance no
+  longer causes `bkt skill publish` to fail while walking `.git`.
+
 ## [0.32.0] - 2026-09-04
 ### Added
 - `bkt skill` installs and manages [Agent Skills](https://agentskills.io/specification)

--- a/internal/skills/discovery/discovery.go
+++ b/internal/skills/discovery/discovery.go
@@ -443,6 +443,11 @@ func DiscoverAllLocalSkills(dir string) ([]Skill, error) {
 		if walkErr != nil {
 			return walkErr
 		}
+		// Git metadata is not skill content; pruning it also avoids races with
+		// concurrent maintenance. Other hidden directories remain eligible.
+		if info.IsDir() && info.Name() == ".git" {
+			return filepath.SkipDir
+		}
 		// Skip symlinks to avoid following links outside the source tree.
 		if info.Mode()&os.ModeSymlink != 0 {
 			return nil

--- a/internal/skills/discovery/discovery_test.go
+++ b/internal/skills/discovery/discovery_test.go
@@ -412,6 +412,26 @@ func TestDiscoverAllLocalSkills(t *testing.T) {
 		}
 	})
 
+	t.Run("git metadata is pruned without excluding other hidden directories", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "skills", "real", "SKILL.md"), "---\nname: real\n---\n")
+		writeFile(t, filepath.Join(dir, ".claude", "skills", "hidden", "SKILL.md"), "---\nname: hidden\n---\n")
+		writeFile(t, filepath.Join(dir, ".git", "skills", "fake", "SKILL.md"), "---\nname: fake\n---\n")
+
+		skills, err := DiscoverAllLocalSkills(dir)
+		if err != nil {
+			t.Fatalf("DiscoverAllLocalSkills: %v", err)
+		}
+		var names []string
+		for _, skill := range skills {
+			names = append(names, skill.DisplayName())
+		}
+		sort.Strings(names)
+		if !reflect.DeepEqual(names, []string{"[hidden-dir] hidden", "real"}) {
+			t.Fatalf("skills = %v, want authored and supported hidden skills only", names)
+		}
+	})
+
 	t.Run("single skill directory uses frontmatter name", func(t *testing.T) {
 		dir := t.TempDir()
 		writeFile(t, filepath.Join(dir, "SKILL.md"), "---\nname: renamed\ndescription: One\n---\n")


### PR DESCRIPTION
Fixes the release-blocking master CI failure in TestPublishTagOnDataCenterRemote: Git maintenance can remove a lock file while skill discovery walks .git. Prune Git metadata before descent; keep supported hidden skill directories and preserve other filesystem errors.

Validation: full tests, targeted vet, independent discovery race tests (10 runs), and the failing publish test (30 runs) passed. Regression distinguishes Git metadata from supported hidden skills. Reviewed and simplified before commit.

Publication of v0.32.0 was stopped; its tag is retained. This fix will ship in v0.32.1.