### PR TITLE
chore(release): v0.32.1

### DIFF
--- a/.agents/skills/bkt/SKILL.md
+++ b/.agents/skills/bkt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bkt
-version: 0.32.0
+version: 0.32.1
 description: Bitbucket CLI for Data Center and Cloud. Use when users need to manage repositories, pull requests, branches, issues, webhooks, or pipelines in Bitbucket. Triggers include "bitbucket", "bkt", "pull request", "PR", "repo list", "branch create", "Bitbucket Data Center", "Bitbucket Cloud", "keyring timeout".
 metadata:
   short-description: Bitbucket CLI for repos, PRs, branches

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/.claude/skills/bkt/SKILL.md
+++ b/.claude/skills/bkt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bkt
-version: 0.32.0
+version: 0.32.1
 description: Bitbucket CLI for Data Center and Cloud. Use when users need to manage repositories, pull requests, branches, issues, webhooks, or pipelines in Bitbucket. Triggers include "bitbucket", "bkt", "pull request", "PR", "repo list", "branch create", "Bitbucket Data Center", "Bitbucket Cloud", "keyring timeout".
 metadata:
   short-description: Bitbucket CLI for repos, PRs, branches

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bkt",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "Bitbucket CLI - manage repos, PRs, branches, issues, webhooks, and pipelines for both Data Center and Cloud",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented here. The format follows
 
 ## [Unreleased]
 
+## [0.32.1] - 2026-09-04
 ### Added
 - Carried forward from the unpublished `v0.32.0` tag: `bkt skill` now supports
   installing, listing, previewing, updating, and publishing Agent Skills hosted
@@ -16,6 +17,7 @@ All notable changes to this project will be documented here. The format follows
 ### Fixed
 - Local skill discovery ignores Git metadata, so concurrent Git maintenance no
   longer causes `bkt skill publish` to fail while walking `.git`.
+
 
 ## [0.32.0] - 2026-09-04
 ### Added
@@ -745,7 +747,8 @@ All notable changes to this project will be documented here. The format follows
 ## [0.1.0] - 2025-10-26
 - Initial public release of `bkt`.
 
-[Unreleased]: https://github.com/avivsinai/bitbucket-cli/compare/v0.32.0...HEAD
+[Unreleased]: https://github.com/avivsinai/bitbucket-cli/compare/v0.32.1...HEAD
+[0.32.1]: https://github.com/avivsinai/bitbucket-cli/compare/v0.32.0...v0.32.1
 [0.32.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.31.1...v0.32.0
 [0.31.1]: https://github.com/avivsinai/bitbucket-cli/compare/v0.31.0...v0.31.1
 [0.31.0]: https://github.com/avivsinai/bitbucket-cli/compare/v0.30.1...v0.31.0

--- a/skills/bkt/SKILL.md
+++ b/skills/bkt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bkt
-version: 0.32.0
+version: 0.32.1
 description: Bitbucket CLI for Data Center and Cloud. Use when users need to manage repositories, pull requests, branches, issues, webhooks, or pipelines in Bitbucket. Triggers include "bitbucket", "bkt", "pull request", "PR", "repo list", "branch create", "Bitbucket Data Center", "Bitbucket Cloud", "keyring timeout".
 metadata:
   short-description: Bitbucket CLI for repos, PRs, branches


### PR DESCRIPTION
## Release

- moves `CHANGELOG.md` into `v0.32.1`
- aligns skill/plugin metadata to `0.32.1`
- merge triggers `.github/workflows/release.yml`, which validates the release commit, creates `v0.32.1`, publishes the release, and publishes skills in the same workflow run